### PR TITLE
Fix memory corruption when a compound variable is unset

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,9 @@ Any uppercase BUG_* names are modernish shell bug IDs.
 - Variables created with 'typeset -RF' no longer cause a memory fault
   when accessed.
 
+- Unsetting an array that was turned into a compound variable will no
+  longer cause silent memory corruption.
+
 2020-06-26:
 
 - Changing to a directory that has a name starting with a '.' will no

--- a/src/cmd/ksh93/sh/nvtree.c
+++ b/src/cmd/ksh93/sh/nvtree.c
@@ -1142,6 +1142,8 @@ static void put_tree(register Namval_t *np, const char *val, int flags,Namfun_t 
 	nv_putv(np, val, flags,fp);
 	if(val && nv_isattr(np,(NV_INTEGER|NV_BINARY)))
 		return;
+	if(!val && !np->nvfun)
+		return;
 	if(ap= nv_arrayptr(np))
 		nleft = array_elem(ap);
 	if(nleft==0)


### PR DESCRIPTION
The following set of commands sometimes ends with a memory fault because ksh attempts to free memory twice, causing memory corruption:

```sh
# To reproduce the crash more consistently, run these
# commands individually in a terminal.
$ testarray=(1 2)
$ compound testarray
$ unset testarray
$ eval testarray=
Memory fault

# If you wish to run the above commands from a script
# instead, then use this set of commands:
$ unset LC_ALL
$ chmod +x ./reproducer.sh
$ ksh -c ./reproducer.sh
```

The fix is to make sure `np->nvfun` is a valid pointer before attempting to free memory in `put_tree`. This patch is from OpenSUSE: https://build.opensuse.org/package/view_file/shells/ksh/ksh93-nvtree-free.dif?expand=1