### PR TITLE
Fix a few bugs with escaping backslashes

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -14,11 +14,11 @@ Any uppercase BUG_* names are modernish shell bug IDs.
   string such as 'ab\\\' will only cause the first backslash to escape a
   Backspace as '^?', like in emacs mode.
 
-- An odd interaction with Backspace when the last character of a temporary
+- An odd interaction with Backspace when the last character of a separate
   buffer created with Shift-C was '\' has been fixed. '^?' will no longer
-  be output repeatedly when attempting to erase a temporary buffer with
-  a Backspace. Note that temporary buffers created with Shift-C are not
-  meant to be erasable:
+  be output repeatedly when attempting to erase a separate buffer with
+  a Backspace. Note that buffers created with Shift-C are not meant to be
+  erasable:
   https://pubs.opengroup.org/onlinepubs/9699919799/utilities/vi.html#tag_20_152_13_49
 
 2020-07-02:

--- a/NEWS
+++ b/NEWS
@@ -14,6 +14,13 @@ Any uppercase BUG_* names are modernish shell bug IDs.
   string such as 'ab\\\' will only cause the first backslash to escape a
   Backspace as '^?', like in emacs mode.
 
+- An odd interaction with Backspace when the last character of a temporary
+  buffer created with Shift-C was '\' has been fixed. '^?' will no longer
+  be output repeatedly when attempting to erase a temporary buffer with
+  a Backspace. Note that temporary buffers created with Shift-C are not
+  meant to be erasable:
+  https://pubs.opengroup.org/onlinepubs/9699919799/utilities/vi.html#tag_20_152_13_49
+
 2020-07-02:
 
 - Fixed a crash that occurred if a directory named '.paths' existed in any

--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,17 @@ For full details, see the git log at: https://github.com/ksh93/ksh
 
 Any uppercase BUG_* names are modernish shell bug IDs.
 
+2020-07-03:
+
+- Backslashes are no longer escaped in the raw Bourne Shell-like editing
+  mode in multibyte locales, i.e. backslashes are no longer treated like
+  Control-V if the emacs and vi modes are disabled.
+
+- Deleting a backslash in vi mode with Control-H or Backspace now only
+  escapes a backslash if it was the previous input. This means erasing a
+  string such as 'ab\\\' will only cause the first backslash to escape a
+  Backspace as '^?', like in emacs mode.
+
 2020-07-02:
 
 - Fixed a crash that occurred if a directory named '.paths' existed in any

--- a/src/cmd/ksh93/edit/vi.c
+++ b/src/cmd/ksh93/edit/vi.c
@@ -1363,7 +1363,7 @@ static void getline(register Vi_t* vp,register int mode)
 {
 	register int c;
 	register int tmp;
-	int	max_virt=0, last_save=0;
+	int	max_virt=0, last_save=0, backslash=0;
 	genchar saveline[MAXLINE];
 	vp->addnl = 1;
 
@@ -1460,8 +1460,9 @@ static void getline(register Vi_t* vp,register int mode)
 				/*** treat as backspace ***/
 
 		case '\b':		/** backspace **/
-			if( virtual[cur_virt] == '\\' )
+			if( sh_isoption(SH_VI) && backslash && virtual[cur_virt] == '\\' )
 			{
+				backslash = 0;
 				cdelete(vp,1, BAD);
 				append(vp,usrerase, mode);
 			}
@@ -1505,8 +1506,9 @@ static void getline(register Vi_t* vp,register int mode)
 			break;
 
 		case UKILL:		/** user kill line char **/
-			if( virtual[cur_virt] == '\\' )
+			if( sh_isoption(SH_VI) && backslash && virtual[cur_virt] == '\\' )
 			{
+				backslash = 0;
 				cdelete(vp,1, BAD);
 				append(vp,usrkill, mode);
 			}
@@ -1580,6 +1582,7 @@ static void getline(register Vi_t* vp,register int mode)
 				mode = APPEND;
 				max_virt = last_virt+3;
 			}
