### PR TITLE
Handle the escape sequence for the End key

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,12 @@ For full details, see the git log at: https://github.com/ksh93/ksh
 
 Any uppercase BUG_* names are modernish shell bug IDs.
 
+2020-07-15:
+
+- The End key escape sequence '^[[F' is now handled in the emacs and vi editing
+  modes. The End key moves the cursor to the end of the line (in contrast to
+  the Home key doing the opposite).
+
 2020-07-14:
 
 - Fixed a bug that caused 'set -b' to have no effect.

--- a/src/cmd/ksh93/edit/emacs.c
+++ b/src/cmd/ksh93/edit/emacs.c
@@ -1105,6 +1105,7 @@ static int escape(register Emacs_t* ep,register genchar *out,int count)
 			    case 'H':
 				ed_ungetchar(ep->ed,cntl('A'));
 				return(-1);
+			    case 'F':
 			    case 'Y':
 				ed_ungetchar(ep->ed,cntl('E'));
 				return(-1);

--- a/src/cmd/ksh93/edit/vi.c
+++ b/src/cmd/ksh93/edit/vi.c
@@ -1669,6 +1669,7 @@ static int mvcursor(register Vi_t* vp,register int motion)
 		    case 'H':
 			tcur_virt = 0;
 			break;
+		    case 'F':
 		    case 'Y':
 			tcur_virt = last_virt;
 			break;

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -17,4 +17,4 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                                                                      *
 ***********************************************************************/
-#define SH_RELEASE	"93u+m 2020-07-14"
+#define SH_RELEASE	"93u+m 2020-07-15"


### PR DESCRIPTION
Many terminals (xterm being one example) give `Home` and `End` the escape sequences `^[[H` and `^[[F`. The first sequence is handled in both editing modes by moving the cursor to start of line, but the second sequence is ignored. Most programs that handle `Home` also handle `End` by moving the cursor to the end of the line. This pull request fixes the strange behavior by adding case labels to handle `End` in both editing modes, giving `End` the common behavior.