### PR TITLE
Merge dtksh patches from one of the CDE developers

### DIFF
--- a/src/cmd/ksh93/data/msg.c
+++ b/src/cmd/ksh93/data/msg.c
@@ -178,8 +178,13 @@ const char e_traceprompt[]	= "+ ";
 const char e_supprompt[]	= "# ";
 const char e_stdprompt[]	= "$ ";
 const char e_profile[]		= "$HOME/.profile";
+#ifdef BUILD_DTKSH
+const char e_sysprofile[] = PROFILEPATH;
+const char e_suidprofile[] = SUIDPROFILEPATH;
+#else
 const char e_sysprofile[]	= "/etc/profile";
 const char e_suidprofile[]	= "/etc/suid_profile";
+#endif
 #if SHOPT_SYSRC
 const char e_sysrc[]		= "/etc/ksh.kshrc";
 #endif
@@ -194,9 +199,13 @@ const char e_bash_profile[]	= "$HOME/.bash_profile";
 #endif
 const char e_crondir[]		= "/usr/spool/cron/atjobs";
 const char e_prohibited[]	= "login setuid/setgid shells prohibited";
+#ifdef BUILD_DTKSH
+   const char e_suidexec[]      = SUIDEXECPATH;
+#else
 #if SHOPT_SUID_EXEC
    const char e_suidexec[]	= "/etc/suid_exec";
 #endif /* SHOPT_SUID_EXEC */
+#endif
 const char hist_fname[]		= "/.sh_history";
 const char e_dot[]		= ".";
 const char e_envmarker[]	= "A__z";

--- a/src/cmd/ksh93/include/nval.h
+++ b/src/cmd/ksh93/include/nval.h
@@ -33,6 +33,10 @@
 #include	<cdt.h>
 #include	<option.h>
 
+#ifdef BUILD_DTKSH
+#include       <hash.h>
+#endif
+
 /* for compatibility with old hash library */
 #define Hashtab_t	Dt_t
 #define HASH_BUCKET	1
@@ -111,6 +115,9 @@ struct Namdecl
 /* This defines the attributes for an attributed name-value pair node */
 struct Namval
 {
+#if BUILD_DTKSH
+	HASH_HEADER;                    /* space for hash library */
+#endif
 	Dtlink_t	nvlink;		/* space for cdt links */
 	char		*nvname;	/* pointer to name of the node */
 #if _ast_sizeof_pointer == 8

--- a/src/cmd/ksh93/sh/suid_exec.c
+++ b/src/cmd/ksh93/sh/suid_exec.c
@@ -62,7 +62,11 @@
 #define FDVERIFY	12	/* used to validate /tmp process */
 #undef BLKSIZE 
 #define BLKSIZE		sizeof(char*)*1024
+#if BUILD_DTKSH
+#define THISPROG	SUIDEXECPATH
+#else
 #define THISPROG	"/etc/suid_exec"
+#endif
 #define DEFSHELL	"/bin/sh"
 
 static void error_exit(const char*);
@@ -235,6 +239,9 @@ exec:
 	/* only use SHELL if file is in trusted directory and ends in sh */
 	shell = getenv("SHELL");
 	if(shell == 0 || !endsh(shell) || (
+#ifdef BUILD_DTKSH
+		!in_dir(CDE_INSTALLATION_TOP"/bin",shell) &&
+#endif
 		!in_dir("/bin",shell) &&
 		!in_dir("/usr/bin",shell) &&
 		!in_dir("/usr/lbin",shell) &&


### PR DESCRIPTION
This pull request merges some fixes to allow building ksh93 with dtksh support though `-DBUILD_DTKSH`. These patches were sent through private email from the CDE developer Chase. The reason these patches were submitted is because Chase wishes to include ksh in CDE as an up-to-date git submodule. Quote from Chase:
> ... my priority is to get your new version into our code as a git submodule, and do it quickly before our code bases differ too widely.

Link to CDE for anyone interested:
https://sourceforge.net/projects/cdesktopenv/

Although the patches were privately discussed, there are some public emails on the CDE mailing list regarding this:
[ksh-chaos thread](https://sourceforge.net/p/cdesktopenv/mailman/cdesktopenv-devel/thread/J8OfApQGb3_guPlY0FF3Tx5fRA9ul_eWMI6paTLp9XjQpKlx4Xz-gdhlg5V1SwECqsm-ZUL8I5g2IFnxHL9hWNNeiDlzCaElUuUqZsl2O_Q=@protonmail.ch/#msg37052893)
[dtksh alias thread](https://sourceforge.net/p/cdesktopenv/mailman/cdesktopenv-devel/thread/53fbef8c-a6a6-8dc8-c8d7-39f0a1a085cf@radscan.com/)

The primary fix is for `suid_exec`, which is now told that /usr/dt is a valid directory to run from via preprocessor flags. A patch for Shift-JIS was also submitted, but it isn't in this commit because it isn't an effective fix for the existing Shift-JIS bugs. I will be giving that patch some more testing; it is include as a separate patch below for anyone else who wants to test it:
[dtksh-shiftjis.patch.txt](https://github.com/ksh93/ksh/files/4956412/dtksh-shiftjis.patch.txt)