### PR TITLE
Fix spurious creation of '=' file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 # Project-specific files
-=
 arch
 tgz
 lcl

--- a/bin/package
+++ b/bin/package
@@ -32,6 +32,7 @@ esac
 checksh()
 {
 	egrep 'Version.*(88|1993)' $1 >/dev/null 2>&1 ||
+	$1 -c '(( 2 + 2 ))' >/dev/null 2>&1 &&
 	$1 -c '(( .sh.version >= 20111111 ))' >/dev/null 2>&1
 }
 

--- a/bin/package
+++ b/bin/package
@@ -32,7 +32,7 @@ esac
 checksh()
 {
 	egrep 'Version.*(88|1993)' $1 >/dev/null 2>&1 ||
-	$1 -c '(( 2 + 2 ))' >/dev/null 2>&1 &&
+	PATH=/dev/null $1 -c '(( 2 + 2 ))' >/dev/null 2>&1 &&
 	$1 -c '(( .sh.version >= 20111111 ))' >/dev/null 2>&1
 }
 

--- a/src/cmd/INIT/package.sh
+++ b/src/cmd/INIT/package.sh
@@ -31,7 +31,7 @@ esac
 checksh()
 {
 	egrep 'Version.*(88|1993)' $1 >/dev/null 2>&1 ||
-	$1 -c '(( 2 + 2 ))' >/dev/null 2>&1 &&
+	PATH=/dev/null $1 -c '(( 2 + 2 ))' >/dev/null 2>&1 &&
 	$1 -c '(( .sh.version >= 20111111 ))' >/dev/null 2>&1
 }
 

--- a/src/cmd/INIT/package.sh
+++ b/src/cmd/INIT/package.sh
@@ -31,6 +31,7 @@ esac
 checksh()
 {
 	egrep 'Version.*(88|1993)' $1 >/dev/null 2>&1 ||
+	$1 -c '(( 2 + 2 ))' >/dev/null 2>&1 &&
 	$1 -c '(( .sh.version >= 20111111 ))' >/dev/null 2>&1
 }
 


### PR DESCRIPTION
The build system on certain platforms will create a spurious '=' file in the repository's root directory due to an incorrect assumption the `checksh` function makes about the shell. The following is quoted from @saper:
> When running under FreeBSD /bin/sh (and not ksh) we get spurious file named '=' created in the root. This is because the "checksh" function runs `/bin/sh -c '(( .sh.version >= 20111111 ))'` which produces a "=" file with /bin/sh as a side effect.

The bugfix simply makes sure the shell supports (( ... )) expressions before attempting to check `${.sh.version}`. This bug was reported in #13, but that issue was closed in error. I was still getting an "=" file to generate on FreeBSD.

References:
https://github.com/att/ast/issues/963#issuecomment-590001778
https://bsd.network/@saper/103196289917156347
https://repo.or.cz/INIT.git