### PR TITLE
Fix segfault if $PATH contains a .paths directory

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,12 @@ For full details, see the git log at: https://github.com/ksh93/ksh
 
 Any uppercase BUG_* names are modernish shell bug IDs.
 
+2020-07-02:
+
+- Fixed a crash that occurred if a directory named '.paths' existed in any
+  directory listed in $PATH. The fix was to only read '.paths' if it is a
+  regular file or a symlink to a regular file.
+
 2020-06-30:
 
 - 'read -u' will no longer crash with a memory fault when given an out of

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -17,4 +17,4 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                                                                      *
 ***********************************************************************/
-#define SH_RELEASE	"93u+m 2020-06-30"
+#define SH_RELEASE	"93u+m 2020-07-02"

--- a/src/cmd/ksh93/sh/path.c
+++ b/src/cmd/ksh93/sh/path.c
@@ -1507,6 +1507,10 @@ static int path_chkpaths(Shell_t *shp,Pathcomp_t *first, Pathcomp_t* old,Pathcom
 	if((fd=open(stakptr(offset),O_RDONLY))>=0)
 	{
 		fstat(fd,&statb);
+		if (S_ISDIR(statb.st_mode)) {
+			close(fd);
+			return 0;
+		}
 		n = statb.st_size;
 		stakseek(offset+pp->len+n+2);
 		sp = stakptr(offset+pp->len);

--- a/src/cmd/ksh93/sh/path.c
+++ b/src/cmd/ksh93/sh/path.c
@@ -1507,7 +1507,7 @@ static int path_chkpaths(Shell_t *shp,Pathcomp_t *first, Pathcomp_t* old,Pathcom
 	if((fd=open(stakptr(offset),O_RDONLY))>=0)
 	{
 		fstat(fd,&statb);
-		if (S_ISDIR(statb.st_mode)) {
+		if (!S_ISREG(statb.st_mode)) {
 			close(fd);
 			return 0;
 		}

--- a/src/cmd/ksh93/tests/path.sh
+++ b/src/cmd/ksh93/tests/path.sh
@@ -409,8 +409,13 @@ v=$(PATH=/dev/null "$SHELL" -c 'command -p ls /dev/null')
 [[ $v == /dev/null ]] || err_exit 'command -p fails to find standard utility'
 
 # ksh segfaults if $PATH contains a .paths directory
+mkdir -p $tmp/paths-dir-crash/
+cat > $tmp/paths-dir-crash/run.sh <<- EOF
 mkdir -p $tmp/paths-dir-crash/.paths
 export PATH=$tmp/paths-dir-crash:$PATH
+print ok
+EOF
+[[ $($SHELL $tmp/paths-dir-crash/run.sh 2>/dev/null) == ok ]] || err_exit "ksh crashes if PATH contains a .paths directory"
 
 # ======
 exit $((Errors<125?Errors:125))

--- a/src/cmd/ksh93/tests/path.sh
+++ b/src/cmd/ksh93/tests/path.sh
@@ -408,6 +408,10 @@ END
 v=$(PATH=/dev/null "$SHELL" -c 'command -p ls /dev/null')
 [[ $v == /dev/null ]] || err_exit 'command -p fails to find standard utility'
 
+# ksh segfaults if $PATH contains a .paths directory
+mkdir -p $tmp/paths-dir-crash/.paths
+export PATH=$tmp/paths-dir-crash:$PATH
+
 # ======
 exit $((Errors<125?Errors:125))
 


### PR DESCRIPTION
ksh will crash if it encounters a .paths directory in any of the
directories in $PATH.

Ref: https://bugs.launchpad.net/ubuntu/+source/ksh/+bug/1534855