### PR TITLE
Fix creation of extra associative array element '0'

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,11 @@ For full details, see the git log at: https://github.com/ksh93/ksh
 
 Any uppercase BUG_* names are modernish shell bug IDs.
 
+2020-07-31:
+
+- Fix a bug that caused multidimensional associative arrays to be created with
+  an extra array member.
+
 2020-07-29:
 
 - On a ksh compiled to use fork(2) to run external commands, a bug has been

--- a/NEWS
+++ b/NEWS
@@ -5,8 +5,8 @@ Any uppercase BUG_* names are modernish shell bug IDs.
 
 2020-07-31:
 
-- Fix a bug that caused multidimensional associative arrays to be created with
-  an extra array member.
+- Fixed a bug that caused multidimensional associative arrays to be created
+  with an extra array member.
 
 2020-07-29:
 

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -17,4 +17,4 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                                                                      *
 ***********************************************************************/
-#define SH_RELEASE	"93u+m 2020-07-29"
+#define SH_RELEASE	"93u+m 2020-07-31"

--- a/src/cmd/ksh93/sh/array.c
+++ b/src/cmd/ksh93/sh/array.c
@@ -1003,7 +1003,7 @@ Namarr_t *nv_setarray(Namval_t *np, void *(*fun)(Namval_t*,const char*,int))
 		ap->nelem = nelem;
 		ap->fun = fun;
 		nv_onattr(np,NV_ARRAY);
-		if(fp || value)
+		if(fp || (value && value!=Empty))
 		{
 			nv_putsub(np, "0", ARRAY_ADD);
 			if(value)

--- a/src/cmd/ksh93/tests/arrays.sh
+++ b/src/cmd/ksh93/tests/arrays.sh
@@ -708,4 +708,14 @@ unset foo
 [[ -n ${ typeset -p foo; } ]] && err_exit 'Associative array leaks out of subshell'
 
 # ======
+# Multidimensional associative arrays shouldn't be created with an extra 0 element
+unset foo
+typeset -A foo
+typeset -A foo[bar]
+expect="typeset -A foo=([bar]=() )"
+actual="$(typeset -p foo)"
+# $expect and $actual are quoted intentionally
+[[ "$expect" == "$actual" ]] || err_exit "Multidimensional associative arrays are created with an extra array member (expected $expect, got $actual)"
+
+# ======
 exit $((Errors<125?Errors:125))


### PR DESCRIPTION
Multidimensional associative arrays are created with an extra array member named '0', which is set to no value:
```
$ typeset -A foo
$ typeset -A foo[bar]
$ typeset -p foo
typeset -A foo=([bar]=([0]='') )

# Alternate reproducer
$ typeset -A foo
$ typeset -A foo[bar]
$ typeset -A foo[baz]
$ foo[bar][cat]=1
$ foo[bar][dog]=2
$ foo[baz][mouse]=3
$ foo[baz][fish]=4
$ set | fgrep foo
_='foo[baz]'
foo=([bar]=([cat]=1 [dog]=2) [baz]=([0]='' [fish]=4 [mouse]=3) )
```

Output from ksh93v- (which fixed this bug):
```
$ typeset -A foo    
$ typeset -A foo[bar]
$ typeset -p foo
typeset -A foo=([bar]=() )
```

The bugfix prevents `nv_setarray` from creating the extra '0' member when an associative array is empty. This bug was discussed on the old mailing list:
https://www.mail-archive.com/ast-developers@lists.research.att.com/msg01574.html