### PR TITLE
Multibyte character string after $1-9 in ksh is not expanded correctly

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,10 @@ Any uppercase BUG_* names are modernish shell bug IDs.
 - Fixed a bug that caused multidimensional associative arrays to be created
   with an extra array member.
 
+- Fixed a bug that caused the expansions of positional parameters $1 - $9,
+  as well as special parameters such as $? and $-, to corrupt any multibyte
+  characters immediately following the expansion if a UTF-8 locale is active.
+
 2020-07-29:
 
 - On a ksh compiled to use fork(2) to run external commands, a bug has been

--- a/src/cmd/ksh93/sh/macro.c
+++ b/src/cmd/ksh93/sh/macro.c
@@ -1506,7 +1506,10 @@ retry1:
 	    default:
 		goto nosub;
 	}
-	c = fcmbget(&LEN);
+	if(type)
+		c = fcmbget(&LEN);
+	else
+		c = fcget();
 	if(type>M_TREE)
 	{
 		if(c!=RBRACE)

--- a/src/cmd/ksh93/tests/basic.sh
+++ b/src/cmd/ksh93/tests/basic.sh
@@ -615,5 +615,18 @@ then	actual=$(
 		"(expected $(printf %q "$expect"), got $(printf %q "$actual"))"
 fi
 
+#"======
+# Expansion of multibyte characters after expansion of single-character names $1..$9, $?, $!, $-, etc.
+function exptest
+{
+	print -r "$1テスト"
+	print -r "$?テスト"
+	print -r "$#テスト"
+}
+expect=$'fooテスト\n0テスト\n1テスト'
+actual=$(exptest foo)
+[[ $actual == "$expect" ]] || err_exit 'Corruption of multibyte char following expansion of single-char name' \
+	"(expected $(printf %q "$expect"), got $(printf %q "$actual"))"
+
 # ======
 exit $((Errors<125?Errors:125))


### PR DESCRIPTION
From RedHat BZ1256495

https://bugzilla.redhat.com/show_bug.cgi?id=1256495

ksh93-20120801 (fault):
$ ./test1.sh
?スト
テスト
test

Correct behavior:
$ /Users/mwilson/src/mwilson/ksh/arch/darwin.i386-64/bin/ksh test1.sh
テスト
テスト
test

Reproducer:

mbp13 $ cat test1.sh
echo "$1テスト"
echo "${1}テスト"
echo "$1test"