### PR TITLE
Fix command substitutions run on the same line as a here-doc

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,11 @@ For full details, see the git log at: https://github.com/ksh93/ksh
 
 Any uppercase BUG_* names are modernish shell bug IDs.
 
+2020-07-23:
+
+- A command substitution that is run on the same line as a here-document
+  will no longer cause a syntax error.
+
 2020-07-22:
 
 - Fixed two race conditions when running external commands on

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -17,4 +17,4 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                                                                      *
 ***********************************************************************/
-#define SH_RELEASE	"93u+m 2020-07-22"
+#define SH_RELEASE	"93u+m 2020-07-23"

--- a/src/cmd/ksh93/sh/lex.c
+++ b/src/cmd/ksh93/sh/lex.c
@@ -1563,6 +1563,7 @@ static int comsub(register Lex_t *lp, int endtok)
 {
 	register int	n,c,count=1;
 	register int	line=lp->sh->inlineno;
+	struct ionod	*inheredoc = lp->heredoc;
 	char *first,*cp=fcseek(0),word[5];
 	int off, messages=0, assignok=lp->assignok, csub;
 	struct lexstate	save;
@@ -1689,7 +1690,7 @@ done:
 	lp->lexd.dolparen--;
 	lp->lex = save;
 	lp->assignok = (endchar(lp)==RBRACT?assignok:0);
-	if(lp->heredoc)
+	if(lp->heredoc && !inheredoc)
 		errormsg(SH_DICT,ERROR_exit(SYNBAD),e_lexsyntax5,lp->sh->inlineno,lp->heredoc->ioname);
 	return(messages);
 }

--- a/src/cmd/ksh93/tests/heredoc.sh
+++ b/src/cmd/ksh93/tests/heredoc.sh
@@ -498,4 +498,16 @@ print foo > $tmp/foofile
 x=$( $SHELL 2> /dev/null 'read <<< $(<'"$tmp"'/foofile) 2> /dev/null;print -r "$REPLY"')
 [[ $x == foo ]] || err_exit '<<< $(<file) not working'
 
+# ======
+# A syntax error should not occur if a command substitution is run on the same line
+# as a here document.
+$SHELL -c 'true << EOF || true "$(true)"
+EOF' || err_exit 'placing a command substitution and here-doc on the same line causes a syntax error'
+
+# A here-document in a command substitution should cause a syntax error if it isn't
+# completed inside of the command substitution.
+$SHELL -c '$(true << !)
+!' 2> /dev/null && err_exit "a here-doc that isn't completed before the closing ) in a command substitution doesn't cause an error"
+
+# ======
 exit $((Errors<125?Errors:125))


### PR DESCRIPTION
When a command substitution is run on the same line as a here-document, a syntax error occurs due to a regression introduced in ksh93u+ 2011-04-15:

```
$ cat ./foo.sh
true << EOF; true $(true)
EOF
$ ksh ./foo.sh
./foo.sh: syntax error at line 1: `<<EOF' here-document not contained within command substitution
```

The regression is caused by the following error check, which was added to fix a bug with here-documents in command substitutions:
https://github.com/ksh93/ksh/blob/f207cd57879ea248f33d84ad9018577b53de3a5a/src/cmd/ksh93/sh/lex.c#L1692-L1693
```sh
# A syntax error should occur because the here-document isn't completed
# in the command substitution, but in versions of ksh prior to ksh93u+
# 2011-04-15 this isn't an error.
$(true << EOF)
EOF
```
The bugfix (which was backported from ksh93v- 2013-10-10-alpha) stops the syntax error from occurring when a here-document is not inside of a command substitution. It should only be a syntax error when a here-document inside of a command substitution isn't completed before the ending ')'.