### PR TITLE
Fixes for implicit declaration warnings

### DIFF
--- a/src/cmd/ksh93/include/terminal.h
+++ b/src/cmd/ksh93/include/terminal.h
@@ -185,6 +185,10 @@
 #   endif /* !FIORDCHK */
 #endif /* FIONREAD */
 
+#if _sys_ioctl
+#include        <sys/ioctl.h>
+#endif
+
 extern int	tty_alt(int);
 extern void	tty_cooked(int);
 extern int	tty_get(int,struct termios*);

--- a/src/lib/libast/port/astwinsize.c
+++ b/src/lib/libast/port/astwinsize.c
@@ -29,15 +29,15 @@
 #include <ast.h>
 #include <ast_tty.h>
 
+#if _sys_ioctl
+#include <sys/ioctl.h>
+#endif
+
 #if defined(__STDPP__directive) && defined(__STDPP__hide)
 __STDPP__directive pragma pp:hide ioctl sleep
 #else
 #define ioctl		______ioctl
 #define sleep		______sleep
-#endif
-
-#if _sys_ioctl
-#include <sys/ioctl.h>
 #endif
 
 #if defined(TIOCGWINSZ)

--- a/src/lib/libcmd/tail.c
+++ b/src/lib/libcmd/tail.c
@@ -104,6 +104,7 @@ USAGE_LICENSE
 #include <ls.h>
 #include <tv.h>
 #include <rev.h>
+#include <time.h>
 
 #define COUNT		(1<<0)
 #define ERROR		(1<<1)


### PR DESCRIPTION
This is to upstream some minor fixes for implicit declaration warnings currently in Debian.

Author: Anuradha Weeraman <aweeraman@gmail.com>
Reviewed-By: Thorsten Glaser <t.glaser@tarent.de>
Last-Update: 2020-02-09