### PR TITLE
Fix failure to zero pad with 'printf %(%0l)T'

### DIFF
--- a/src/cmd/ksh93/tests/builtins.sh
+++ b/src/cmd/ksh93/tests/builtins.sh
@@ -797,6 +797,25 @@ unset foo
 [[ $(printf '%(%f)T') == $(printf '%(%Y.%m.%d-%H:%M:%S)T') ]] || err_exit 'date format %f is not the same as %Y.%m.%d-%H:%M:%S'
 [[ $(printf '%(%q)T') == $(printf '%(%Qz)T') ]] && err_exit 'date format %q is the same as %Qz'
 
+# Test manually specified blank and zero padding with 'printf  %T'
+(
+	IFS=$'\n\t' # Preserve spaces in output
+	for i in d e H I j J k l m M N S U V W y; do
+		for f in ' ' 0; do
+			if [[ $f == ' ' ]]; then
+				padding='blank'
+				specify='_'
+			else
+				padding='zero'
+				specify='0'
+			fi
+			actual="$(printf "%(%${specify}${i})T" 'January 1 6AM 2001')"
+			expect="${f}${actual:1}"
+			[[ $expect != $actual ]] && err_exit "Specifying $padding padding with format '%$i' doesn't work (expected '$expect', got '$actual')"
+		done
+	done
+)
+
 # ======
 # Test various AST getopts usage/manual outputs
 

--- a/src/lib/libast/tm/tmxfmt.c
+++ b/src/lib/libast/tm/tmxfmt.c
@@ -316,9 +316,9 @@ tmxfmt(char* buf, size_t len, const char* format, Time_t t)
 		case 'J':	/* Julian date (0 offset) */
 			cp = number(cp, ep, (long)tm->tm_yday, 3, width, pad);
 			continue;
-		case 'k':	/* hour (0 - 23) with blank padding */
-			p = "%_H";
-			goto push;
+		case 'k':	/* hour (0 - 23) with blank padding (can't be an alias to %_H) */
+			cp = number(cp, ep, (long)tm->tm_hour, -2, width, pad);
+			continue;
 		case 'K':	/* (AST) largest to smallest */
 			switch (alt)
 			{
@@ -333,9 +333,11 @@ tmxfmt(char* buf, size_t len, const char* format, Time_t t)
 				break;
 			}
 			goto push;
-		case 'l':	/* hour (0 - 12) with blank padding */
-			p = "%_I";
-			goto push;
+		case 'l':	/* hour (0 - 12) with blank padding (can't be an alias to %_I) */
+			if ((n = tm->tm_hour) > 12) n -= 12;
+			else if (n == 0) n = 12;
+			cp = number(cp, ep, (long)n, -2, width, pad);
+			continue;
 		case 'L':	/* (AST) OBSOLETE use %Ql */
 			p = "%Ql";
 			goto push;


### PR DESCRIPTION
My previous fix for #62 (in #65) made `%l` and `%k` aliases to `%_I` and `%_H` to avoid duplicating code,  which only fixed `%l` and `%k` with blank padding. Zero padding with those time formats wasn't working correctly:
```sh
$ printf '%(%0l)T\n' 7AM # Should be the same as %I
 7
```

This pull request applies the original bugfix for `%l` and `%k` (https://github.com/ksh93/ksh/issues/62#issuecomment-653883658) to fix zero padding with those formats. A regression test has been added to builtins.sh to test blank padding and zero padding with sixteen different `printf %T` formats.