### PR TITLE
Fix a crash when 'read -u' is given an invalid fd

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,11 @@ For full details, see the git log at: https://github.com/ksh93/ksh
 
 Any uppercase BUG_* names are modernish shell bug IDs.
 
+2020-06-30:
+
+- 'read -u' will no longer crash with a memory fault when given an out of
+  range or negative file descriptor.
+
 2020-06-28:
 
 - Variables created with 'typeset -RF' no longer cause a memory fault

--- a/src/cmd/ksh93/bltins/read.c
+++ b/src/cmd/ksh93/bltins/read.c
@@ -128,6 +128,8 @@ int	b_read(int argc,char *argv[], Shbltin_t *context)
 		break;
 	    case 'u':
 		fd = (int)opt_info.num;
+		if(opt_info.num<0 || opt_info.num>INT_MAX || (fd>=shp->gd->lim.open_max && !sh_iovalidfd(shp,fd)))
+			errormsg(SH_DICT,ERROR_exit(1),e_file,opt_info.arg); /* reject invalid file descriptors */
 		if(sh_inuse(shp,fd))
 			fd = -1;
 		break;

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -17,4 +17,4 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                                                                      *
 ***********************************************************************/
-#define SH_RELEASE	"93u+m 2020-06-28"
+#define SH_RELEASE	"93u+m 2020-06-30"

--- a/src/cmd/ksh93/tests/io.sh
+++ b/src/cmd/ksh93/tests/io.sh
@@ -558,4 +558,17 @@ result=$("$SHELL" -ic 'echo >(true) >/dev/null' 2>&1)
 				"(expected '', got $(printf %q "$result"))"
 
 # ======
+# Out of range file descriptors shouldn't cause 'read -u' to segfault
+"$SHELL" -c 'read -u2000000' 2> /dev/null
+[[ $? == 1 ]] || err_exit "Large file descriptors cause 'read -u' to crash"
+
+# Separately test numbers outside of the 32-bit limit as well
+"$SHELL" -c 'read -u2000000000000' 2> /dev/null
+[[ $? == 1 ]] || err_exit "File descriptors larger than the 32-bit limit cause 'read -u' to crash"
+
+# Negative numbers shouldn't segfault either
+"$SHELL" -c 'read -u-2000000' 2> /dev/null
+[[ $? == 1 ]] || err_exit "Negative file descriptors cause 'read -u' to crash"
+
+# ======
 exit $((Errors<125?Errors:125))


### PR DESCRIPTION
File descriptors that are too far out of range cause `read -u` to crash. The following example will generate two crashes:

```sh
$ ksh -c 'read -u2000000' || ksh -c 'read -u-2000000'
```

The fix is to error out when the given file descriptor is out of range. This bugfix is from Tomas Klacko, although it was
modified to use `sh_iovalidfd` and reject numbers greater than `INT_MAX`:
https://www.mail-archive.com/ast-developers@lists.research.att.com/msg01912.html
The question about `shp->fdstatus[-1]` only applies to ksh93v- (ksh93u+ doesn't have any references to `shp->fdstatus[-1]` afaict).