### PR TITLE
Fix a fork bomb when vi is run from a script and sent Ctrl-Z

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,11 @@ For full details, see the git log at: https://github.com/ksh93/ksh
 
 Any uppercase BUG_* names are modernish shell bug IDs.
 
+2020-07-13:
+
+- Fixed a fork bomb that could occur when the vi editor was sent SIGTSTP
+  while running in a ksh script.
+
 2020-07-10:
 
 - Fixed a bug that caused types created with 'typeset -T' to throw an error

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -17,4 +17,4 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                                                                      *
 ***********************************************************************/
-#define SH_RELEASE	"93u+m 2020-07-10"
+#define SH_RELEASE	"93u+m 2020-07-13"

--- a/src/cmd/ksh93/sh/fault.c
+++ b/src/cmd/ksh93/sh/fault.c
@@ -519,7 +519,7 @@ void sh_exit(register int xno)
 	if(pp && pp->mode>1)
 		cursig = -1;
 #ifdef SIGTSTP
-	if(shp->trapnote&SH_SIGTSTP)
+	if((shp->trapnote&SH_SIGTSTP) && job.jobcontrol)
 	{
 		/* ^Z detected by the shell */
 		shp->trapnote = 0;


### PR DESCRIPTION
This bug was reported on the old mailing list: https://www.mail-archive.com/ast-developers@lists.research.att.com/msg00207.html

A fork bomb can occur when `SIGTSTP` is sent to `vi`. `vi` must be launched from a script that was run with `exec` (tested with BusyBox vi, nvi and vim):
```
$ cat /tmp/foo
vi /tmp/bar
echo end
$ ksh
$ chmod +x /tmp/foo
$ exec /tmp/foo
While in vi, send SIGTSTP using Ctrl-Z
```

The fix is to only do a fork after Ctrl-Z if job control is available (this pull request applies a patch from Red Hat which checks `job.jobcontrol` instead of `SH_MONITOR`):
https://git.centos.org/rpms/ksh/blob/c8/f/SOURCES/ksh-20120801-forkbomb.patch