### PR TITLE
Fix test failures in CI build, disable Mac build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,15 +13,6 @@ jobs:
     - name: Build
       run: bin/package make
     - name: Regression tests
-      run: bin/shtests
-
-  MacOS:
-    name: MacOS
-    runs-on: macos-latest
-    steps:
-    - name: Checkout sources
-      uses: actions/checkout@v2
-    - name: Build
-      run: bin/package make
-    - name: Regression tests
-      run: bin/shtests
+      run: |
+        ulimit -n 1024
+        script -q -e -c "bin/shtests"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,5 +14,6 @@ jobs:
       run: bin/package make
     - name: Regression tests
       run: |
+        export TZ=GMT
         ulimit -n 1024
         script -q -e -c "bin/shtests"


### PR DESCRIPTION
Fix for test failures during CI:

- subshell.sh: set the ulimit for open files to 1024
- bracket.sh: use the script command as a workaround for the "/dev/tty: cannot create" issue (see https://github.com/actions/runner/issues/241)
- builtins.sh: set TZ variable in the CI step

Disabled Mac build as the runners are unstable and tend to hang.

All tests run successfully.