### PR TITLE
Fix type names starting with lowercase 'a'

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,11 @@ For full details, see the git log at: https://github.com/ksh93/ksh
 
 Any uppercase BUG_* names are modernish shell bug IDs.
 
+2020-07-10:
+
+- Fixed a bug that caused types created with 'typeset -T' to throw an error
+  when used if the type name started with a lowercase 'a'.
+
 2020-07-09:
 
 - Fixed a crash on syntax error when sourcing/dotting multiple files.

--- a/src/cmd/ksh93/sh/parse.c
+++ b/src/cmd/ksh93/sh/parse.c
@@ -1477,7 +1477,7 @@ static Shnode_t *simple(Lex_t *lexp,int flag, struct ionod *io)
 						t->comnamp = (void*)np;
 					if(nv_isattr(np,BLT_DCL))
 					{
-						assignment = 1+(*argp->argval=='a');
+						assignment = 1;
 						if(np==SYSTYPESET)
 							lexp->intypeset = 1;
 						key_on = 1;

--- a/src/cmd/ksh93/tests/types.sh
+++ b/src/cmd/ksh93/tests/types.sh
@@ -642,5 +642,8 @@ bar.foo+=(bam)
 # 'typeset -RF' should not create variables that cause crashes
 "$SHELL" -c 'typeset -RF foo=1; test $foo' || err_exit 'typeset -RF does not work'
 
+# Type names that have 'a' as the first letter should be functional
+"$SHELL" -c 'typeset -T al=(typeset bar); al foo=(bar=testset)' || err_exit "type names that start with 'a' don't work"
+
 # ======
 exit $((Errors<125?Errors:125))


### PR DESCRIPTION
Type names that start with a lowercase 'a' cause an error when used:

```sh
$ typeset -T al=(typeset bar)
$ al foo=(bar=testset)
/usr/bin/ksh: al: : invalid variable name
```

The error occurs because when the parser checks for the `alias` builtin (to set `assignment` to two instead of one), only the first letter of `argp->argval` is checked (rather than the entire string):
https://github.com/ksh93/ksh/blob/f9d28935bb93fe7336ba8c5eab4231050de2e11e/src/cmd/ksh93/sh/parse.c#L1478-L1480

This was fixed in ksh93v- by comparing `argp->argval` against `alias` with `strcmp`, but in ksh93u+m the check can simply be removed because it is only run when a builtin has the `BLT_DCL` flag. `alias` isn't assigned the `BLT_DCL` flag:
https://github.com/ksh93/ksh/blob/f9d28935bb93fe7336ba8c5eab4231050de2e11e/src/cmd/ksh93/data/builtins.c#L84