### PR TITLE
Fix memory leak on unset of associative array

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,8 @@ Any uppercase BUG_* names are modernish shell bug IDs.
 - 'notty' is now written to the ksh auditing file instead of '(null)' if
   the user's tty could not be determined.
 
+- Unsetting an associative array no longer causes a memory leak to occur.
+
 2020-07-05:
 
 - In UTF-8 locales, fix corruption of the shell's internal string quoting

--- a/src/cmd/ksh93/sh/name.c
+++ b/src/cmd/ksh93/sh/name.c
@@ -1298,7 +1298,18 @@ void nv_delete(Namval_t* np, Dt_t *root, int flags)
 		if(dtdelete(root,np))
 		{
 			if(!(flags&NV_NOFREE) && ((flags&NV_FUNCTION) || !nv_subsaved(np)))
+			{
+				Namarr_t *ap;
+				if(nv_isarray(np) && np->nvfun && (ap=nv_arrayptr(np)) && array_assoc(ap))
+				{
+					/* free associative array from memory */
+					while(nv_associative(np,0,NV_ANEXT))
+						nv_associative(np,0,NV_ADELETE);
+					nv_associative(np,0,NV_AFREE);
+					free((void*)np->nvfun);
+				}
 				free((void*)np);
+			}
 		}
 #if 0
 		else

--- a/src/cmd/ksh93/tests/leaks.sh
+++ b/src/cmd/ksh93/tests/leaks.sh
@@ -101,4 +101,24 @@ done
 after=$(getmem)
 (( after > before )) && err_exit "memory leak with read -C when using <<< (leaked $((after - before)) $unit)"
 
+# ======
+# Unsetting an associative array shouldn't cause a memory leak
+# See https://www.mail-archive.com/ast-users@lists.research.att.com/msg01017.html
+typeset -A stuff
+typeset -lui i=0
+before=$(getmem)
+for (( i=0; i<1000; i++ ))
+do
+	unset stuff[xyz]
+	typeset -A stuff[xyz]
+	stuff[xyz][elem0]="data0"
+	stuff[xyz][elem1]="data1"
+	stuff[xyz][elem2]="data2"
+	stuff[xyz][elem3]="data3"
+	stuff[xyz][elem4]="data4"
+done
+after=$(getmem)
+(( after > before )) && err_exit 'unset of associative array causes memory leak'
+
+# ======
 exit $((Errors<125?Errors:125))

--- a/src/cmd/ksh93/tests/leaks.sh
+++ b/src/cmd/ksh93/tests/leaks.sh
@@ -119,7 +119,7 @@ do
 done
 after=$(getmem)
 (( after > before )) && err_exit 'unset of associative array causes memory leak' \
-	"(leaked $((after - before)) KiB)"
+	"(leaked $((after - before)) $unit)"
 
 # ======
 exit $((Errors<125?Errors:125))

--- a/src/cmd/ksh93/tests/leaks.sh
+++ b/src/cmd/ksh93/tests/leaks.sh
@@ -118,7 +118,8 @@ do
 	stuff[xyz][elem4]="data4"
 done
 after=$(getmem)
-(( after > before )) && err_exit 'unset of associative array causes memory leak'
+(( after > before )) && err_exit 'unset of associative array causes memory leak' \
+	"(leaked $((after - before)) KiB)"
 
 # ======
 exit $((Errors<125?Errors:125))

--- a/src/cmd/ksh93/tests/leaks.sh
+++ b/src/cmd/ksh93/tests/leaks.sh
@@ -103,7 +103,7 @@ after=$(getmem)
 
 # ======
 # Unsetting an associative array shouldn't cause a memory leak
-# See https://www.mail-archive.com/ast-users@lists.research.att.com/msg01017.html
+# See https://www.mail-archive.com/ast-users@lists.research.att.com/msg01016.html
 typeset -A stuff
 typeset -lui i=0
 before=$(getmem)

--- a/src/cmd/ksh93/tests/leaks.sh
+++ b/src/cmd/ksh93/tests/leaks.sh
@@ -117,6 +117,7 @@ do
 	stuff[xyz][elem3]="data3"
 	stuff[xyz][elem4]="data4"
 done
+unset stuff
 after=$(getmem)
 (( after > before )) && err_exit 'unset of associative array causes memory leak' \
 	"(leaked $((after - before)) $unit)"

--- a/src/cmd/ksh93/tests/leaks.sh
+++ b/src/cmd/ksh93/tests/leaks.sh
@@ -105,7 +105,6 @@ after=$(getmem)
 # Unsetting an associative array shouldn't cause a memory leak
 # See https://www.mail-archive.com/ast-users@lists.research.att.com/msg01016.html
 typeset -A stuff
-typeset -lui i=0
 before=$(getmem)
 for (( i=0; i<1000; i++ ))
 do


### PR DESCRIPTION
Associative arrays aren't completely freed from memory in `nv_delete`, which causes a memory leak to occur when an associative array is unset. This is fixed by freeing all elements of an associative array with a loop before they become inaccessible. Reproducer from https://www.mail-archive.com/ast-users@lists.research.att.com/msg01016.html:
```sh
$ cat ./reproducer.sh
#!/bin/ksh
export UNIX95=1
printf 'Memory usage before:'
ps -p $$ -o vsz=
typeset -A stuff
typeset -lui i=0 
for (( i=0; i<1000; i++ )); do
    unset stuff[xyz]
    typeset -A stuff[xyz]
    stuff[xyz][elem0]="data0"
    stuff[xyz][elem1]="data1"
    stuff[xyz][elem2]="data2"
    stuff[xyz][elem3]="data3"
    stuff[xyz][elem4]="data4"
done
printf 'Memory usage after: '
ps -p $$ -o vsz=
$ ksh ./reproducer.sh
Memory usage before: 8592
Memory usage after:  9456
```