### PR TITLE
`builtin -d` should not delete special builtins

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,10 @@ Any uppercase BUG_* names are modernish shell bug IDs.
 
 2020-06-11:
 
+- Fixed a bug that caused running 'builtin -d' on a special builtin to
+  delete it. The man page for the 'builtin' command documents that special
+  builtins cannot be deleted.
+
 - POSIX compliance fix: It is now possible to set shell functions named
   'alias' or 'unalias', overriding the commands by the same names. In
   technical terms, they are now regular builtins, not special builtins.

--- a/src/cmd/ksh93/sh/nvdisc.c
+++ b/src/cmd/ksh93/sh/nvdisc.c
@@ -1203,6 +1203,8 @@ Namval_t *sh_addbuiltin(const char *path, Shbltin_f bltin, void *extra)
 		stakseek(offset);
 		if(extra == (void*)1)
 		{
+			if(nv_isattr(np,BLT_SPC))
+				errormsg(SH_DICT,ERROR_exit(1),"cannot delete: %s%s",name,is_spcbuiltin);
 			if(np->nvfun && !nv_isattr(np,NV_NOFREE))
 				free((void*)np->nvfun);
 			dtdelete(sh.bltin_tree,np);

--- a/src/cmd/ksh93/tests/builtins.sh
+++ b/src/cmd/ksh93/tests/builtins.sh
@@ -687,4 +687,10 @@ PATH=$tmp:$PATH $SHELL <<-\EOF || err_exit "'whence' gets wrong path on init"
 EOF
 
 # ======
+# `builtin -d` should not delete special builtins
+(builtin -d export 2> /dev/null
+PATH=/dev/null
+whence -q export) || err_exit '`builtin -d` deletes special builtins'
+
+# ======
 exit $((Errors<125?Errors:125))


### PR DESCRIPTION
The man page for the `builtin` command says special builtins cannot be deleted with `builtin -d`:
>  -d              Deletes each of the specified built-ins. Special built-ins cannot be deleted.

This flag doesn't behave as documented, running `builtin -d` on a special builtin does delete it. As an example, the following set of commands ends with 'export: not found':
```
$ builtin -d export
$ export foo=bar
```
This pull request backports the bugfix from ksh93v- (2014-12-24-beta), which added an error check to prevent special builtins from being deleted.