### PR TITLE
Remove a buggy optimization for variables in subshells

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,9 @@ Any uppercase BUG_* names are modernish shell bug IDs.
 
 - The 'source' alias has been converted into a regular built-in command.
 
+- Functions that set variables in a virtual subshell will no longer affect
+  variables of the same name outside of the virtual subshell's environment.
+
 2020-06-14:
 
 - 'read -S' is now able to correctly handle strings with double quotes

--- a/src/cmd/ksh93/sh/subshell.c
+++ b/src/cmd/ksh93/sh/subshell.c
@@ -251,9 +251,6 @@ Namval_t *sh_assignok(register Namval_t *np,int add)
 	/* don't bother with this */
 	if(!sp->shpwd || np==SH_LEVELNOD || np==L_ARGNOD || np==SH_SUBSCRNOD || np==SH_NAMENOD)
 		return(np);
-	/* don't bother to save if in newer scope */
-	if(sp->var!=shp->var_tree && sp->var!=shp->var_base && shp->last_root==shp->var_tree)
-		return(np);
 	if((ap=nv_arrayptr(np)) && (mp=nv_opensub(np)))
 	{
 		shp->last_root = ap->table;

--- a/src/cmd/ksh93/tests/subshell.sh
+++ b/src/cmd/ksh93/tests/subshell.sh
@@ -727,4 +727,17 @@ check_hash_table()
 [[ $(hash) == "chmod=$(whence -p chmod)" ]] || err_exit $'changes to a subshell\'s hash table affect the parent shell'
 
 # ======
+# Variables set in functions inside of a virtual subshell should not affect the
+# outside environment. This regression test must be run from the disk.
+testvars=$tmp/testvars.sh
+cat >| "$testvars" << 'EOF'
+c=0
+function set_ac { a=1; c=1; }
+function set_abc { ( set_ac ; b=1 ) }
+set_abc
+echo "a=$a b=$b c=$c"
+EOF
+v=$($SHELL $testvars) && [[ "$v" == "a= b= c=0" ]] || err_exit 'variables set in subshells are not confined to the subshell'
+
+# ======
 exit $((Errors<125?Errors:125))


### PR DESCRIPTION
This bug was originally reported by @lijog in att/ast#7 and has been reported again in #15. KSH does not save the original state of a variable if it is in a newer scope. This is because of an optimization in `sh_assignok` first introduced in ksh93t+ 2010-05-24. Here is the code change in that version ([link to the original source code](https://github.com/multishell/ksh93/blob/ms_2010-03-09/src/cmd/ksh93/sh/subshell.c#L261-L269)):

```C
                return(np);
        /* don't bother to save if in newer scope */
-       if(!(rp=shp->st.real_fun)  || !(dp=rp->sdict))
-               dp = sp->var;
-       if(np->nvenv && !nv_isattr(np,NV_MINIMAL|NV_EXPORT) && shp->last_root)
-               dp = shp->last_root;
-       if((mp=nv_search((char*)np,dp,HASH_BUCKET))!=np)
-       {
-               if(mp || !np->nvfun || np->nvfun->subshell>=sh.subshell)
-                       return(np);
-       }
+       if(sp->var!=shp->var_tree && shp->last_root==shp->var_tree)
+               return(np);
        if((ap=nv_arrayptr(np)) && (mp=nv_opensub(np)))
        {
```

This change was originally made to replace a buggier optimization. However, the current optimization causes variables set in subshells to wrongly affect the environment outside of the subshell, as the variable does not get set back to its original value. This patch simply removes the buggy optimization to fix this problem. The regression test must be run ~in a here document~ from the disk for this bug to be reproducible in the regression test suite.