### PR TITLE
Backport the ksh2020 fix for timezone name determination

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,10 @@ For full details, see the git log at:
 
 Any uppercase BUG_* names are modernish shell bug IDs.
 
+2020-06-13:
+- Fixed a timezone name determination bug on FreeBSD that caused the
+  output from `LC_ALL=C printf '%T' now` to print the wrong time zone name.
+
 2020-06-11:
 
 - Fixed a bug that caused running 'builtin -d' on a special builtin to

--- a/src/lib/libast/tm/tminit.c
+++ b/src/lib/libast/tm/tminit.c
@@ -248,10 +248,6 @@ tmlocal(void)
 			environ[0] = e;
 	}
 #endif
-#if _dat_tzname
-	local.standard = strdup(tzname[0]);
-	local.daylight = strdup(tzname[1]);
-#endif
 	tmlocale();
 
 	/*
@@ -296,10 +292,8 @@ tmlocal(void)
 		 * POSIX
 		 */
 
-		if (!local.standard)
-			local.standard = strdup(tzname[0]);
-		if (!local.daylight)
-			local.daylight = strdup(tzname[1]);
+		local.standard = strdup(tzname[0]);
+		local.daylight = strdup(tzname[1]);
 	}
 	else
 #endif


### PR DESCRIPTION
This fix for `printf '%T' now` on FreeBSD was written by @krader1961. The following is from https://github.com/att/ast/pull/591:

> On FreeBSD calling tzset() does not guarantee the tzname array will
> be correctly populated. On most systems that works but on FreeBSD you
> have to call localtime() or a related function (e.g., ctime()).

> This change also eliminates a potential, very small, memory leak due to
> the strdup()'ed tznames not being freed.

While this pull request does fix the initial bug reported in #6, it still doesn't update the outdated `Tm_leap_t` leap second array in tmdata.c.