### PR TITLE
Build warning in ratz for exceeding value range in case label

### DIFF
--- a/src/cmd/INIT/ratz.c
+++ b/src/cmd/INIT/ratz.c
@@ -4736,7 +4736,7 @@ char**	argv;
 	}
 	else
 		state.id = "ratz";
-	switch ('~')
+	switch ((unsigned char)'~')
 	{
 	case 0241:
 		switch ('\n')


### PR DESCRIPTION
Build warning:

```
src/cmd/INIT/ratz.c:4741:2: warning: case label value exceeds maximum value for
 type
 4741 |  case 0241:
      |  ^~~~
```

The character literal in the switch expression is being treated as a signed char while the case label 0241 is greater than 127 resulting in this warning.