### PR TITLE
Fix compiler warnings for implicit-ints

### DIFF
--- a/src/cmd/ksh93/edit/edit.c
+++ b/src/cmd/ksh93/edit/edit.c
@@ -1851,7 +1851,7 @@ int	sh_ioctl(int fd, int cmd, void* val, int sz)
 
 #ifdef _lib_tcgetattr
 #   undef tcgetattr
-    sh_tcgetattr(int fd, struct termios *tty)
+int sh_tcgetattr(int fd, struct termios *tty)
     {
 	int r,err = errno;
 	while((r=tcgetattr(fd,tty)) < 0 && errno==EINTR)
@@ -1860,7 +1860,7 @@ int	sh_ioctl(int fd, int cmd, void* val, int sz)
     }
 
 #   undef tcsetattr
-    sh_tcsetattr(int fd, int cmd, struct termios *tty)
+int sh_tcsetattr(int fd, int cmd, struct termios *tty)
     {
 	int r,err = errno;
 	while((r=tcsetattr(fd,cmd,tty)) < 0 && errno==EINTR)


### PR DESCRIPTION
Fix compiler warning in cmd/ksh93/edit/edit.c:

warning: return type defaults to 'int' [-Wimplicit-int]
 1854:     sh_tcgetattr(int fd, struct termios *tty)
 1863:     sh_tcsetattr(int fd, int cmd, struct termios *tty)

The fix was to set the return type explicitly to int and align with the prototype declared in include/terminal.h.