### PR TITLE
Fix memory leak regression tests by using ps(1)

### DIFF
--- a/src/cmd/ksh93/tests/leaks.sh
+++ b/src/cmd/ksh93/tests/leaks.sh
@@ -17,7 +17,6 @@
 #                  David Korn <dgk@research.att.com>                   #
 #                                                                      #
 ########################################################################
-builtin vmstate 2>/dev/null || exit 0
 
 function err_exit
 {
@@ -29,6 +28,12 @@ alias err_exit='err_exit $LINENO'
 
 Command=${0##*/}
 integer Errors=0
+
+# Get the current amount of memory usage
+function getmem
+{
+	echo $(ps -p $$ -o pid,vsz | awk '{ if (NR != 1){ print $2 } }')
+}
 
 # test for variable reset leak #
 
@@ -46,16 +51,16 @@ n=1000
 # one round to get to steady state -- sensitive to -x
 
 test_reset $n
-a=0$(vmstate --format='+%(size)u')
-b=0$(vmstate --format='+%(size)u')
+before="$(getmem)"
+after="$(getmem)"
 
 test_reset $n
-a=0$(vmstate --format='+%(size)u')
+before="$(getmem)"
 test_reset $n
-b=0$(vmstate --format='+%(size)u')
+after="$(getmem)"
 
-if	(( b > a ))
-then	err_exit "variable value reset memory leak -- $((b-a)) bytes after $n iterations"
+if	(( after > before ))
+then	err_exit "variable value reset memory leak -- $((after - before)) bytes after $n iterations"
 fi
 
 # buffer boundary tests
@@ -67,21 +72,21 @@ done
 
 data="(v=;sid=;di=;hi=;ti='1328244300';lv='o';id='172.3.161.178';var=(k='conn_num._total';u=;fr=;l='Number of Connections';n='22';t='number';))"
 read -C stat <<< "$data"
-a=0$(vmstate --format='+%(size)u')
+before="$(getmem)"
 for ((i=0; i < 500; i++))
 do	print -r -- "$data"
 done |	while read -u$n -C stat
 	do	:
 	done	{n}<&0-
-b=0$(vmstate --format='+%(size)u')
-(( b > a )) && err_exit 'memory leak with read -C when deleting compound variable'
+after="$(getmem)"
+(( after > before )) && err_exit 'memory leak with read -C when deleting compound variable'
 
 read -C stat <<< "$data"
-a=0$(vmstate --format='+%(size)u')
+before="$(getmem)"
 for ((i=0; i < 500; i++))
 do      read -C stat <<< "$data"
 done
-b=0$(vmstate --format='+%(size)u')
-(( b > a )) && err_exit 'memory leak with read -C when using <<<'
+after="$(getmem)"
+(( after > before )) && err_exit 'memory leak with read -C when using <<<'
 
 exit $((Errors<125?Errors:125))

--- a/src/cmd/ksh93/tests/leaks.sh
+++ b/src/cmd/ksh93/tests/leaks.sh
@@ -32,8 +32,13 @@ integer Errors=0
 # Get the current amount of memory usage
 function getmem
 {
-	echo $(ps -p $$ -o pid,vsz | awk '{ if (NR != 1){ print $2 } }')
+	UNIX95=1 ps -p "$$" -o vsz=
 }
+n=$(getmem)
+if	! let "$n == $n" 2>/dev/null	# not a number?
+then	err\_exit "$LINENO" "'ps' not POSIX-compliant; skipping tests"
+	exit 0
+fi
 
 # test for variable reset leak #
 
@@ -51,13 +56,13 @@ n=1000
 # one round to get to steady state -- sensitive to -x
 
 test_reset $n
-before="$(getmem)"
-after="$(getmem)"
+before=$(getmem)
+after=$(getmem)
 
 test_reset $n
-before="$(getmem)"
+before=$(getmem)
 test_reset $n
-after="$(getmem)"
+after=$(getmem)
 
 if	(( after > before ))
 then	err_exit "variable value reset memory leak -- $((after - before)) bytes after $n iterations"
@@ -72,21 +77,21 @@ done
 
 data="(v=;sid=;di=;hi=;ti='1328244300';lv='o';id='172.3.161.178';var=(k='conn_num._total';u=;fr=;l='Number of Connections';n='22';t='number';))"
 read -C stat <<< "$data"
-before="$(getmem)"
+before=$(getmem)
 for ((i=0; i < 500; i++))
 do	print -r -- "$data"
 done |	while read -u$n -C stat
 	do	:
 	done	{n}<&0-
-after="$(getmem)"
+after=$(getmem)
 (( after > before )) && err_exit 'memory leak with read -C when deleting compound variable'
 
 read -C stat <<< "$data"
-before="$(getmem)"
+before=$(getmem)
 for ((i=0; i < 500; i++))
 do      read -C stat <<< "$data"
 done
-after="$(getmem)"
+after=$(getmem)
 (( after > before )) && err_exit 'memory leak with read -C when using <<<'
 
 exit $((Errors<125?Errors:125))

--- a/src/cmd/ksh93/tests/leaks.sh
+++ b/src/cmd/ksh93/tests/leaks.sh
@@ -89,6 +89,6 @@ for ((i=0; i < 500; i++))
 do      read -C stat <<< "$data"
 done
 after=$(getmem)
-(( after > before )) && err_exit 'memory leak with read -C when using <<< (leaked $((after - before)) bytes)'
+(( after > before )) && err_exit "memory leak with read -C when using <<< (leaked $((after - before)) bytes)"
 
 exit $((Errors<125?Errors:125))

--- a/src/cmd/ksh93/tests/leaks.sh
+++ b/src/cmd/ksh93/tests/leaks.sh
@@ -62,7 +62,7 @@ test_reset $N
 after=$(getmem)
 
 if	(( after > before ))
-then	err_exit "variable value reset memory leak -- $((after - before)) bytes after $N iterations"
+then	err_exit "variable value reset memory leak -- $((after - before)) KiB after $N iterations"
 fi
 
 # buffer boundary tests
@@ -81,7 +81,7 @@ done |	while read -u$n -C stat
 	do	:
 	done	{n}<&0-
 after=$(getmem)
-(( after > before )) && err_exit "memory leak with read -C when deleting compound variable (leaked $((after - before)) bytes)"
+(( after > before )) && err_exit "memory leak with read -C when deleting compound variable (leaked $((after - before)) KiB)"
 
 read -C stat <<< "$data"
 before=$(getmem)
@@ -89,6 +89,6 @@ for ((i=0; i < 500; i++))
 do      read -C stat <<< "$data"
 done
 after=$(getmem)
-(( after > before )) && err_exit "memory leak with read -C when using <<< (leaked $((after - before)) bytes)"
+(( after > before )) && err_exit "memory leak with read -C when using <<< (leaked $((after - before)) KiB)"
 
 exit $((Errors<125?Errors:125))

--- a/src/cmd/ksh93/tests/leaks.sh
+++ b/src/cmd/ksh93/tests/leaks.sh
@@ -44,28 +44,25 @@ fi
 
 function test_reset
 {
-	integer i n=$1
+	integer i N=$1
 
-	for ((i = 0; i < n; i++))
+	for ((i = 0; i < N; i++))
 	do	u=$i
 	done
 }
 
-n=1000
+N=1000
 
 # one round to get to steady state -- sensitive to -x
 
-test_reset $n
+test_reset $N
+test_reset $N
 before=$(getmem)
-after=$(getmem)
-
-test_reset $n
-before=$(getmem)
-test_reset $n
+test_reset $N
 after=$(getmem)
 
 if	(( after > before ))
-then	err_exit "variable value reset memory leak -- $((after - before)) bytes after $n iterations"
+then	err_exit "variable value reset memory leak -- $((after - before)) bytes after $N iterations"
 fi
 
 # buffer boundary tests
@@ -84,7 +81,7 @@ done |	while read -u$n -C stat
 	do	:
 	done	{n}<&0-
 after=$(getmem)
-(( after > before )) && err_exit 'memory leak with read -C when deleting compound variable'
+(( after > before )) && err_exit "memory leak with read -C when deleting compound variable (leaked $((after - before)) bytes)"
 
 read -C stat <<< "$data"
 before=$(getmem)
@@ -92,6 +89,6 @@ for ((i=0; i < 500; i++))
 do      read -C stat <<< "$data"
 done
 after=$(getmem)
-(( after > before )) && err_exit 'memory leak with read -C when using <<<'
+(( after > before )) && err_exit 'memory leak with read -C when using <<< (leaked $((after - before)) bytes)'
 
 exit $((Errors<125?Errors:125))


### PR DESCRIPTION
EDIT: This pull request now uses `ps` and `awk` instead of `vmstate` to fix `leaks.sh`, as adding `vmstate` to the builtin table increases the binary size of ksh by 12k. My original comment is below:

Although the `vmstate` builtin in libcmd is built when ksh is compiled, it can't be enabled with `builtin vmstate` because it isn't in the table of builtins. As a result the regression tests in `leaks.sh` are not actually run, rather the script silently fails without printing a message to indicate the tests were skipped:
https://github.com/ksh93/ksh/blob/5135cf651c03952114132b1efd429a0a45026c37/src/cmd/ksh93/tests/leaks.sh#L20

This pull request makes the following changes to fix the memory leak regression tests:
* `vmstate` has been added to the table of builtins because the regression tests in `leaks.sh` require `vmstate`.
* The `leaks.sh` regression test script will now print a warning if it cannot run `vmstate` as a builtin.