+			backslash = (c == '\\');
 			append(vp,c, mode);
 			break;
 		}

--- a/src/cmd/ksh93/tests/pty.sh
+++ b/src/cmd/ksh93/tests/pty.sh
@@ -524,9 +524,8 @@ for mode in emacs vi; do
 tst $LINENO << !
 L escaping backslashes in $mode mode
 
-# Backslashes should only be escaped if the previous input character was
-# a backslash. Other backslashes stored in the input buffer should be
-# deleted normally.
+# Backslashes should only be escaped if the previous input was a backslash.
+# Other backslashes stored in the input buffer should be erased normally.
 
 w set -o $mode; stty erase ^H
 p :test-2:

--- a/src/cmd/ksh93/tests/pty.sh
+++ b/src/cmd/ksh93/tests/pty.sh
@@ -511,6 +511,8 @@ L raw Bourne mode backslash handling
 # The escaping backslash feature should be disabled in the raw Bourne mode.
 # This is tested with both erase and kill characters.
 
+d 10
+p :test-1:
 w set +o vi +o emacs; stty erase ^H kill ^X
 p :test-2:
 w true string\\\\\cH\cH
@@ -527,6 +529,8 @@ L escaping backslashes in $mode mode
 # Backslashes should only be escaped if the previous input was a backslash.
 # Other backslashes stored in the input buffer should be erased normally.
 
+d 10
+p :test-1:
 w set -o $mode; stty erase ^H
 p :test-2:
 w true string\\\\\\\\\\cH\\cH\\cH

--- a/src/cmd/ksh93/tests/pty.sh
+++ b/src/cmd/ksh93/tests/pty.sh
@@ -505,5 +505,35 @@ r ^:test-2: true (/de\tv/nu\tl\tl|/de       v/nu    l       l)\r\n$
 p :test-3:
 !
 
+LC_ALL=C.UTF8 tst $LINENO <<"!"
+L raw Bourne mode backslash handling
+
+# The escaping backslash feature should be disabled in the raw Bourne mode.
+# This is tested with both erase and kill characters.
+
+w set +o vi +o emacs; stty erase ^H kill ^X
+p :test-2:
+w true string\\\\\cH\cH
+r ^:test-2: true string\r\n$
+p :test-3:
+w true incorrect\\\cXtrue correct
+r ^:test-3: true correct\r\n$
+!
+
+for mode in emacs vi; do
+tst $LINENO << !
+L escaping backslashes in $mode mode
+
+# Backslashes should only be escaped if the previous input character was
+# a backslash. Other backslashes stored in the input buffer should be
+# deleted normally.
+
+w set -o $mode; stty erase ^H
+p :test-2:
+w true string\\\\\\\\\\cH\\cH\\cH
+r ^:test-2: true string\\r\\n$
+!
+done
+
 # ======
 exit $((Errors<125?Errors:125))


### PR DESCRIPTION
This pull request fixes the following bugs in the escaping backslash feature:

* The vi mode now only escapes the next character if the last character input was a backslash, fixing the bug reported at https://github.com/ksh-community/ksh/issues/8#issuecomment-605896180. This is done by unsetting a variable named `backslash` if a backslash escaped a character. `backslash` is set to the result of `c == '\\'` when the user enters a new character.

* Escaping backslashes are now always disabled if the vi and emacs modes are disabled. This makes the behavior of the raw editing mode consistent with `LC_ALL=C` and `LC_ALL=C.UTF-8` when handling backslashes.

* (Added after initial pull request): An odd interaction with Backspace when the last character of a temporary buffer created with Shift-C was a backslash has been fixed. `^?` will no longer be output repeatedly when attempting to erase a separate buffer with a Backspace (although buffers created with Shift-C cannot be deleted, see https://github.com/ksh93/ksh/issues/56#issuecomment-653586994).

Fixes #56