### PR TITLE
Fix regular expressions that use '{x}'

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,9 @@ Any uppercase BUG_* names are modernish shell bug IDs.
 - 'read -u' will no longer crash with a memory fault when given an out of
   range or negative file descriptor.
 
+- The '=~' operator no longer raises an error if a regular expression
+  combines the '{x}' quantifier with a sub-expression.
+
 2020-06-28:
 
 - Variables created with 'typeset -RF' no longer cause a memory fault

--- a/src/cmd/ksh93/sh/lex.c
+++ b/src/cmd/ksh93/sh/lex.c
@@ -388,6 +388,12 @@ int sh_lex(Lex_t* lp)
 		switch(n)
 		{
 			case S_BREAK:
+				if(lp->lex.incase>TEST_RE && mode==ST_NORM && c==LPAREN)
+				{
+					pushlevel(lp,RPAREN,mode);
+					mode = ST_NESTED;
+					continue;
+				}
 				fcseek(-LEN);
 				goto breakloop;
 			case S_EOF:
@@ -1163,7 +1169,7 @@ int sh_lex(Lex_t* lp)
 				}
 				if(mode==ST_NONE)
 					return(0);
-				if(c!=n)
+				if(c!=n && lp->lex.incase<TEST_RE)
 				{
 					lp->token = c;
 					sh_syntax(lp);

--- a/src/cmd/ksh93/tests/bracket.sh
+++ b/src/cmd/ksh93/tests/bracket.sh
@@ -389,4 +389,9 @@ test 123 -eq 123x 2>/dev/null
 [[ $? -ge 2 ]] || err_exit 'test builtin should return value greater than 1 on error'
 
 # ======
+# The '=~' operator should work with curly brackets
+$SHELL -c '[[ AATAAT =~ (AAT){2} ]]' || err_exit '[[ AATAAT =~ (AAT){2} ]] does not match'
+$SHELL -c '[[ AATAATCCCAATAAT =~ (AAT){2}CCC(AAT){2} ]]' || err_exit '[[ AATAATCCCAATAAT =~ (AAT){2}CCC(AAT){2} ]] does not match'
+
+# ======
 exit $((Errors<125?Errors:125))


### PR DESCRIPTION
Regular expressions that make use of the `{x}` quantifier throw a garbled syntax error:

```
$ [[ AATAAT =~ (AAT){2} ]]
ksh: syntax error: `~(E)(AAT){2} ]]
:'%Cred%h%Creseksh: syntax error: `~(E)(AAT){2} ]]
:'%Cred%h%Creseksh: syntax' unexpected
```

The syntax error occurs because ksh is not properly accounting for `=~` when it runs into a curly bracket. This fix disables the syntax error when the operator is `=~` and adds handling for multiple instances of `(str){x}`. This bugfix and the regression tests for it were backported from ksh93v- 2014-12-24-beta.