### PR TITLE
Fix 'kill -INFO' on systems that support SIGINFO

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -21,6 +21,9 @@ Any uppercase BUG_* names are modernish shell bug IDs.
   erasable:
   https://pubs.opengroup.org/onlinepubs/9699919799/utilities/vi.html#tag_20_152_13_49
 
+- The 'kill' builtin now supports the SIGINFO signal (on operating systems
+  with support for SIGINFO).
+
 2020-07-02:
 
 - Fixed a crash that occurred if a directory named '.paths' existed in any

--- a/src/cmd/ksh93/data/signals.c
+++ b/src/cmd/ksh93/data/signals.c
@@ -108,7 +108,7 @@ const struct shtable2 shtab_signals[] =
 	"INT",		VAL(SIGINT,SH_SIGINTERACTIVE),			"",
 #endif /* JOBS */
 #ifdef SIGINFO
-	"INFO",		VAL(SIGINFO,SH_SIGDONE),			S("Information request"),
+	"INFO",		VAL(SIGINFO,SH_SIGIGNORE),			S("Information request"),
 #endif	/* SIGINFO */
 #ifdef SIGIO
 	"IO",		VAL(SIGIO,SH_SIGDONE),				S("IO signal"),

--- a/src/cmd/ksh93/data/signals.c
+++ b/src/cmd/ksh93/data/signals.c
@@ -107,6 +107,9 @@ const struct shtable2 shtab_signals[] =
 #else
 	"INT",		VAL(SIGINT,SH_SIGINTERACTIVE),			"",
 #endif /* JOBS */
+#ifdef SIGINFO
+	"INFO",		VAL(SIGINFO,SH_SIGDONE),			S("Information request"),
+#endif	/* SIGINFO */
 #ifdef SIGIO
 	"IO",		VAL(SIGIO,SH_SIGDONE),				S("IO signal"),
 #endif	/* SIGIO */

--- a/src/cmd/ksh93/tests/signal.sh
+++ b/src/cmd/ksh93/tests/signal.sh
@@ -460,4 +460,11 @@ $SHELL -c 'kill %+ 2> /dev/null'; [[ $? == 1 ]] || err_exit $'`kill` doesn\'t ha
 $SHELL -c 'kill %- 2> /dev/null'; [[ $? == 1 ]] || err_exit $'`kill` doesn\'t handle a non-existent job correctly when passed \'%-\''
 
 # ======
+# SIGINFO should be supported by the kill builtin on platforms that have it.
+if "$(whence -p kill)" -INFO $$ 2> /dev/null
+then
+	kill -INFO $$ || err_exit '`kill` cannot send SIGINFO to processes when passed `-INFO`'
+fi
+
+# ======
 exit $((Errors<125?Errors:125))


### PR DESCRIPTION
`SIGINFO` is absent from the table of signals, which causes commands like `kill -INFO $$` to fail on platforms that support `SIGINFO` (such as macOS and FreeBSD). This is fixed by adding `SIGINFO` to the signal table.