### PR TITLE
`command` now disables the special properties of special builtins

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,10 @@ Any uppercase BUG_* names are modernish shell bug IDs.
 - Passing the '-d' flag to the read builtin will no longer cause the '-r'
   flag to be discarded when 'read -r -d' is run.
 
+- Fix BUG_CMDSPASGN: preceding a "special builtin"[*] with 'command' now
+  prevents preceding invocation-local variable assignments from becoming global.
+  [*] https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_14
+
 2020-06-15:
 
 - The 'source' alias has been converted into a regular built-in command.

--- a/TODO
+++ b/TODO
@@ -13,9 +13,6 @@ Fix build system:
 - Reimport the removed nmake. It is necessary for changes in Makefiles
   to take effect. The machine-generated Mamfiles are now used as a fallback,
   but they are not meant to be edited by hand.
-- Reimport the removed pty command (for scripting interactive sessions). This
-  is necessary for the pty.sh regression tests to work, which test ksh as an
-  interactive shell. We want to avoid breaking the interactive shell, too.
 
 ______
 Fix or remove broken or misguided default aliases:
@@ -58,10 +55,6 @@ https://github.com/modernish/modernish/tree/0.16/lib/modernish/cap/
 	set -- command ls; "$@"
   don't work.
   See also: https://github.com/att/ast/issues/963
-
-- BUG_CMDSPASGN: preceding a "special builtin"[*] with 'command' does not
-  stop preceding invocation-local variable assignments from becoming global.
-  [*] https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_14
 
 - BUG_CMDSPEXIT: preceding a "special builtin"[*] (other than 'eval', 'exec',
   'return' or 'exit') with 'command' does not always stop it from exiting

--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -1134,7 +1134,7 @@ int sh_exec(register const Shnode_t *t, int flags)
 			io = t->tre.treio;
 			if(shp->envlist = argp = t->com.comset)
 			{
-				if(argn==0 || (np && nv_isattr(np,(BLT_DCL|BLT_SPC))))
+				if(argn==0 || (np && (nv_isattr(np,BLT_DCL) || (!command && nv_isattr(np,BLT_SPC)))))
 				{
 					Namval_t *tp=0;
 					if(argn)

--- a/src/cmd/ksh93/tests/builtins.sh
+++ b/src/cmd/ksh93/tests/builtins.sh
@@ -698,4 +698,9 @@ printf '\\\000' | read -r -d ''
 [[ $REPLY == $'\\' ]] || err_exit "read -r -d '' ignores -r"
 
 # ======
+# Preceding a special builtin with `command` should disable its special properties
+foo=BUG command eval ':'
+[[ $foo == BUG ]] && err_exit '`command` fails to disable the special properties of special builtins'
+
+# ======
 exit $((Errors<125?Errors:125))


### PR DESCRIPTION
Ksh does not check for `command` when running a special builtin, which causes preceding invocation-local variable assignments to become global. This is the reproducer from the att/ast#72, which prints 'BUG' due to this:

```bash
$ foo=BUG command eval ':'
$ echo "$foo"
```

This pull request fixes this bug by adding a check to prevent special builtins from having special properties if `command` is used to run the builtin. This bugfix has been backported from ksh93v- 2013-10-10-alpha.

I also removed the TODO note for reintroducing the `pty` command, as it was reintroduced in commit cd5c181a.