### PR TITLE
Over-shifting in a function should cause scripts to exit

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,11 @@ For full details, see the git log at: https://github.com/ksh93/ksh
 
 Any uppercase BUG_* names are modernish shell bug IDs.
 
+2020-08-05:
+
+- Fixed a bug that caused scripts to continue running after over-shifting
+  in a function when the function call had a redirection.
+
 2020-07-31:
 
 - Fixed a bug that caused multidimensional associative arrays to be created

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -17,4 +17,4 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                                                                      *
 ***********************************************************************/
-#define SH_RELEASE	"93u+m 2020-07-31"
+#define SH_RELEASE	"93u+m 2020-08-05"

--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -1508,7 +1508,7 @@ int sh_exec(register const Shnode_t *t, int flags)
 						unset_instance(nq,&node,&nr,mode);
 					sh_funstaks(slp->slchild,-1);
 					stakdelete(slp->slptr);
-					if(jmpval > SH_JMPFUN)
+					if(jmpval > SH_JMPFUN || (io && jmpval > SH_JMPIO))
 						siglongjmp(*shp->jmplist,jmpval);
 					goto setexit;
 				}

--- a/src/cmd/ksh93/tests/functions.sh
+++ b/src/cmd/ksh93/tests/functions.sh
@@ -1262,4 +1262,18 @@ function f1 { f2; env | grep -q "^foo" || err_exit "Environment variable is not 
 foo=bar f1
 
 # ======
+# Over-shifting in a function should terminate the script
+$SHELL <<- \EOF
+	fun() {
+		shift 10
+	}
+	for i in a b
+	do
+		fun 2> /dev/null
+		[[ $i == b ]] && exit 2
+	done
+EOF
+[[ $? == 2 ]] && err_exit 'Over-shifting in a function does not terminate the script if the function call has a redirection'
+
+# ======
 exit $((Errors<125?Errors:125))

--- a/src/cmd/ksh93/tests/functions.sh
+++ b/src/cmd/ksh93/tests/functions.sh
@@ -1262,7 +1262,7 @@ function f1 { f2; env | grep -q "^foo" || err_exit "Environment variable is not 
 foo=bar f1
 
 # ======
-# Over-shifting in a function should terminate the script
+# Over-shifting in a POSIX function should terminate the script
 $SHELL <<- \EOF
 	fun() {
 		shift 10
@@ -1273,7 +1273,7 @@ $SHELL <<- \EOF
 		[[ $i == b ]] && exit 2
 	done
 EOF
-[[ $? == 2 ]] && err_exit 'Over-shifting in a function does not terminate the script if the function call has a redirection'
+[[ $? == 2 ]] && err_exit 'Over-shifting in a POSIX function does not terminate the script if the function call has a redirection'
 
 # ======
 exit $((Errors<125?Errors:125))


### PR DESCRIPTION
The required longjmp used to terminate scripts was not being run when over-shifting in a function with a redirection. This caused scripts to continue after an error in the shift builtin, which is incorrect since shift is a special builtin. The interpreter is sent into an indeterminate state after over-shifting, causing undefined behavior as well:
```
$ cat reproducer.ksh
some_func() {
   shift 10 
}

for i in a b c d e f; do
  echo "read $i"
  [ "$i" != "c" ] && continue
  some_func 2>&1
  echo "$i = c"
done
$ ksh ./reproducer.ksh
read a
read b
read c
/tmp/k[2]: shift: 10: bad number
c = c
read d
/tmp/k[2]: shift: 10: bad number
d = c
read e
/tmp/k[2]: shift: 10: bad number
e = c
read f
/tmp/k[2]: shift: 10: bad number
f = c
```

Bug report and fix from the old mailing list:
https://www.mail-archive.com/ast-developers@lists.research.att.com/msg00732.html