### PR TITLE
Fix two crashes related to kshdb

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,13 @@ For full details, see the git log at: https://github.com/ksh93/ksh
 
 Any uppercase BUG_* names are modernish shell bug IDs.
 
+2020-07-19:
+
+- Fixed a crash that occured in the '.' command when using kshdb.
+
+- Fixed a crash that occured when attempting to use redirection with an
+  invalid file descriptor.
+
 2020-07-16:
 
 - The 'history' and 'r' default aliases have been made regular built-ins,

--- a/src/cmd/ksh93/bltins/misc.c
+++ b/src/cmd/ksh93/bltins/misc.c
@@ -279,7 +279,7 @@ int    b_dot_cmd(register int n,char *argv[],Shbltin_t *context)
 	shp->topscope = (Shscope_t*)shp->st.self;
 	prevscope->save_tree = shp->var_tree;
 	if(np)
-		shp->st.filename = np->nvalue.rp->fname;
+		shp->st.filename = np->nvalue.rp->fname ? strdup(np->nvalue.rp->fname) : 0;
 	nv_putval(SH_PATHNAMENOD, shp->st.filename ,NV_NOFREE);
 	shp->posix_fun = 0;
 	if(np || argv[1])

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -17,4 +17,4 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                                                                      *
 ***********************************************************************/
-#define SH_RELEASE	"93u+m 2020-07-16"
+#define SH_RELEASE	"93u+m 2020-07-19"

--- a/src/cmd/ksh93/sh/io.c
+++ b/src/cmd/ksh93/sh/io.c
@@ -1194,7 +1194,7 @@ int	sh_redirect(Shell_t *shp,struct ionod *iop, int flag)
 						toclose = dupfd;
 						number++;
 					}
-					if(*number || dupfd > IOUFD)
+					if(*number || !sh_iovalidfd(shp,dupfd) || dupfd > IOUFD)
 					{
 						message = e_file;
 						goto fail;

--- a/src/cmd/ksh93/tests/io.sh
+++ b/src/cmd/ksh93/tests/io.sh
@@ -563,5 +563,9 @@ result=$("$SHELL" -ic 'echo >(true) >/dev/null' 2>&1)
 "$SHELL" -c 'read -u-2000000' 2> /dev/null
 [[ $? == 1 ]] || err_exit "Negative file descriptors cause 'read -u' to crash"
 
+# An out of range fd shouldn't segfault with redirections
+"$SHELL" -c 'true 20000>&20000000000000000000' 2> /dev/null
+[[ $? == 1 ]] || err_exit "Out of range file descriptors cause redirections to segfault"
+
 # ======
 exit $((Errors<125?Errors:125))

--- a/src/cmd/ksh93/tests/io.sh
+++ b/src/cmd/ksh93/tests/io.sh
@@ -564,7 +564,7 @@ result=$("$SHELL" -ic 'echo >(true) >/dev/null' 2>&1)
 [[ $? == 1 ]] || err_exit "Negative file descriptors cause 'read -u' to crash"
 
 # An out of range fd shouldn't segfault with redirections
-"$SHELL" -c 'true 20000>&20000000000000000000' 2> /dev/null
+"$SHELL" -c 'true 9>&20000000000000000000' 2> /dev/null
 [[ $? == 1 ]] || err_exit "Out of range file descriptors cause redirections to segfault"
 
 # ======


### PR DESCRIPTION
_edit_: Changed the reproducer for redirections to a more correct version.

This pull request fixes two different crashes related to kshdb (first reported in att/ast#582):
- When redirect is given an invalid or out of range file descriptor, a segfault no longer occurs. Reproducer:
  ```sh
  $ ksh -c 'redirect 9>&200000000000'
  ```

- Fixed a crash due to free(3) being used on an invalid pointer. Ksh expects `shp->st.filename` to be a pointer that can be freed from memory, so the fix duplicates the string with `strdup`. The crash can be reproduced with kshdb:
  ```sh
  $ git clone https://github.com/rocky/kshdb.git
  $ cd kshdb
  $ ksh autogen.sh
  $ echo "print hi there" > $HOME/.kshdbrc
  $ ksh ./kshdb -L . test/example/dbg-test1.sh
   ```