### PR TITLE
Fix bugged completion of ~/some in vi mode

### DIFF
--- a/src/cmd/ksh93/edit/vi.c
+++ b/src/cmd/ksh93/edit/vi.c
@@ -2391,6 +2391,7 @@ static int textmod(register Vi_t *vp,register int c, int mode)
 	register genchar *p = vp->lastline;
 	register int trepeat = vp->repeat;
 	genchar *savep;
+	int ch;
 
 	if(mode && (fold(vp->lastmotion)=='F' || fold(vp->lastmotion)=='T')) 
 		vp->lastmotion = ';';
@@ -2421,7 +2422,10 @@ addin:
 		++last_virt;
 		mode = cur_virt-1;
 		virtual[last_virt] = 0;
-		if(ed_expand(vp->ed,(char*)virtual, &cur_virt, &last_virt, c, vp->repeat_set?vp->repeat:-1)<0)
+		ch = c;
+		if(mode>=0 && c=='\\' && virtual[mode+1]=='/')
+			c = '=';
+		if(ed_expand(vp->ed,(char*)virtual, &cur_virt, &last_virt, ch, vp->repeat_set?vp->repeat:-1)<0)
 		{
 			if(vp->ed->e_tabcount)
 			{
@@ -2433,9 +2437,8 @@ addin:
 			last_virt = i;
 			ed_ringbell();
 		}
-		else if((c=='=' || (c=='\\'&&virtual[i]=='/')) && !vp->repeat_set)
+		else if((c=='=' || (c=='\\'&&virtual[last_virt]=='/')) && !vp->repeat_set)
 		{
-			last_virt = i;
 			vp->nonewline++;
 			ed_ungetchar(vp->ed,cntl('L'));
 			return(GOOD);

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -17,4 +17,4 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                                                                      *
 ***********************************************************************/
-#define SH_RELEASE	"93u+m 2020-06-23"
+#define SH_RELEASE	"93u+m 2020-06-24"

--- a/src/cmd/ksh93/tests/pty.sh
+++ b/src/cmd/ksh93/tests/pty.sh
@@ -453,4 +453,22 @@ w fg
 u yes-yes
 !
 
+# ======
+# err_exit #
+# Test file name completion in vi mode
+mkdir /tmp/fakehome
+tst $LINENO <<"!"
+L vi mode file name completion
+
+# Completing a file name in vi mode that contains '~' and has a
+# base name the same length as the home directory's parent directory
+# shouldn't fail.
+
+w set -o vi; HOME=/tmp/fakehome; touch ~/testfile
+w echo ~/tes\t
+u ^/tmp/fakehome/testfile\r?\n$
+!
+rm -r /tmp/fakehome
+
+# ======
 exit $((Errors<125?Errors:125))


### PR DESCRIPTION
This pull request fixes the bug reported in att/ast#682. The following sequence fails in vi mode because ksh looks in the wrong part of the `virtual` buffer:

```sh
$ touch ~/testfile
$ ls ~/test<tab>
```

This is fixed by changing `virtual[i]` to `virtual[last_virt]` in the bugged section of code. The other change in this pull request is to make sure listing files in a directory with something like `ls /etc/<tab>` calls the code for Ctrl+L to preserve `ls /etc/` rather than try (and fail) to complete the directory name, producing `ls /etc\n/`. This bugfix was backported from ksh93v- 2013-10-10-alpha. The ksh93v- changelog list a different example for this bug:

>    12-08-31  A bug in vi mode in which ~/tst/make/users/hv<TAB> did not expand correctly has been fixed

~There was also a minor typo in the NEWS file that I fixed as part of this pull request.~