### PR TITLE
Fix `./bin/package host cpu` on FreeBSD

### DIFF
--- a/bin/package
+++ b/bin/package
@@ -1673,6 +1673,13 @@ hostinfo() # attribute ...
 			continue
 			;;
 		esac
+		cpu=`sysctl -n hw.ncpu`
+		case $cpu in
+		[123456789]*)
+			_hostinfo_="$_hostinfo_ $cpu"
+			continue
+			;;
+		esac
 		cpu=`grep -ic '^processor[ 	][ 	]*:[ 	]*[0123456789]' /proc/cpuinfo`
 		case $cpu in
 		[123456789]*)

--- a/src/cmd/INIT/package.sh
+++ b/src/cmd/INIT/package.sh
@@ -1672,6 +1672,13 @@ hostinfo() # attribute ...
 			continue
 			;;
 		esac
+		cpu=`sysctl -n hw.ncpu`
+		case $cpu in
+		[123456789]*)
+			_hostinfo_="$_hostinfo_ $cpu"
+			continue
+			;;
+		esac
 		cpu=`grep -ic '^processor[ 	][ 	]*:[ 	]*[0123456789]' /proc/cpuinfo`
 		case $cpu in
 		[123456789]*)


### PR DESCRIPTION
Currently running `bin/package host cpu` on FreeBSD only reports that the system has one CPU core, even if the CPU has multiple cores:

```sh
$ ./bin/package host cpu
1
```

This bugfix is from @saper's fork of the INIT build system ([link to relevant commit](https://repo.or.cz/INIT.git/commit/faa6f6aaa0cd7abdbd247aacf5675a1c65524214)). `sysctl -n hw.ncpu` is now used on the BSDs to get the number of CPUs available, which fixes this bug.