### PR TITLE
Fix a test failure for `printf %T now` on Ubuntu 20.04

### DIFF
--- a/src/cmd/ksh93/tests/builtins.sh
+++ b/src/cmd/ksh93/tests/builtins.sh
@@ -310,8 +310,8 @@ then	err_exit "printf '%..*s' not working"
 fi
 [[ $(printf '%q\n') == '' ]] || err_exit 'printf "%q" with missing arguments'
 # we won't get hit by the one second boundary twice, right?
-[[ $(printf '%T\n' now) == "$(date)" ]] ||
-[[ $(printf '%T\n' now) == "$(date)" ]] ||
+[[ $(LC_ALL=C printf '%T\n' now) == "$(LC_ALL=C date)" ]] ||
+[[ $(LC_ALL=C printf '%T\n' now) == "$(LC_ALL=C date)" ]] ||
 err_exit 'printf "%T" now'
 behead()
 {


### PR DESCRIPTION
The output of `printf %T now` and the external `date` command aren't guaranteed to be the same unless `LC_ALL` is set to 'C'. This pull request fixes a spurious regression test failure on Linux by setting `LC_ALL` to 'C' when the output of `printf %T now` is compared against `date`.