### PR TITLE
Fix a syntax error when ((...)) is combined with redirections

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -12,6 +12,9 @@ Any uppercase BUG_* names are modernish shell bug IDs.
 - Fixed a memory leak when restoring PATH when temporarily setting PATH
   for a command (e.g. PATH=/foo/bar command ...) or in a virtual subshell.
 
+- Combining ((...)) with redirections no longer causes a syntax error
+  due to the parser handling '>' incorrectly.
+
 2020-07-07:
 
 - Four of the date formats accepted by 'printf %()T' have had their

--- a/src/cmd/ksh93/sh/parse.c
+++ b/src/cmd/ksh93/sh/parse.c
@@ -1368,7 +1368,7 @@ static Shnode_t	*item(Lex_t *lexp,int flag)
 	}
 	sh_lex(lexp);
 done:
-	/* redirection(s) following a compound command */
+	/* redirection(s) following a compound command or arithmetic expression */
 	if(io=inout(lexp,io,0))
 	{
 		t=makeparent(lexp,TSETIO,t);

--- a/src/cmd/ksh93/sh/parse.c
+++ b/src/cmd/ksh93/sh/parse.c
@@ -1367,13 +1367,13 @@ static Shnode_t	*item(Lex_t *lexp,int flag)
 		return(t);
 	}
 	sh_lex(lexp);
+done:
 	/* redirection(s) following a compound command */
 	if(io=inout(lexp,io,0))
 	{
 		t=makeparent(lexp,TSETIO,t);
 		t->tre.treio=io;
 	}
-done:
 	lexp->lasttok = savwdval;
 	lexp->lastline = savline;
 	return(t);

--- a/src/cmd/ksh93/tests/arith.sh
+++ b/src/cmd/ksh93/tests/arith.sh
@@ -761,4 +761,10 @@ x=0x1.0000000000000000000000000000p+6
 v=$(printf $'%.28a\n' 64)
 [[ $v == "$x" ]] || err_exit "'printf %.28a 64' failed -- expected '$x', got '$v'"
 
+# ======
+# Redirections with ((...)) should not cause a syntax error
+"$SHELL" 2>/dev/null -c '(($(echo 1+1 | tee /dev/fd/3))) >/dev/null 3>&1'
+(( $? )) && err_exit 'redirections with ((...))) yield a syntax error'
+
+# ======
 exit $((Errors<125?Errors:125))

--- a/src/cmd/ksh93/tests/arith.sh
+++ b/src/cmd/ksh93/tests/arith.sh
@@ -764,7 +764,7 @@ v=$(printf $'%.28a\n' 64)
 # ======
 # Redirections with ((...)) should not cause a syntax error
 "$SHELL" 2>/dev/null -c '(($(echo 1+1 | tee /dev/fd/3))) >/dev/null 3>&1'
-(( $? )) && err_exit 'redirections with ((...))) yield a syntax error'
+(( $? )) && err_exit 'redirections with ((...)) yield a syntax error'
 
 # ======
 exit $((Errors<125?Errors:125))

--- a/src/cmd/ksh93/tests/arith.sh
+++ b/src/cmd/ksh93/tests/arith.sh
@@ -763,8 +763,7 @@ v=$(printf $'%.28a\n' 64)
 
 # ======
 # Redirections with ((...)) should not cause a syntax error
-"$SHELL" 2>/dev/null -c '(($(echo 1+1 | tee /dev/fd/3))) >/dev/null 3>&1'
-(( $? )) && err_exit 'redirections with ((...)) yield a syntax error'
+(eval '((1)) >/dev/null') 2>/dev/null || err_exit 'redirections with ((...)) yield a syntax error'
 
 # ======
 exit $((Errors<125?Errors:125))


### PR DESCRIPTION
The following command causes a spurious syntax error:
```
$ ((1+2)) > /dev/null
/usr/bin/ksh: syntax error: `>' unexpected
```
This happens because the `done` label in parse.c is placed after the `inout` call that handles I/O redirections; `>` is not treated as a redirection operator after `goto done`:
https://github.com/ksh93/ksh/blob/5e7d335f2fc9c42b26386c4eea7abe52da5944e5/src/cmd/ksh93/sh/parse.c#L1149-L1151
https://github.com/ksh93/ksh/blob/5e7d335f2fc9c42b26386c4eea7abe52da5944e5/src/cmd/ksh93/sh/parse.c#L1370-L1379

Moving the `done` label fixes the syntax error because `inout` needs to handle `>`. This bugfix was backported from ksh93v- 2013-10-10-alpha.