### PR TITLE
Fix crashes caused by 'typeset -RF'

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,11 @@ For full details, see the git log at: https://github.com/ksh93/ksh
 
 Any uppercase BUG_* names are modernish shell bug IDs.
 
+2020-06-28:
+
+- Variables created with 'typeset -RF' no longer cause a memory fault
+  when accessed.
+
 2020-06-26:
 
 - Changing to a directory that has a name starting with a '.' will no

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -17,4 +17,4 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                                                                      *
 ***********************************************************************/
-#define SH_RELEASE	"93u+m 2020-06-26"
+#define SH_RELEASE	"93u+m 2020-06-28"

--- a/src/cmd/ksh93/sh/array.c
+++ b/src/cmd/ksh93/sh/array.c
@@ -578,7 +578,7 @@ static char *array_getval(Namval_t *np, Namfun_t *disc)
 		return(cp);
 	}
 #if SHOPT_FIXEDARRAY
-	if(ap->fixed && nv_isattr(np,NV_INT16P) == NV_INT16)
+	if(ap->fixed && nv_isattr(np,NV_INT16P|NV_DOUBLE) == NV_INT16)
 		np->nvalue.s = *np->nvalue.sp;
 #endif /* SHOPT_FIXEDARRAY */
 	return(nv_getv(np,&ap->hdr));

--- a/src/cmd/ksh93/sh/name.c
+++ b/src/cmd/ksh93/sh/name.c
@@ -1648,7 +1648,7 @@ void nv_putval(register Namval_t *np, const char *string, int flags)
 		return;
 	}
 	up= &np->nvalue;
-	if(nv_isattr(np,NV_INT16P) == NV_INT16)
+	if(nv_isattr(np,NV_INT16P|NV_DOUBLE) == NV_INT16)
 	{
 		if(!np->nvalue.up || !nv_isarray(np))
 		{

--- a/src/cmd/ksh93/sh/nvdisc.c
+++ b/src/cmd/ksh93/sh/nvdisc.c
@@ -862,7 +862,7 @@ static void *num_clone(register Namval_t *np, void *val)
 			size = sizeof(Sflong_t);
 		else if(nv_isattr(np,NV_SHORT))
 		{
-			if(nv_isattr(np,NV_INT16P)==NV_INT16P)
+			if(nv_isattr(np,NV_INT16P|NV_DOUBLE)==NV_INT16P)
 				size = sizeof(short);
 			else
 				return((void*)np->nvalue.ip);

--- a/src/cmd/ksh93/tests/types.sh
+++ b/src/cmd/ksh93/tests/types.sh
@@ -645,4 +645,9 @@ Bar_t bar
 bar.foo+=(bam)
 [[ ${bar.foo[0]} == bam ]] || err_exit 'appending to empty array variable in type does not create element 0'
 
+# ======
+# 'typeset -RF' should not create variables that cause crashes
+"$SHELL" -c 'typeset -RF foo=1; test $foo' || err_exit 'typeset -RF does not work'
+
+# ======
 exit $((Errors<125?Errors:125))


### PR DESCRIPTION
Variables created with `typeset -RF` were being treated as short integers, even though they are actually floating point values. As a result the following example will cause a crash (`foo` cannot be zero):

```sh
$ typeset -RF foo=1
$ test "$foo"
```

This is fixed by checking for `NV_DOUBLE` with `nv_isattr`, which prevents ksh from treating floating point values as short integers due to `== NV_INT16P` excluding `NV_DOUBLE`. This bugfix was backported from ksh93v- 2013-10-10-alpha.