### PR TITLE
`read -S` now correctly handles nested double quotes

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,10 @@ For full details, see the git log at: https://github.com/ksh93/ksh
 
 Any uppercase BUG_* names are modernish shell bug IDs.
 
+2020-06-14:
+- 'read -S' is now able to correctly handle strings with double quotes
+  nested inside of double quotes.
+
 2020-06-13:
 
 - Fixed a timezone name determination bug on FreeBSD that caused the

--- a/src/cmd/ksh93/bltins/read.c
+++ b/src/cmd/ksh93/bltins/read.c
@@ -566,12 +566,20 @@ int sh_readline(register Shell_t *shp,char **names, volatile int fd, int flags,s
 #endif /*SHOPT_MULTIBYTE */
 		    case S_QUOTE:
 			c = shp->ifstable[*cp++];
-			inquote = !inquote;
+			if(inquote && c==S_QUOTE)
+				c = -1;
+			else
+				inquote = !inquote;
 			if(val)
 			{
 				stakputs(val);
 				use_stak = 1;
 				*val = 0;
+			}
+			if(c==-1)
+			{
+				stakputc('"');
+				c = shp->ifstable[*cp++];
 			}
 			continue;
 		    case S_ESC:

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -17,4 +17,4 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                                                                      *
 ***********************************************************************/
-#define SH_RELEASE	"93u+m 2020-06-11"
+#define SH_RELEASE	"93u+m 2020-06-14"

--- a/src/cmd/ksh93/sh.1
+++ b/src/cmd/ksh93/sh.1
@@ -6679,7 +6679,8 @@ option causes the variable
 .I vname\^
 to be read as a compound variable.  Blanks will be ignored when
 finding the beginning open parenthesis.
-The \-S
+The
+.B \-S
 option causes the line to be treated like a record in a
 .B .csv
 format file so that double quotes can be used to allow the delimiter

--- a/src/cmd/ksh93/tests/builtins.sh
+++ b/src/cmd/ksh93/tests/builtins.sh
@@ -693,4 +693,9 @@ PATH=/dev/null
 whence -q export) || err_exit '`builtin -d` deletes special builtins'
 
 # ======
+# `read -S` should handle double quotes correctly
+IFS=',' read -S a b c <<<'foo,"""title"" data",bar'
+[[ $b == '"title" data' ]] || err_exit '"" inside "" not handled correctly with read -S'
+
+# ======
 exit $((Errors<125?Errors:125))


### PR DESCRIPTION
The following set of commands fails to print two double quotes because `read` fails to put the first required double quote from the second string into `$b` due to nested double quotes:

```
$ IFS=',' read -S a b c <<<'foo,"""title"" data",bar'
$ echo $b
title" data
```

This bugfix was backported from ksh93v- 2013-10-10-alpha, although it has been revised to use `stakputc` instead of `sfputc`  for consistency with the ksh93u+ codebase.