### PR TITLE
`read -r -d` should not ignore `-r`

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,11 @@ For full details, see the git log at: https://github.com/ksh93/ksh
 
 Any uppercase BUG_* names are modernish shell bug IDs.
 
+2020-06-16:
+
+- Passing the '-d' flag to the read builtin will no longer cause the '-r'
+  flag to be discarded when 'read -r -d' is run.
+
 2020-06-15:
 
 - The 'source' alias has been converted into a regular built-in command.

--- a/src/cmd/ksh93/bltins/read.c
+++ b/src/cmd/ksh93/bltins/read.c
@@ -103,8 +103,8 @@ int	b_read(int argc,char *argv[], Shbltin_t *context)
 		if(opt_info.arg && *opt_info.arg!='\n')
 		{
 			char *cp = opt_info.arg;
-			flags &= ~((1<<D_FLAG)-1);
-			flags |= (mbchar(cp)<< D_FLAG);
+			flags &= ((1<<D_FLAG+1)-1);
+			flags |= (mbchar(cp)<<D_FLAG+1) | (1<<D_FLAG);
 		}
 		break;
 	    case 'p':
@@ -283,7 +283,7 @@ int sh_readline(register Shell_t *shp,char **names, volatile int fd, int flags,s
 			tty_raw(fd,1);
 		if(!(flags&(N_FLAG|NN_FLAG)))
 		{
-			delim = ((unsigned)flags)>>D_FLAG;
+			delim = ((unsigned)flags)>>(D_FLAG+1);
 			ep->e_nttyparm.c_cc[VEOL] = delim;
 			ep->e_nttyparm.c_lflag |= ISIG;
 			tty_set(fd,TCSADRAIN,&ep->e_nttyparm);

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -17,4 +17,4 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                                                                      *
 ***********************************************************************/
-#define SH_RELEASE	"93u+m 2020-06-15"
+#define SH_RELEASE	"93u+m 2020-06-16"

--- a/src/cmd/ksh93/tests/builtins.sh
+++ b/src/cmd/ksh93/tests/builtins.sh
@@ -693,4 +693,9 @@ PATH=/dev/null
 whence -q export) || err_exit '`builtin -d` deletes special builtins'
 
 # ======
+# `read -r -d` should not ignore `-r`
+printf '\\\000' | read -r -d ''
+[[ $REPLY == $'\\' ]] || err_exit "read -r -d '' ignores -r"
+
+# ======
 exit $((Errors<125?Errors:125))


### PR DESCRIPTION
This bug was previously reported in att/ast#37. Ksh ignores `-r` when `read -r -d` is run because when the bit for `D_FLAG` is set, the bit for `R_FLAG` is unset as a side effect of setting `D_FLAG`. The following set of commands fails to print a backslash:

```
$ printf '\\\000' | read -r -d ''
$ echo $REPLY
```

The fix for this bug is to set the bit for `D_FLAG` with `D_FLAG + 1`, which prevents `R_FLAG` from being unset. This bugfix and its regression test have been backported from ksh93v- 2013-10-10-alpha.