### PR TITLE
Fix use of strdup on a NULL pointer

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,11 @@ For full details, see the git log at: https://github.com/ksh93/ksh
 
 Any uppercase BUG_* names are modernish shell bug IDs.
 
+2020-07-06:
+
+- 'notty' is now written to the ksh auditing file instead of '(null)' if
+  the user's tty could not be determined.
+
 2020-07-05:
 
 - In UTF-8 locales, fix corruption of the shell's internal string quoting

--- a/src/cmd/ksh93/edit/history.c
+++ b/src/cmd/ksh93/edit/history.c
@@ -395,7 +395,7 @@ retry:
 			if(fd>=0)
 			{
 				fcntl(fd,F_SETFD,FD_CLOEXEC);
-				hp->tty = strdup(ttyname(2));
+				hp->tty = strdup(isatty(2)?ttyname(2):"notty");
 				hp->auditfp = sfnew((Sfio_t*)0,NULL,-1,fd,SF_WRITE);
 			}
 		}

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -17,4 +17,4 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                                                                      *
 ***********************************************************************/
-#define SH_RELEASE	"93u+m 2020-07-05"
+#define SH_RELEASE	"93u+m 2020-07-06"


### PR DESCRIPTION
EDIT: The pull request message has been updated with a correction for using `strdup` on a null pointer.

The following set of commands can cause a memory fault when auditing is enabled, although it can also cause ksh to write '(null)' to the auditing file in place of a tty name:

```sh
$ [ -e /etc/ksh_audit ] || echo "/tmp/ksh_auditfile;$(id -u)" | sudo tee /etc/ksh_audit;  # Enable auditing
$ v=$(ksh 2>/dev/null +o rc -ic $'getopts a:bc: opt --man\nprint $?')
$ cat /tmp/ksh_auditfile
1000;1594036971;(null); getopts a:bc: opt --man
1000;1594036971;(null); print $?
```

The crash can also occur in this regression test, although intermittently:
https://github.com/ksh93/ksh/blob/300cd199872b577769f749c18e19b39f22476725/src/cmd/ksh93/tests/builtins.sh#L651-L653

```
$ bin/shtests builtins
#### Regression-testing /home/johno/Documents/GitRepos/Clones/ksh/arch/linux.i386-64/bin/ksh ####
test builtins begins at 2020-07-06+04:51:55
builtins.sh: line 652: 4640: Memory fault
	builtins.sh[653]: getopts --man does not exit 2 for interactive shells
test builtins failed at 2020-07-06+04:52:03 with exit code 1 [ 167 tests 1 error ]
test builtins(C.UTF-8) begins at 2020-07-06+04:52:03
builtins.sh: line 652: 4755: Memory fault
	builtins.sh[653]: getopts --man does not exit 2 for interactive shells
test builtins(C.UTF-8) failed at 2020-07-06+04:52:11 with exit code 1 [ 167 tests 1 error ]
test builtins(shcomp) begins at 2020-07-06+04:52:11
/tmp/ksh93.shtests.4496.23731/shcomp-builtins.ksh: line 652: 4875: Memory fault
	shcomp-builtins.ksh[653]: getopts --man does not exit 2 for interactive shells
test builtins(shcomp) failed at 2020-07-06+04:52:20 with exit code 1 [ 167 tests 1 error ]
Total errors: 3
CPU time       user:      system:
main:       0m00.00s     0m00.00s
tests:      0m00.23s     0m00.06s
```

This happens because `strdup` is used unconditionally on the pointer returned by `ttyname`, which can be NULL if `stderr` is closed. The string is then set to NULL, which causes the crash as ksh expects a valid pointer to be returned:
https://github.com/ksh93/ksh/blob/300cd199872b577769f749c18e19b39f22476725/src/cmd/ksh93/edit/history.c#L397-L399
https://github.com/ksh93/ksh/blob/300cd199872b577769f749c18e19b39f22476725/src/lib/libast/string/strdup.c#L53-L60

From https://pubs.opengroup.org/onlinepubs/9699919799/functions/ttyname.html#tag_16_628_04:
> Upon successful completion, ttyname() shall return a pointer to a string. Otherwise, a null pointer shall be returned and errno set to indicate the error.

This bug was originally reported in att/ast#1028. The fix (from att/ast#1062) is to have strdup duplicate 'notty' if `ttyname` returns a null pointer, which results in the auditing file now recording 'notty' instead of '(null)':
```sh
$ v=$(ksh  2> /dev/null +o rc -ic $'getopts a:bc: opt --man\nprint $?')  # This may cause a segfault
$ cat /tmp/ksh_auditfile
1000;1594036922;notty; getopts a:bc: opt --man
1000;1594036922;notty; print $?
```