### PR TITLE
Fix how unrecognized options are handled in sleep and suspend

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -11,6 +11,10 @@ Any uppercase BUG_* names are modernish shell bug IDs.
   based on the incorrect assumption the IFS would never be larger
   than a single byte.
 
+- Fixed a bug that caused the sleep builtin to continue after being given
+  an unrecognized option. 'sleep -: 1' will now show a usage message and
+  exit instead of sleep for one second.
+
 2020-07-23:
 
 - Fixed an infinite loop that could occur when ksh is the system's /bin/sh.

--- a/src/cmd/ksh93/bltins/sleep.c
+++ b/src/cmd/ksh93/bltins/sleep.c
@@ -62,6 +62,8 @@ int	b_sleep(register int argc,char *argv[],Shbltin_t *context)
 			errormsg(SH_DICT,ERROR_usage(2), "%s", opt_info.arg);
 			break;
 	}
+	if(error_info.errors)
+		errormsg(SH_DICT, ERROR_usage(2), "%s", optusage(NULL));
 	argv += opt_info.index;
 	if(cp = *argv)
 	{

--- a/src/cmd/ksh93/bltins/trap.c
+++ b/src/cmd/ksh93/bltins/trap.c
@@ -249,8 +249,19 @@ endopts:
 int	b_suspend(int argc,char *argv[],Shbltin_t *context)
 {
 	NOT_USED(argc);
-	if(optget(argv, sh_optsuspend))	/* no options supported (except AST --man, etc.) */
-		errormsg(SH_DICT, ERROR_exit(2), "%s", opt_info.arg);
+
+	int n;
+	while((n = optget(argv, sh_optsuspend))) switch(n)
+	{
+		case ':':
+			errormsg(SH_DICT,2, "%s", opt_info.arg);
+			break;
+		case '?':
+			errormsg(SH_DICT,ERROR_usage(2), "%s", opt_info.arg);
+			break;
+	}
+	if(error_info.errors)	/* no options supported (except AST --man, etc.) */
+		errormsg(SH_DICT,ERROR_usage(2),"%s", optusage((char*)0));
 	if(argv[opt_info.index])	/* no operands supported */
 		errormsg(SH_DICT, ERROR_exit(2), e_toomanyops);
 	if(sh_isoption(SH_LOGIN_SHELL))

--- a/src/cmd/ksh93/tests/builtins.sh
+++ b/src/cmd/ksh93/tests/builtins.sh
@@ -892,7 +892,7 @@ EOF
 	for name in $(builtin -l | grep -Ev '(echo|/opt|test|true|false|getconf|uname|\[|:)'); do
 	    actual="$($name --this-option-does-not-exist 2>&1)"
 	    expect="Usage: $name"
-	    [[ $actual =~ $expect ]] || err_exit "$name should show usage info on unrecognized options (expected $expect, got $actual)"
+	    [[ $actual =~ $expect ]] || err_exit "$name should show usage info on unrecognized options (expected $(printf '%q' "$expect"), got $(printf '%q' "$actual"))"
 	done
 )
 

--- a/src/cmd/ksh93/tests/builtins.sh
+++ b/src/cmd/ksh93/tests/builtins.sh
@@ -885,5 +885,16 @@ fi
 EOF
 "$SHELL" -i "$sleepsig" 2> /dev/null || err_exit "'sleep -s' doesn't work with intervals of more than 30 seconds"
 
+# ==========
+# Builtins should handle unrecognized options correctly
+(
+	builtin $(builtin -l | awk -F "/" '/\/opt/ {print $5}') # Load all /opt/ast/bin builtins
+	for name in $(builtin -l | grep -Ev '(echo|/opt|test|true|false|getconf|uname|\[|:)'); do
+	    actual="$($name --this-option-does-not-exist 2>&1)"
+	    expect="Usage: $name"
+	    [[ $actual =~ $expect ]] || err_exit "$name should show usage info on unrecognized options (expected $expect, got $actual)"
+	done
+)
+
 # ======
 exit $((Errors<125?Errors:125))


### PR DESCRIPTION
When a builtin is given an unrecognized option, the usage information for that builtin should be shown as 'Usage: builtin-name options'. `sleep` and `suspend` were exceptions to this. `suspend` wouldn't show usage information and `sleep` wouldn't exit immediately after being given an invalid option:

```sh
$ suspend -e
/usr/bin/ksh: suspend: -e: unknown option
$ time sleep -e 1
sleep: -e: unknown option

real	0m1.00s
user	0m0.00s
sys	0m0.00s

# Output of `exit -e` for comparison
$ exit -e
/usr/bin/ksh: exit: -e: unknown option
Usage: exit [ options | --help | --man ] [n]
```

This pull request fixes these bugs by doing the following:
- `sleep` now shows usage information and exits when given an invalid argument. This bugfix and the regression test are from att/ast#1024.
- `suspend` now parses options with `optget` in the same way as other builtins. The shortened method of getting arguments was causing the backported ksh2020 regression test to fail.