### PR TITLE
Fix the readonly builtin's scope in functions

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -12,7 +12,8 @@ Any uppercase BUG_* names are modernish shell bug IDs.
   longer cause silent memory corruption.
 
 - Variables created with 'readonly' in functions are now set to the
-  specified value instead of nothing.
+  specified value instead of nothing. Note that 'readonly' does not
+  create a function-local scope, unlike 'typeset -r' which does.
 
 2020-06-26:
 

--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,9 @@ Any uppercase BUG_* names are modernish shell bug IDs.
 - Variables created with 'typeset -RF' no longer cause a memory fault
   when accessed.
 
+- Variables created with 'readonly' in functions are now set to the
+  specified value instead of nothing.
+
 2020-06-26:
 
 - Changing to a directory that has a name starting with a '.' will no

--- a/src/cmd/ksh93/bltins/typeset.c
+++ b/src/cmd/ksh93/bltins/typeset.c
@@ -125,11 +125,9 @@ int    b_readonly(int argc,char *argv[],Shbltin_t *context)
 	}
 #endif
 	else
-	{
 		flag = (NV_ASSIGN|NV_EXPORT|NV_IDENT);
-		if(!tdata.sh->prefix)
-			tdata.sh->prefix = "";
-	}
+	if(!tdata.sh->prefix)
+		tdata.sh->prefix = "";
 	return(setall(argv,flag,tdata.sh->var_tree, &tdata));
 }
 

--- a/src/cmd/ksh93/data/builtins.c
+++ b/src/cmd/ksh93/data/builtins.c
@@ -1360,7 +1360,7 @@ USAGE_LICENSE
 ;
 
 const char sh_optreadonly[] =
-"[-1c?\n@(#)$Id: readonly (AT&T Research) 2008-06-16 $\n]"
+"[-1c?\n@(#)$Id: readonly (AT&T Research/ksh93) 2020-06-28 $\n]"
 USAGE_LICENSE
 "[+NAME?readonly - set readonly attribute on variables]"
 "[+DESCRIPTION?\breadonly\b sets the readonly attribute on each of "
@@ -1368,6 +1368,9 @@ USAGE_LICENSE
 	"values from being changed.  If \b=\b\avalue\a is specified, "
 	"the variable \aname\a is set to \avalue\a before the variable "
 	"is made readonly.]"
+"[+?Unlike \btypeset -r\b, \breadonly\b does not create a function-local "
+	"scope and the given \aname\as are marked globally read-only by "
+	"default.]"
 "[+?Within a type definition, if the value is not specified, then a "
 	"value must be specified when creating each instance of the type "
         "and the value is readonly for each instance.]"

--- a/src/cmd/ksh93/sh.1
+++ b/src/cmd/ksh93/sh.1
@@ -6752,6 +6752,12 @@ are marked
 readonly and these
 names cannot be changed
 by subsequent assignment.
+Unlike
+.B typeset\ -r ,
+.B readonly
+does not create a function-local scope and the given
+.IR vname s
+are marked globally read-only by default.
 When defining a type, if the value of a readonly sub-variable is not defined
 the value is required when creating each instance.
 .TP

--- a/src/cmd/ksh93/tests/builtins.sh
+++ b/src/cmd/ksh93/tests/builtins.sh
@@ -727,4 +727,16 @@ chmod is a tracked alias for $(whence -p chmod)"
 ) || err_exit 'cd ../.bar when ../.bar exists should not fail'
 
 # ======
+# 'readonly' should set the correct scope when creating variables in functions
+unset foo
+(
+	function test_func
+	{
+		readonly foo="bar"
+		[[ "$foo" = "bar" ]] || err_exit "readonly variable is not assigned a value inside functions"
+	}
+	test_func
+)
+
+# ======
 exit $((Errors<125?Errors:125))


### PR DESCRIPTION
This bug was first reported in att/ast#881. `tdata.sh->prefix` is only set to the correct value when `b_readonly` is called as `export`, which breaks `readonly` in functions because the correct scope isn't set. Due to this bug the following example will only print a newline:

```sh
$ function show_bar { readonly foo=bar; echo $foo; }; show_bar
```

The fix is to move the required code out of the if statement for `export`, as it needs to be run for `readonly` as well. This bugfix is from att/ast#906.