### PR TITLE
Package clean on a fresh clone deletes the entire git repo

### DIFF
--- a/bin/package
+++ b/bin/package
@@ -4992,7 +4992,7 @@ admin)	while	test ! -f $admin_db
 
 clean|clobber)
 	cd $PACKAGEROOT
-	$exec rm -rf $INSTALLROOT
+	$exec rm -rf arch/$HOSTTYPE
 	exit
 	;;
 

--- a/src/cmd/INIT/package.sh
+++ b/src/cmd/INIT/package.sh
@@ -4991,7 +4991,7 @@ admin)	while	test ! -f $admin_db
 
 clean|clobber)
 	cd $PACKAGEROOT
-	$exec rm -rf $INSTALLROOT
+	$exec rm -rf arch/$HOSTTYPE
 	exit
 	;;
 


### PR DESCRIPTION
This appears to be originating from:

```
2755         *)      if      test ! -d $INSTALLROOT
2756                 then    INSTALLROOT=$PACKAGEROOT;
```

where INSTALLROOT=PACKAGEROOT and 'clean' deletes everything under
INSTALLROOT thus deleting the entire git repo. This only applies when
there's no arch/$HOSTTYPE directory due to the condition above.

The resolution followed was to delete arch/$HOSTTYPE as stated in the
documentation for the clean action instead of INSTALLROOT.