### PR TITLE
Fix unset method in multidimensional arrays

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,11 @@ For full details, see the git log at: https://github.com/ksh93/ksh
 
 Any uppercase BUG_* names are modernish shell bug IDs.
 
+2020-08-05:
+
+- Fixed a bug in functions that caused ksh to crash when an array with an
+  unset method was turned into a multidimensional array.
+
 2020-07-31:
 
 - Fixed a bug that caused multidimensional associative arrays to be created

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -17,4 +17,4 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                                                                      *
 ***********************************************************************/
-#define SH_RELEASE	"93u+m 2020-07-31"
+#define SH_RELEASE	"93u+m 2020-08-05"

--- a/src/cmd/ksh93/sh/nvdisc.c
+++ b/src/cmd/ksh93/sh/nvdisc.c
@@ -331,12 +331,17 @@ static void	assign(Namval_t *np,const char* val,int flags,Namfun_t *handle)
 	else if(!nq || !isblocked(bp,type))
 	{
 		Dt_t *root = sh_subfuntree(1);
+		Namval_t *pp=0;
 		int n;
 		Namarr_t *ap;
 		block(bp,type);
 		nv_disc(np,handle,NV_POP);
+		if(!nv_isattr(np,NV_MINIMAL))
+			pp = (Namval_t*)np->nvenv;
 		nv_putv(np, val, flags, handle);
 		if(sh.subshell)
+			goto done;
+		if(pp && nv_isarray(pp))
 			goto done;
 		if(nv_isarray(np) && (ap=nv_arrayptr(np)) && ap->nelem>0)
 			goto done;

--- a/src/cmd/ksh93/tests/arrays2.sh
+++ b/src/cmd/ksh93/tests/arrays2.sh
@@ -238,7 +238,7 @@ function foo {
 }
 foo
 EOF
-ksh "$multiarray_unset" > /dev/null || err_exit 'Multidimensional arrays with an unset method crash ksh'
+$SHELL "$multiarray_unset" > /dev/null || err_exit 'Multidimensional arrays with an unset method crash ksh'
 
 # ======
 exit $((Errors<125?Errors:125))

--- a/src/cmd/ksh93/tests/arrays2.sh
+++ b/src/cmd/ksh93/tests/arrays2.sh
@@ -224,4 +224,21 @@ print -v cx > /dev/null
 print -v cx | read -C l 2> /dev/null || err_exit 'read -C fails from output of print -v'
 [[ ${cx%cx=} ==  "${l%l=}" ]] || err_exit 'print -v for compound variable with fixed 2d array not working'
 
+# ======
+# Multidimensional arrays with an unset method shouldn't cause a crash.
+# The test itself must be run inside of a function.
+multiarray_unset="$tmp/multiarray_unset.sh"
+cat >| "$multiarray_unset" << EOF
+function foo {
+	typeset -a a
+	a.unset() {
+		print unset
+	}
+	a[3][6][11][20]=7
+}
+foo
+EOF
+ksh "$multiarray_unset" > /dev/null || err_exit 'Multidimensional arrays with an unset method crash ksh'
+
+# ======
 exit $((Errors<125?Errors:125))


### PR DESCRIPTION
A segfault happens when an array with an unset method is turned into a multidimensional array. Reproducer:
```bash
$ cat ./reproducer.ksh
#!/bin/ksh
function foo {
    typeset -a a
    a.unset() {
        print unset
    }
    a[3][6][11][20]=7
}
foo
$ ksh ./reproducer.ksh
Memory fault
```

This crash happens because the `assign` function in nvdisc.c is not properly handling multidimensional arrays. The bugfix (backported from ksh93v- 2013-10-10-alpha) goes to the `done` label in `assign` if `np->nvenv` is an array.

Bug report on the old mailing list:
https://www.mail-archive.com/ast-developers@lists.research.att.com/msg01195.html