### PR TITLE
Make liblist an extern to fix dtksh compile

### DIFF
--- a/src/cmd/ksh93/bltins/typeset.c
+++ b/src/cmd/ksh93/bltins/typeset.c
@@ -904,18 +904,9 @@ static int     setall(char **argv,register int flag,Dt_t *troot,struct tdata *tp
 
 typedef void (*Libinit_f)(int,void*);
 
-typedef struct Libcomp_s
-{
-	void*		dll;
-	char*		lib;
-	dev_t		dev;
-	ino_t		ino;
-	unsigned int	attr;
-} Libcomp_t;
-
 #define GROWLIB	4
 
-static Libcomp_t	*liblist;
+Libcomp_t	*liblist;
 static int		nlib;
 static int		maxlib;
 

--- a/src/cmd/ksh93/include/shell.h
+++ b/src/cmd/ksh93/include/shell.h
@@ -150,6 +150,17 @@ struct Shell_s
 #endif /* _SH_PRIVATE */
 };
 
+/* used for builtins */
+typedef struct Libcomp_s
+{
+	void*		dll;
+	char*		lib;
+	dev_t		dev;
+	ino_t		ino;
+	unsigned int	attr;
+} Libcomp_t;
+extern Libcomp_t *liblist;
+
 /* flags for sh_parse */
 #define SH_NL		1	/* Treat new-lines as ; */
 #define SH_EOF		2	/* EOF causes syntax error */


### PR DESCRIPTION
The `liblist` variable needs to be an extern for dtksh to build. Quote from CDE developer Chase:
> we use an old function that no longer appears in kornshell, `sh_getliblist`, it seems to be replaced by the function `sh_getlib`, which is fine, but it seems to return a `Shbltin_f` type, which I can't seem to find any information on what it is. We need the void pointer `dlsym` provides for some widget init stuff, I tried making `liblist` an extern, but it kept giving me an error about `Libcomp_t` being undefined.

dtksh findsym.c for reference:
https://sourceforge.net/p/cdesktopenv/code/ci/2.3.2/tree/cde/programs/dtksh/findsym.c