### PR TITLE
Fix the max precision of the 'time' keyword

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,18 @@ Any uppercase BUG_* names are modernish shell bug IDs.
 - Fixed a fork bomb that could occur when the vi editor was sent SIGTSTP
   while running in a ksh script.
 
+- Appending a lone percent to the end of a format specifier no longer
+  causes a syntax error. The extra percent will be treated as a literal
+  '%', like in Bash and zsh.
+
+- The 'time' keyword now has proper support for millisecond precision.
+  Although this feature was previously documented, the 'time' keyword
+  only supported up to centisecond precision, which caused a command
+  like the one below to return '0.000' on certain operating systems:
+  $ TIMEFORMAT='%3R'; time sleep .003
+
+- The 'time' keyword now zero-pads seconds less than ten (like mksh).
+
 2020-07-10:
 
 - Fixed a bug that caused types created with 'typeset -T' to throw an error

--- a/src/cmd/ksh93/features/time
+++ b/src/cmd/ksh93/features/time
@@ -1,5 +1,5 @@
-hdr	utime
-lib	gettimeofday,setitimer
+hdr	utime,sys/resource
+lib	getrusage,gettimeofday,setitimer
 mem	timeval.tv_usec sys/time.h
 tst	lib_2_timeofday note{ 2 arg gettimeofday() }end link{
 	#include <sys/types.h>
@@ -23,6 +23,7 @@ tst	lib_1_timeofday note{ 1 arg gettimeofday() }end link{
 cat{
 	#undef _def_time
 	#include	<times.h>
+	#include	<sys/time.h>
 	#define _def_time	1
 	#undef timeofday
 	#if _lib_2_timeofday
@@ -31,5 +32,28 @@ cat{
 	#if _lib_1_timeofday
 	#define timeofday(p)	gettimeofday(p)
 	#endif
+	#endif
+	/* BSD timeradd and timersub macros */
+	#if !defined(timeradd)
+	#define	timeradd(tvp, uvp, vvp)						\
+	do {								\
+		(vvp)->tv_sec = (tvp)->tv_sec + (uvp)->tv_sec;		\
+		(vvp)->tv_usec = (tvp)->tv_usec + (uvp)->tv_usec;	\
+		if ((vvp)->tv_usec >= 1000000) {			\
+			(vvp)->tv_sec++;				\
+			(vvp)->tv_usec -= 1000000;			\
+		}							\
+	} while(0)
+	#endif
+	#if !defined(timersub)
+	#define	timersub(tvp, uvp, vvp)						\
+	do {								\
+		(vvp)->tv_sec = (tvp)->tv_sec - (uvp)->tv_sec;		\
+		(vvp)->tv_usec = (tvp)->tv_usec - (uvp)->tv_usec;	\
+		if ((vvp)->tv_usec < 0) {				\
+			(vvp)->tv_sec--;				\
+			(vvp)->tv_usec += 1000000;			\
+		}							\
+	} while(0)
 	#endif
 }end

--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -295,6 +295,9 @@ static void p_time(Shell_t *shp, Sfio_t *out, const char *format, clock_t *tm)
 			continue;
 		unsigned char l_modifier = 0;
 		int precision = 3;
+#ifndef timeofday
+		n = 0;
+#endif
 
 		sfwrite(stkp, first, format-first);
 		c = *++format;

--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -360,7 +360,7 @@ static void p_time(Shell_t *shp, Sfio_t *out, const char *format, clock_t *tm)
 			/* scale fraction from micro to milli, centi, or deci second according to precision */
 			int n, frac = tvp->tv_usec;
 			for(n = 3 + (3 - precision); n > 0; --n) frac /= 10;
-			sfprintf(stkp, "%d.%0*d", tvp->tv_sec, precision, frac);
+			sfprintf(stkp, "%d%c%0*d", tvp->tv_sec, GETDECIMAL(0), precision, frac);
 		}
 #else
 		if(c=='U')

--- a/src/cmd/ksh93/tests/basic.sh
+++ b/src/cmd/ksh93/tests/basic.sh
@@ -581,7 +581,7 @@ us=$(
 	time sleep 0
 )
 eu=$(
-	LC_ALL='C-EU.UTF-8' # radix point ','
+	LC_ALL='C_EU.UTF-8' # radix point ','
 	TIMEFORMAT='%1U'
 	redirect 2>&1
 	time sleep 0

--- a/src/cmd/ksh93/tests/basic.sh
+++ b/src/cmd/ksh93/tests/basic.sh
@@ -573,5 +573,20 @@ result=( $(
 ) )
 [[ ${result[4]} == bad ]] && err_exit "'%' is not treated literally when placed after a format specifier"
 
+# The locale's radix point shouldn't be ignored
+us=$(
+	LC_ALL='C.UTF-8' # radix point `.`
+	TIMEFORMAT='%1S'
+	redirect 2>&1
+	time sleep 0
+)
+eu=$(
+	LC_ALL='C-EU.UTF-8' # radix point `,`
+	TIMEFORMAT='%1S'
+	redirect 2>&1
+	time sleep 0
+)
+[[ ${us:1:1} == ${eu:1:1} ]] && err_exit "The time keyword ignores the locale's radix point"
+
 # ======
 exit $((Errors<125?Errors:125))

--- a/src/cmd/ksh93/tests/basic.sh
+++ b/src/cmd/ksh93/tests/basic.sh
@@ -576,17 +576,17 @@ result=( $(
 # The locale's radix point shouldn't be ignored
 us=$(
 	LC_ALL='C.UTF-8' # radix point `.`
-	TIMEFORMAT='%1S'
+	TIMEFORMAT='%1U' # catch -1.99 bug as well by getting user time
 	redirect 2>&1
 	time sleep 0
 )
 eu=$(
 	LC_ALL='C-EU.UTF-8' # radix point `,`
-	TIMEFORMAT='%1S'
+	TIMEFORMAT='%1U'
 	redirect 2>&1
 	time sleep 0
 )
-[[ ${us:1:1} == ${eu:1:1} ]] && err_exit "The time keyword ignores the locale's radix point"
+[[ ${us:1:1} == ${eu:1:1} ]] && err_exit "The time keyword ignores the locale's radix point (both are ${eu:1:1})"
 
 # ======
 exit $((Errors<125?Errors:125))

--- a/src/cmd/ksh93/tests/basic.sh
+++ b/src/cmd/ksh93/tests/basic.sh
@@ -575,13 +575,13 @@ result=( $(
 
 # The locale's radix point shouldn't be ignored
 us=$(
-	LC_ALL='C.UTF-8' # radix point `.`
+	LC_ALL='C.UTF-8' # radix point '.'
 	TIMEFORMAT='%1U' # catch -1.99 bug as well by getting user time
 	redirect 2>&1
 	time sleep 0
 )
 eu=$(
-	LC_ALL='C-EU.UTF-8' # radix point `,`
+	LC_ALL='C-EU.UTF-8' # radix point ','
 	TIMEFORMAT='%1U'
 	redirect 2>&1
 	time sleep 0

--- a/src/cmd/ksh93/tests/basic.sh
+++ b/src/cmd/ksh93/tests/basic.sh
@@ -553,4 +553,25 @@ $SHELL 2> /dev/null -c $'for i;\ndo :;done' || err_exit 'for i ; <newline> not v
 ) || err_exit "crash when sourcing multiple files (exit status $?)"
 
 # ======
+# The time keyword should correctly handle millisecond precision.
+# This can be checked by verifying the last digit is not a zero
+# when 'time sleep .002' is run.
+result=$(
+	TIMEFORMAT=$'\%3R'
+	redirect 2>&1
+	time sleep .002
+)
+[[ ${result: -1} == 0 ]] && err_exit "the 'time' keyword doesn't properly support millisecond precision"
+
+# A single '%' after a format specifier should not be a syntax
+# error (it should be treated as a literal '%').
+IFS=' '
+result=( $(
+	TIMEFORMAT=$'%0S%'
+	redirect 2>&1
+	time :
+) )
+[[ ${result[4]} == bad ]] && err_exit "'%' is not treated literally when placed after a format specifier"
+
+# ======
 exit $((Errors<125?Errors:125))

--- a/src/lib/libast/features/time
+++ b/src/lib/libast/features/time
@@ -1,7 +1,12 @@
 set	prototyped
-lib	nanosleep,usleep,_strftime
+lib	getrusage,nanosleep,usleep,_strftime
 typ	clock_t = uint32_t
 typ	time_t = uint32_t
+
+if sys resource {
+	#include <sys/resource.h>
+}
+endif
 
 if sys time {
 	#include <sys/time.h>

--- a/src/lib/libast/misc/debug.c
+++ b/src/lib/libast/misc/debug.c
@@ -27,6 +27,7 @@
 #include <ast.h>
 #include <error.h>
 #include <debug.h>
+#include "FEATURE/time"
 
 void
 debug_fatal(const char* file, int line)
@@ -35,11 +36,9 @@ debug_fatal(const char* file, int line)
 	abort();
 }
 
-#if _sys_times
+#if defined(_sys_times) && defined(_lib_getrusage)
 
 #include <times.h>
-#include <sys/resource.h>
-
 double
 debug_elapsed(int set)
 {	


### PR DESCRIPTION
This pull request makes the following changes:

* The `time` keyword now prioritizes `getrusage` to fix the bug reported at ksh-community/ksh#7. Reproducer:
  ``
 TIMEFORMAT=$'\nreal\t%3R\tuser\t%3U\tsys\t%3S';
 time sleep 1.235 # → real  1.240   user    0.000   sys 0.000
  ``
  This bugfix is based on the following ksh2020 commits:
  att/ast@48230e61
  att/ast@2e18c672
  ~att/ast@27777b3d~ (that commit breaks command substitutions, now reverted)
  `getrusage`, `timeradd` and `timersub` are detected with `iffe` feature tests. The `times` function is used as a fallback if `getrusage` isn't available.

* A single percent at the end of a format specifier is now treated as a literal '%' (like in Bash and ksh2020). The following command no longer causes a syntax error:
``
TIMEFORMAT='%3S%'; time sleep .1
``

* The default output from `time` now zero-pads seconds. This change was made for consistency with the `times` builtin, which also zero-pads seconds as of commit 5c677a4c.

* Fixed one instance of `getrusage` in libast that was missing an ifdef for `_lib_getrusage`.

This patch can be extended with support for microsecond precision, ~which I put in a separate gist~ *edit:* now in a downstream branch (since that isn't a bugfix):
https://github.com/JohnoKing/ksh/commit/d97b64e29105c4e074bee261594db9aa58b6c98c