### PR TITLE
Fix a two decade old bug in `whence -a`

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,13 @@ For full details, see the git log at: https://github.com/ksh93/ksh
 
 Any uppercase BUG_* names are modernish shell bug IDs.
 
+2020-06-18:
+
+- A two decade old bug that caused 'whence -a' to base the path of
+  tracked aliases on the user's current working directory has been
+  fixed. Now the real path to the tracked aliases is shown when '-a'
+  is passed to the whence command.
+
 2020-06-17:
 
 - A bug in 'unset -f' was fixed that prevented shell functions from

--- a/src/cmd/ksh93/bltins/whence.c
+++ b/src/cmd/ksh93/bltins/whence.c
@@ -249,7 +249,10 @@ static int whence(Shell_t *shp,char **argv, register int flags)
 					if(*cp!= '/')
 					{
 						if(!np && (np=nv_search(name,shp->track_tree,0)))
-							sfprintf(sfstdout,"%s %s %s/%s\n",name,sh_translate(is_talias),path_pwd(shp,0),cp);
+						{
+							const char *command_path = np->nvalue.pathcomp->name;
+							sfprintf(sfstdout,"%s %s %s/%s\n",name,sh_translate(is_talias),command_path,cp);
+						}
 						else if(!np || nv_isnull(np))
 							sfprintf(sfstdout,"%s%s\n",name,sh_translate(is_ufunction));
 						continue;

--- a/src/cmd/ksh93/include/name.h
+++ b/src/cmd/ksh93/include/name.h
@@ -32,6 +32,7 @@
 #include	<cdt.h>
 
 typedef int (*Nambfp_f)(int, char**, void*);
+struct pathcomp;
 
 /* Nodes can have all kinds of values */
 union Value
@@ -54,6 +55,7 @@ union Value
 	struct Namfun		*funp;	/* discipline pointer */
 	struct Namref		*nrp;	/* name reference */
 	Nambfp_f		bfp;	/* builtin entry point function pointer */
+	struct pathcomp *pathcomp;
 };
 
 #include	"nval.h"

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -17,4 +17,4 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                                                                      *
 ***********************************************************************/
-#define SH_RELEASE	"93u+m 2020-06-17"
+#define SH_RELEASE	"93u+m 2020-06-18"

--- a/src/cmd/ksh93/sh/path.c
+++ b/src/cmd/ksh93/sh/path.c
@@ -1793,8 +1793,10 @@ void path_alias(register Namval_t *np,register Pathcomp_t *pp)
 	{
 		struct stat statb;
 		char *sp;
+		Pathcomp_t *old;
 		nv_offattr(np,NV_NOPRINT);
 		nv_stack(np,&talias_init);
+		old = np->nvalue.pathcomp;
 		np->nvalue.cp = (char*)pp;
 		pp->refcount++;
 		nv_setattr(np,NV_TAGGED|NV_NOFREE);

--- a/src/cmd/ksh93/tests/builtins.sh
+++ b/src/cmd/ksh93/tests/builtins.sh
@@ -703,4 +703,18 @@ foo=BUG command eval ':'
 [[ $foo == BUG ]] && err_exit '`command` fails to disable the special properties of special builtins'
 
 # ======
+# `whence -a` should not base the path of tracked aliases on the current directory
+run_whence()
+{
+	whence -a chmod >> /dev/null
+	builtin chmod
+	whence -a chmod
+}
+actual="$(run_whence)"
+expected="chmod is a shell builtin
+chmod is $(whence -p chmod)
+chmod is a tracked alias for $(whence -p chmod)"
+[[ $actual == $expected ]] || err_exit '`whence -a` does not work correctly with tracked aliases'
+
+# ======
 exit $((Errors<125?Errors:125))


### PR DESCRIPTION
This pull request (which is properly tested this time) fixes a bug that was originally reported by @DavidMorano about two decades ago to the AST team (ref att/ast#954). `whence -a` bases the path for tracked aliases on the user's current working directory if it an enabled ksh builtin of the same name is also available. The following example will claim `cat` is in the user's current working directory:

```
$ whence -a cat
cat is a tracked alias for /usr/bin/cat
$ builtin cat
$ whence -a cat
cat is a shell builtin
cat is /usr/bin/cat
cat is a tracked alias for /home/youruser/cat
```

This happens because `whence -a` determines the path to tracked aliases with `path_pwd`, which is only meant for getting the current working directory (like `pwd`). The fix is to  properly save the path of the tracked alias for use with `whence -a`.

Note: If the first `whence -a` command in the example is not run first, whence will claim `cat` is an undefined function. This is unfortunately not fixed by this pull request.