### PR TITLE
Fix nested functions ignoring prefixed variable assignments

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -14,6 +14,10 @@ Any uppercase BUG_* names are modernish shell bug IDs.
 - Fixed a bug that caused the kill and stop commands to segfault when given
   a non-existent job.
 
+- Nested functions no longer ignore variable assignments that were prefixed
+  to their parent function, i.e. 'VAR=foo func' will now set $VAR to 'foo'
+  in the scope of any nested function 'func' runs.
+
 2020-06-20:
 
 - Fixed a bug that caused setting the following variables as readonly in

--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -3249,7 +3249,10 @@ static void  local_exports(register Namval_t *np, void *data)
 	if(nv_isarray(np))
 		nv_putsub(np,NIL(char*),0);
 	if((cp = nv_getval(np)) && (mp = nv_search(nv_name(np), shp->var_tree, NV_ADD|HASH_NOSCOPE)) && nv_isnull(mp))
+	{
 		nv_putval(mp, cp, 0);
+		mp->nvflag = np->nvflag;
+	}
 }
 
 /*

--- a/src/cmd/ksh93/tests/functions.sh
+++ b/src/cmd/ksh93/tests/functions.sh
@@ -1259,4 +1259,12 @@ $SHELL -c 'PATH=/dev/null; function fn { unset -f fn; true; }; fn; fn' 2> /dev/n
 [[ $? != 127 ]] && err_exit 'unset of ksh function fails when it is still running'
 
 # ======
+# Check if environment variables passed while invoking a function are exported
+# https://github.com/att/ast/issues/32
+unset foo
+function f2 { env | grep -q "^foo" || err_exit "Environment variable is not propogated from caller function"; }
+function f1 { f2; env | grep -q "^foo" || err_exit "Environment variable is not passed to a function"; }
+foo=bar f1
+
+# ======
 exit $((Errors<125?Errors:125))


### PR DESCRIPTION
This pull request fixes the bug described in att/ast#32. The following explanation is from att/ast#467:

> While copying variables from function's local scope to a new scope, variable attributes were not copied. Such variables were not marked to be exported in the new function. For e.g.
> ```sh
> function f2 { env | grep -i "^foo"; }
> function f1 { env | grep -i "^foo"; f2; }
> foo=bar f1
> ```
> 
> prints 'foo=bar' only once, but it should print be twice.

The fix is to copy the flags a variable has in the parent function's local scope to the nested function's scope.