### PR TITLE
'set -b' should notify job state changes immediately

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,10 @@ For full details, see the git log at: https://github.com/ksh93/ksh
 
 Any uppercase BUG_* names are modernish shell bug IDs.
 
+2020-07-14:
+
+- Fixed a bug that caused 'set -b' to have no effect.
+
 2020-07-13:
 
 - Fixed a fork bomb that could occur when the vi editor was sent SIGTSTP

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -17,4 +17,4 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                                                                      *
 ***********************************************************************/
-#define SH_RELEASE	"93u+m 2020-07-13"
+#define SH_RELEASE	"93u+m 2020-07-14"

--- a/src/cmd/ksh93/sh/jobs.c
+++ b/src/cmd/ksh93/sh/jobs.c
@@ -344,11 +344,11 @@ int job_reap(register int sig)
 	int nochild=0, oerrno, wstat;
 	Waitevent_f waitevent = shp->gd->waitevent;
 	static int wcontinued = WCONTINUED;
+	int was_ttywait_on;
 #if SHOPT_COSHELL
 	Cojob_t		*cjp;
 	int		cojobs;
 	long		cotimeout = sig?0:-1;
-	int was_ttywait_on = sh_isstate(SH_TTYWAIT); /* save tty wait state */
 	for(pw=job.pwlist;pw;pw=pw->p_nxtjob)
 	{
 		if(pw->p_cojob && !(pw->p_flag&P_DONE))
@@ -375,6 +375,7 @@ int job_reap(register int sig)
 		flags = WUNTRACED|wcontinued;
 	shp->gd->waitevent = 0;
 	oerrno = errno;
+	was_ttywait_on = sh_isstate(SH_TTYWAIT); /* save tty wait state */
 	while(1)
 	{
 		if(!(flags&WNOHANG) && !sh.intrap && job.pwlist)

--- a/src/cmd/ksh93/sh/jobs.c
+++ b/src/cmd/ksh93/sh/jobs.c
@@ -348,6 +348,7 @@ int job_reap(register int sig)
 	Cojob_t		*cjp;
 	int		cojobs;
 	long		cotimeout = sig?0:-1;
+	int was_ttywait_on = sh_isstate(SH_TTYWAIT); /* save tty wait state */
 	for(pw=job.pwlist;pw;pw=pw->p_nxtjob)
 	{
 		if(pw->p_cojob && !(pw->p_flag&P_DONE))
@@ -374,7 +375,6 @@ int job_reap(register int sig)
 		flags = WUNTRACED|wcontinued;
 	shp->gd->waitevent = 0;
 	oerrno = errno;
-	int was_ttywait_on = sh_isstate(SH_TTYWAIT); /* save tty wait state */
 	while(1)
 	{
 		if(!(flags&WNOHANG) && !sh.intrap && job.pwlist)

--- a/src/cmd/ksh93/tests/pty.sh
+++ b/src/cmd/ksh93/tests/pty.sh
@@ -549,5 +549,17 @@ r ^:test-2: true string\\r\\n$
 !
 done
 
+# err_exit #
+tst $LINENO <<"!"
+L notify job state changes
+
+# 'set -b' should immediately notify the user about job state changes.
+
+p :test-1:
+w set -b; sleep .01 &
+s 20
+u Done
+!
+
 # ======
 exit $((Errors<125?Errors:125))

--- a/src/cmd/ksh93/tests/pty.sh
+++ b/src/cmd/ksh93/tests/pty.sh
@@ -557,7 +557,6 @@ L notify job state changes
 
 p :test-1:
 w set -b; sleep .01 &
-s 20
 u Done
 !
 


### PR DESCRIPTION
`set -b` currently does not notify job state changes when a background job finishes running. Reproducer and documentation for `set -b`:
```sh
$ set -b
$ sleep .1 &
# Notification doesn't appear when `sleep .1` finishes
```
```
  -b              The shell writes a message to standard error as soon it detects that
                  a background job completes rather than waiting until the next prompt.
```

This option has been broken since ksh93t 2008-07-25. Here is the change in that version that caused `set -b` to break:
```diff
        oerrno = errno;
        while(1)
        {
-               if(!(flags&WNOHANG) && !sh.intrap && waitevent && job.pwlist)
+               if(!(flags&WNOHANG) && !sh.intrap && job.pwlist)
                {
-                       if((*waitevent)(-1,-1L,0))
+                       sh_onstate(SH_TTYWAIT);
+                       if(waitevent && (*waitevent)(-1,-1L,0))
                                flags |= WNOHANG;
                }
                pid = waitpid((pid_t)-1,&wstat,flags);
+               sh_offstate(SH_TTYWAIT);
 
                /*
                 * some systems (linux 2.6) may return EINVAL
```

`SH_TTYWAIT` is always turned off even if it was previously on before the loop, which causes `set -b` to break since `SH_TTYWAIT` needs to be on for the shell to immediately show job state changes. The bugfix is from att/ast#1089, although one instance of `sh_offstate` has been placed behind `SHOPT_COSHELL` since it is only required if `SHOPT_COSHELL` is enabled.