### PR TITLE
Fix two problems with `unset -f` behavior

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,15 @@ For full details, see the git log at: https://github.com/ksh93/ksh
 
 Any uppercase BUG_* names are modernish shell bug IDs.
 
+2020-06-17:
+
+- A POSIX function that unsets itself while it is running no longer causes
+  a segmentation fault.
+
+- `unset -f` no longer silently fails when a KornShell style function tries
+  to unset itself while it is running. The function will now be unset once
+  it has finished running.
+
 2020-06-16:
 
 - Passing the '-d' flag to the read builtin will no longer cause the '-r'

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -17,4 +17,4 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                                                                      *
 ***********************************************************************/
-#define SH_RELEASE	"93u+m 2020-06-16"
+#define SH_RELEASE	"93u+m 2020-06-17"

--- a/src/cmd/ksh93/sh/name.c
+++ b/src/cmd/ksh93/sh/name.c
@@ -2509,7 +2509,7 @@ void	_nv_unset(register Namval_t *np,int flags)
 	if(is_afunction(np) && np->nvalue.ip)
 	{
 		register struct slnod *slp = (struct slnod*)(np->nvenv);
-		if(shp->st.real_fun == np->nvalue.rp)
+		if(np->nvalue.rp->running)
 		{
 			np->nvalue.rp->running |= 1;
 			return;

--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -3505,6 +3505,11 @@ static void sh_funct(Shell_t *shp,Namval_t *np,int argn, char *argv[],struct arg
 	nv_putval(SH_PATHNAMENOD,shp->st.filename,NV_NOFREE);
 	shp->pipepid = pipepid;
 	np->nvalue.rp->running  -= 2;
+	if(np->nvalue.rp && np->nvalue.rp->running==1)
+	{
+		np->nvalue.rp->running = 0;
+		_nv_unset(np, NV_RDONLY);
+	}
 }
 
 /*

--- a/src/cmd/ksh93/tests/functions.sh
+++ b/src/cmd/ksh93/tests/functions.sh
@@ -1250,4 +1250,13 @@ expect_status=0
     err_exit "autoload function skipped dir test wrong output (expected $(printf %q "$expect"), got $(printf %q "$actual"))"
 
 # ======
+# When a function unsets itself, it should not fail to be unset
+$SHELL -c 'PATH=/dev/null; fn() { unset -f fn; true; }; fn' || err_exit 'unset of POSIX function in the calling stack fails'
+$SHELL -c 'PATH=/dev/null; function ftest { ftest2; }; function ftest2 { unset -f ftest; }; ftest' || err_exit 'unset of ksh function in the calling stack fails'
+$SHELL -c 'PATH=/dev/null; fn() { unset -f fn; true; }; fn; fn' 2> /dev/null
+[[ $? != 127 ]] && err_exit 'unset of POSIX function fails when it is still running'
+$SHELL -c 'PATH=/dev/null; function fn { unset -f fn; true; }; fn; fn' 2> /dev/null
+[[ $? != 127 ]] && err_exit 'unset of ksh function fails when it is still running'
+
+# ======
 exit $((Errors<125?Errors:125))


### PR DESCRIPTION
This pull request backports two bug fixes from ksh93v- for the problems detailed in #21. These fixes do the following:

In `src/cmd/ksh93/sh/name.c`, the check for if a function is still running has been corrected to fix a segmentation fault that occurred when a POSIX function unset itself.

The missing functionality for when a KornShell style function unsets itself has been added to `src/cmd/ksh93/sh/xec.c`. This kind of function will now be properly unset after it has finished running, rather than silently cause `unset -f` to fail.