### PR TITLE
Implement a better fix for unsetting special env vars

### DIFF
--- a/src/cmd/ksh93/sh/nvdisc.c
+++ b/src/cmd/ksh93/sh/nvdisc.c
@@ -962,7 +962,7 @@ int nv_clone(Namval_t *np, Namval_t *mp, int flags)
 	{
 		if(nv_isattr(np,NV_INTEGER))
 			mp->nvalue.ip = np->nvalue.ip;
-		np->nvfun = 0;
+		np->nvfun = 0; /* This will remove the discipline function, if there is one */
 		np->nvalue.cp = 0;
 		if(!nv_isattr(np,NV_MINIMAL) || nv_isattr(mp,NV_EXPORT))
 		{

--- a/src/cmd/ksh93/tests/subshell.sh
+++ b/src/cmd/ksh93/tests/subshell.sh
@@ -710,13 +710,19 @@ v=${ eval 'al'; alias al='echo subshare'; } && [[ $v == 'mainalias' && $(eval 'a
 || err_exit 'alias redefinition fails to survive ${ ...; }'
 
 # Resetting a subshell's hash table should not affect the parent shell
-(hash -r)
-[[ $(hash) ]] || err_exit $'resetting the hash table in a subshell affects the parent shell\'s hash table'
-(PATH="$PATH")
-[[ $(hash) ]] || err_exit $'resetting the PATH in a subshell affects the parent shell\'s hash table'
+check_hash_table()
+{
+	[[ $(hash) ]] || err_exit $'resetting the hash table in a subshell affects the parent shell\'s hash table'
+	# Ensure the hash table isn't empty before the next test is run
+	hash -r chmod
+}
+
+(hash -r); check_hash_table
+(PATH="$PATH"); check_hash_table
+(unset PATH); check_hash_table
+(nameref PATH_TWO=PATH; unset PATH_TWO); check_hash_table
 
 # Adding a utility to a subshell's hash table should not affect the parent shell
-hash -r chmod
 (hash cat)
 [[ $(hash) == "chmod=$(whence -p chmod)" ]] || err_exit $'changes to a subshell\'s hash table affect the parent shell'
 


### PR DESCRIPTION
The regression this pull request fixes was first introduced in ksh93t 2008-07-25. It was previously worked around in 6f0e008c by forking subshells if any special environment variable is unset.

The reason why  `(unset LC_NUMERIC; LC_NUMERIC=invalid)` works as expected in ksh93s+ is because when `unall()` calls `sh_assignok()` the second argument doesn't set `NV_MOVE`, as that version never moves nodes, it only clones them. `sh_assignok(np,0)` is similar to `sh_assignok(np,1)` in ksh93s+ ([link](https://github.com/multishell/ksh93/blob/ms_2008-02-02/src/cmd/ksh93/sh/subshell.c#L208-L214)):
```C
	sh.subshell = 0;;
	mp->nvname = np->nvname;
	nv_clone(np,mp,NV_NOFREE);
	sh.subshell = save;
	return(np);
```

In ksh93t and higher, setting the second argument to zero causes the node to be moved with `NV_MOVE`, which causes the discipline function associated with the variable node to be removed when `np->nvfun` is set to zero (i.e. NULL):
https://github.com/ksh93/ksh/blob/289f56cd4cfd554f9ed2406fb1a6fdb82d53ab4e/src/cmd/ksh93/sh/subshell.c#L301-L305
https://github.com/ksh93/ksh/blob/289f56cd4cfd554f9ed2406fb1a6fdb82d53ab4e/src/cmd/ksh93/sh/nvdisc.c#L961-L965

This patch fixes the problem by cloning the node with `sh_assignok()` if it is a special variable with a discipline function. This allows special variables to work as expected in virtual subshells. The original workaround has been kept for the `$PATH` variable only, as hash tables are still broken in virtual subshells. It has been updated accordingly to only fork subshells if it detects the variable node for PATH. I have added two more regression tests for changing the PATH in subshells to make sure hash tables continue working as expected with this fix.