### PR TITLE
Increase the mamake buffer size to 4096

### DIFF
--- a/src/cmd/INIT/mamake.c
+++ b/src/cmd/INIT/mamake.c
@@ -118,7 +118,7 @@ USAGE_LICENSE
 #define set(b,o)	((b)->nxt=(b)->buf+(o))
 #define use(b)		(*(b)->nxt=0,(b)->nxt=(b)->buf)
 
-#define CHUNK		1024
+#define CHUNK		4096
 #define KEY(a,b,c,d)	((((unsigned long)(a))<<15)|(((unsigned long)(b))<<10)|(((unsigned long)(c))<<5)|(((unsigned long)(d))))
 #define NOW		((unsigned long)time((time_t*)0))
 #define ROTATE(p,l,r,t)	((t)=(p)->l,(p)->l=(t)->r,(t)->r=(p),(p)=(t))


### PR DESCRIPTION
This patch fixes a rare build failure by applying one of Oracle's patches ([310-mamake-chunksize.patch](https://github.com/oracle/solaris-userland/blob/7cad9dae7852379b772e7f8bd9b8c2fc17f259df/components/ksh93/patches/310-mamake-chunksize.patch)) to increase mamake's buffer size. Description from the patch:

> The build of KornShell might spuriously fail with the following error.
> ```
> /usr/bin/ksh: line 40: syntax error at line 44: `else unmatched
> mamake [lib/libast]: *** exit code 3 making ast.req
> mamake: *** exit code 139 making lib/libast
> ```
> The patch increases the buffer size of mamake to avoid spurious build failures. See bug 31123523 for more information.

I can't replicate the build error, but I think this patch should be merged anyways because OpenSUSE also increases mamake's buffer size in a patch titled [workaround-stupid-build-system.diff](https://build.opensuse.org/package/view_file/shells/ksh/workaround-stupid-build-system.diff?expand=1). This indicates the reported build failure is a heisenbug that can occur on both Linux and Solaris.