### PR TITLE
Fix an infinite loop related to $_ when ksh is /bin/sh

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,10 @@ For full details, see the git log at: https://github.com/ksh93/ksh
 
 Any uppercase BUG_* names are modernish shell bug IDs.
 
+2020-07-23:
+
+- Fixed an infinite loop that could occur when ksh is the system's /bin/sh.
+
 2020-07-22:
 
 - Fixed two race conditions when running external commands on

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -17,4 +17,4 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                                                                      *
 ***********************************************************************/
-#define SH_RELEASE	"93u+m 2020-07-22"
+#define SH_RELEASE	"93u+m 2020-07-23"

--- a/src/cmd/ksh93/sh/init.c
+++ b/src/cmd/ksh93/sh/init.c
@@ -710,7 +710,7 @@ static char* get_lastarg(Namval_t* np, Namfun_t *fp)
 	char	*cp;
 	int	pid;
         if(sh_isstate(SH_INIT) && (cp=shp->lastarg) && *cp=='*' && (pid=strtol(cp+1,&cp,10)) && *cp=='*')
-		nv_putval(np,(pid==shp->gd->ppid?cp+1:0),0);
+		nv_putval(np,cp+1,0);
 	return(shp->lastarg);
 }
 

--- a/src/cmd/ksh93/sh/main.c
+++ b/src/cmd/ksh93/sh/main.c
@@ -273,7 +273,7 @@ int sh_main(int ac, char *av[], Shinit_f userinit)
 					 * try to undo effect of solaris 2.5+
 					 * change for argv for setuid scripts
 					 */
-					if(((type = sh_type(cp = av[0])) & SH_TYPE_SH) && (!(name = nv_getval(L_ARGNOD)) || !((type = sh_type(cp = name)) & SH_TYPE_SH)))
+					if(((type = sh_type(cp = av[0])) & SH_TYPE_SH) && (name = nv_getval(L_ARGNOD)) && (!((type = sh_type(cp = name)) & SH_TYPE_SH)))
 					{
 						av[0] = (type & SH_TYPE_LOGIN) ? cp : path_basename(cp);
 						/*  exec to change $0 for ps */


### PR DESCRIPTION
An infinite loop can occur if ksh is the system's /bin/sh. The following explanation is mostly taken from [Tomas Klacko's bug report](https://www.mail-archive.com/ast-developers@lists.research.att.com/msg01680.html) on the old mailing list:

1. When ksh starts a binary, it sets its environment variable `$_` to "*number*/path/to/binary". Where "number" is the pid of the ksh process.

2. The binary forks and the child executes a suid root shell script which begins with `#!/bin/sh`. For this bug to occur, ksh must be /bin/sh.

3. The ksh process interpreting the suid shell script leaves the `$_` variable as not set (`nv_getval(L_ARGNOD)` returns `NULL`) because the "number" from step 1 is not the pid of its parent process.

4. Because `$_` is not set and the script is suid root, the following if condition is true in src/cmd/ksh93/sh/main.c, which results in the following code being executed:
https://github.com/ksh93/ksh/blob/f207cd57879ea248f33d84ad9018577b53de3a5a/src/cmd/ksh93/sh/main.c#L272-L284

5. When the `$SHELL` environment variable contains "/bin/sh" `pathshell()` returns "/bin/sh". This becomes an infinite
loop of `/bin/sh /dev/fd/3` executing `/bin/sh /dev/fd/3`.

/dev/fd/3 is the suid root script passed in via file descriptor 3.

The first /bin/sh in the loop is the `#!/bin/sh` from the suid script. The second and subsequent /bin/sh in the loop is from the `$SHELL` environment variable.

The bugfix does the following:
\- In `get_lastarg()`, the check for if the "number" refers to the process id of the parent process is removed.
\- In `sh_main()`, prevent an infinite loop when `$_` is not passed in from the environment.

The reproducer is a C program that sets all the necessary conditions and triggers the infinite loop when ksh is /bin/sh:
```C
#include <fcntl.h>
#include <stdio.h>
#include <stdlib.h>
#include <sys/stat.h>
#include <sys/types.h>
#include <unistd.h>

#define ERROR \
do{ \
    fprintf(stderr, "[%s, %d] error\n", __FILE__, __LINE__); \
    exit(EXIT_FAILURE); \
}while(0)

int main(int argc, char *argv[])
{
    char devfd[]="/dev/fd/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
    char *arg[5];
    int fd;

    if(argc!=2)
        ERROR;

    fd=open(argv[1], O_RDONLY);
    if(fd<0)
        ERROR;

    sprintf(devfd, "/dev/fd/%d", fd);

    arg[0]="sh";
    arg[1]=devfd;
    arg[2]="AAA";
    arg[3]="BBB";
    arg[4]=NULL;

    if(argc>1)
        unsetenv("_");
    else
        setenv("_", "*1234*/garbage", 1);

    setenv("SHELL", "/bin/sh", 1);

    execvp("/bin/sh", arg);

    ERROR;
}
```

Oracle applies this bugfix to their version of ksh:
https://github.com/oracle/solaris-userland/blob/master/components/ksh93/patches/190-17432413.patch