### PR TITLE
Add support for multibyte characters to $IFS

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,14 @@ For full details, see the git log at: https://github.com/ksh93/ksh
 
 Any uppercase BUG_* names are modernish shell bug IDs.
 
+2020-07-25:
+
+- Fixed BUG_MULTIBIFS: Multibyte characters can now be used as IFS
+  delimiters. "$*" was incorrectly joining positional parameters on
+  the first byte of a multibyte character. This was due to truncation
+  based on the incorrect assumption the IFS would never be larger
+  than a single byte.
+
 2020-07-23:
 
 - Fixed an infinite loop that could occur when ksh is the system's /bin/sh.

--- a/TODO
+++ b/TODO
@@ -54,9 +54,3 @@ https://github.com/modernish/modernish/tree/0.16/lib/modernish/cap/
   between 'while'/'until' and 'do'), the exit status passed down from the
   previous command is ignored and the function returns with status 0
   instead.
-
-- BUG_MULTIBIFS: We're on a UTF-8 locale and the shell supports UTF-8
-  characters in general (i.e. we don't have WRN_MULTIBYTE) – however, using
-  multi-byte characters as IFS field delimiters still doesn't work. For
-  example, "$*" joins positional parameters on the first byte of IFS instead
-  of the first character.

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -17,4 +17,4 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                                                                      *
 ***********************************************************************/
-#define SH_RELEASE	"93u+m 2020-07-23"
+#define SH_RELEASE	"93u+m 2020-07-25"

--- a/src/cmd/ksh93/tests/variables.sh
+++ b/src/cmd/ksh93/tests/variables.sh
@@ -435,6 +435,39 @@ case $(unset IFS; set -- $v; print $#) in
 *)	err_exit 'BUG_KUNSETIFS detection failed'
 esac
 
+# The IFS should work with multi-byte characters
+(
+	LC_ALL=C.UTF-8  # The multi-byte tests are pointless without UTF-8
+
+	# Test the following characters:
+	# Lowercase accented e  (two bytes)
+	# Roman sestertius sign (four bytes)
+	for delim in é 𐆘; do
+		IFS="$delim"
+		set : :
+		[ "$*" == ":$delim:" ] || err_exit "IFS failed with multi-byte character $delim (expected :$delim:, got $*)"
+
+		read -r first second third <<< "one${delim}two${delim}three"
+		[[ "$first" == "one" ]] || err_exit "IFS failed with multi-byte character $delim (expected one, got $first)"
+		[[ "$second" == "two" ]] || err_exit "IFS failed with multi-byte character $delim (expected two, got $second)"
+		[[ "$third" == "three" ]] || err_exit "IFS failed with multi-byte character $delim (expected three, got $three)"
+
+		# Ensure subshells don't get corrupted when IFS becomes a multi-byte character
+		expected_output="$(printf ":$delim:\\ntrap -- 'echo end' EXIT\\nend")"
+		output="$(LANG=C.UTF-8; IFS=$delim; set : :; echo "$*"; trap "echo end" EXIT; trap)"
+		[[ $output == $expected_output ]] || err_exit "IFS in subshell failed with multi-byte character $delim (expected $expected_output, got $output)"
+	done
+
+	# Multibyte characters with the same initial byte shouldn't be parsed as the same
+	# character if they are different. The regression test below tests two characters
+	# with the same initial byte (0xC2).
+	IFS='£'  # £ = C2 A3
+	v='abc§def ghi§jkl'  # § = C2 A7 (same initial byte)
+	set -- $v
+	v="${#},${1-},${2-},${3-}"
+	[[ $v == '1,abc§def ghi§jkl,,' ]] || err_exit "IFS treats £ (C2 A3) and § (C2 A7) as the same character"
+)
+
 # ^^^ end: IFS tests ^^^
 # restore default split:
 unset IFS

--- a/src/cmd/ksh93/tests/variables.sh
+++ b/src/cmd/ksh93/tests/variables.sh
@@ -435,7 +435,7 @@ case $(unset IFS; set -- $v; print $#) in
 *)	err_exit 'BUG_KUNSETIFS detection failed'
 esac
 
-# The IFS should work with multi-byte characters
+# Multi-byte characters should work with $IFS
 (
 	LC_ALL=C.UTF-8  # The multi-byte tests are pointless without UTF-8
 
@@ -448,9 +448,9 @@ esac
 		[ "$*" == ":$delim:" ] || err_exit "IFS failed with multi-byte character $delim (expected :$delim:, got $*)"
 
 		read -r first second third <<< "one${delim}two${delim}three"
-		[[ "$first" == "one" ]] || err_exit "IFS failed with multi-byte character $delim (expected one, got $first)"
-		[[ "$second" == "two" ]] || err_exit "IFS failed with multi-byte character $delim (expected two, got $second)"
-		[[ "$third" == "three" ]] || err_exit "IFS failed with multi-byte character $delim (expected three, got $three)"
+		[[ $first == one ]] || err_exit "IFS failed with multi-byte character $delim (expected one, got $first)"
+		[[ $second == two ]] || err_exit "IFS failed with multi-byte character $delim (expected two, got $second)"
+		[[ $third == three ]] || err_exit "IFS failed with multi-byte character $delim (expected three, got $three)"
 
 		# Ensure subshells don't get corrupted when IFS becomes a multi-byte character
 		expected_output="$(printf ":$delim:\\ntrap -- 'echo end' EXIT\\nend")"


### PR DESCRIPTION
This pull request fixes BUG_MULTIBIFS, which had two bug reports in the ksh2020 branch. The modernish regression test suite now only reports eight test failures.

- Backport Eric Scrivner's fix for multibyte IFS characters (slightly modified for compatibility with C89). Explanation from https://github.com/att/ast/pull/737:

  > Previously, the `varsub` method used for the macro expansion of `$param`, `${param}`, and `${param op word}` would incorrectly expand the internal field separator (IFS)  if it was a multibyte character. This was due to truncation based on the incorrect assumption that the IFS would never be larger than a single byte.
  >
  > This change fixes this issue by carefully tracking the number of bytes that should be persisted in the IFS case and ensuring that all bytes are written during expansion and substitution.

  Bug report: https://github.com/att/ast/issues/13

- Fixed another bug that caused multibyte characters with the same initial byte to be treated as the same character by the IFS. This bug was occurring because the initial byte wasn't being written to the stack when the IFS delimiter and multibyte character had the same initial byte:

  ```sh
  $ IFS=£
  $ v='§'
  $ set -- $v
  $ v="${1-}"
  $ echo "$v" | hd # The first byte should be c2, but it isn't due to the bug
  00000000  a7 0a                                             |..|
  00000002
  ```

  The code in question was skipping past the initial byte with `continue`:
  https://github.com/ksh93/ksh/blob/8c16f38a8886fdf5e12762a9c0c427e2fd1eb688/src/cmd/ksh93/sh/macro.c#L2403-L2406
  This problem is fixed by putting the initial byte on the stack with `sfputc` before the `continue`.

  Bug report: https://github.com/att/ast/issues/1372