### PR TITLE
Fix unreliable behavior when special vars are readonly or unset

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,21 @@ For full details, see the git log at: https://github.com/ksh93/ksh
 
 Any uppercase BUG_* names are modernish shell bug IDs.
 
+2020-06-20:
+
+- Fixed a bug that caused setting the following variables as readonly in
+  a virtual subshell to affect the environment outside of the subshell:
+  $_
+  ${.sh.name}
+  ${.sh.subscript}
+  ${.sh.level}
+  $RANDOM
+  $LINENO
+
+- Fixed two bugs that caused `unset .sh.lineno` to always produce a memory
+  fault and `(unset .sh.level)` to memory fault when run in nested
+  functions.
+
 2020-06-18:
 
 - A two decade old bug that caused 'whence -a' to base the path of

--- a/src/cmd/ksh93/bltins/typeset.c
+++ b/src/cmd/ksh93/bltins/typeset.c
@@ -783,7 +783,7 @@ static int     setall(char **argv,register int flag,Dt_t *troot,struct tdata *tp
 			if (tp->aflag && (tp->argnum>0 || (curflag!=newflag)))
 			{
 				if(shp->subshell)
-					sh_assignok(np,1);
+					sh_assignok(np,3);
 				if(troot!=shp->var_tree)
 					nv_setattr(np,newflag&~NV_ASSIGN);
 				else
@@ -1281,7 +1281,7 @@ static int unall(int argc, char **argv, register Dt_t *troot, Shell_t* shp)
 						 * Variables with internal trap/discipline functions (LC_*, LINENO, etc.) need to be
 						 * cloned, as moving them will remove the discipline function.
 						 */
-						np=sh_assignok(np,1);
+						np=sh_assignok(np,2);
 					}
 					else
 						np=sh_assignok(np,0);

--- a/src/cmd/ksh93/data/variables.c
+++ b/src/cmd/ksh93/data/variables.c
@@ -95,7 +95,7 @@ const struct shtable2 shtab_variables[] =
 	".sh.fun",	0,				(char*)0,
 	".sh.subshell",	NV_INTEGER|NV_SHORT|NV_NOFREE,	(char*)0,
 	".sh.level",	0,				(char*)0,
-	".sh.lineno",	NV_INTEGER,			(char*)0,
+	".sh.lineno",	NV_INTEGER|NV_NOFREE,		(char*)0,
 	".sh.stats",	0,				(char*)0,
 	".sh.math",	0,				(char*)0,
 	".sh.pool",	0,				(char*)0,

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -17,4 +17,4 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                                                                      *
 ***********************************************************************/
-#define SH_RELEASE	"93u+m 2020-06-18"
+#define SH_RELEASE	"93u+m 2020-06-20"

--- a/src/cmd/ksh93/sh/init.c
+++ b/src/cmd/ksh93/sh/init.c
@@ -638,7 +638,7 @@ static void put_rand(register Namval_t* np,const char *val,int flags,Namfun_t *f
 		fp = nv_stack(np, NIL(Namfun_t*));
 		if(fp && !fp->nofree)
 			free((void*)fp);
-		_nv_unset(np,0);
+		_nv_unset(np,NV_RDONLY);
 		return;
 	}
 	if(flags&NV_INTEGER)
@@ -696,7 +696,7 @@ static void put_lineno(Namval_t* np,const char *val,int flags,Namfun_t *fp)
 		fp = nv_stack(np, NIL(Namfun_t*));
 		if(fp && !fp->nofree)
 			free((void*)fp);
-		_nv_unset(np,0);
+		_nv_unset(np,NV_RDONLY);
 		return;
 	}
 	if(flags&NV_INTEGER)

--- a/src/cmd/ksh93/sh/subshell.c
+++ b/src/cmd/ksh93/sh/subshell.c
@@ -235,8 +235,15 @@ int nv_subsaved(register Namval_t *np)
 
 /*
  * This routine will make a copy of the given node in the
- * layer created by the most recent subshell_fork if the
- * node hasn't already been copied
+ * layer created by the most recent virtual subshell if the
+ * node hasn't already been copied.
+ *
+ * add == 0:    Move the node pointer from the parent shell to the current virtual subshell.
+ * add == 1:    Create a copy of the node pointer in the current virtual subshell.
+ * add == 2:    This will create a copy of the node pointer like 1, but it will disable the
+ *              optimization for ${.sh.level}.
+ * add == 3:    This is like 1, but it will never skip the following variables:
+ *              ${.sh.level}, $_, ${.sh.subscript} and ${.sh.name}.
  */
 Namval_t *sh_assignok(register Namval_t *np,int add)
 {
@@ -252,7 +259,7 @@ Namval_t *sh_assignok(register Namval_t *np,int add)
 	if(sp->subshare)
 		return(np);
 	/* don't bother with this */
-	if(!sp->shpwd || np==SH_LEVELNOD || np==L_ARGNOD || np==SH_SUBSCRNOD || np==SH_NAMENOD)
+	if(!sp->shpwd || (add != 3 && ((add != 2 && np==SH_LEVELNOD) || np==L_ARGNOD || np==SH_SUBSCRNOD || np==SH_NAMENOD)))
 		return(np);
 	if((ap=nv_arrayptr(np)) && (mp=nv_opensub(np)))
 	{


### PR DESCRIPTION
This pull request fixes the bug detailed in #4. When a virtual subshell finishes, `$RANDOM` and `$LINENO` are ~unset~ restored with `_nv_unset(np, 0)`:
https://github.com/ksh93/ksh/blob/99065353b38715f1533379d549568630537a5f76/src/cmd/ksh93/sh/init.c#L639-L642


This is incorrect, as it doesn't tell `_nv_unset` to ~unset~ restore the variables if they are readonly. This is fixed by adding `NV_RDONLY` to the `_nv_unset` call, like in other variables that aren't affected by this bug:
https://github.com/ksh93/ksh/blob/99065353b38715f1533379d549568630537a5f76/src/cmd/ksh93/sh/init.c#L781-L782

This pull request also fixes another bug with `${.sh.lineno}`. If `unset .sh.lineno` is run, a memory fault will occur as ksh will try to free it from memory. `${.sh.lineno}` cannot be freed from memory because it is an integer; for reference here are the entries for `${.sh.subshell}` and `${.sh.lineno}` in the default variable table:
https://github.com/ksh93/ksh/blob/99065353b38715f1533379d549568630537a5f76/src/cmd/ksh93/data/variables.c#L96-L98

Fixing the memory fault only requires `${.sh.lineno}` to be given the `NV_NOFREE` flag.

EDIT: Corrected 'unset' to 'restore'.