### PR TITLE
Fix a large number of typos and other problems

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -69,9 +69,9 @@ Any uppercase BUG_* names are modernish shell bug IDs.
 
 2020-07-19:
 
-- Fixed a crash that occured in the '.' command when using kshdb.
+- Fixed a crash that occurred in the '.' command when using kshdb.
 
-- Fixed a crash that occured when attempting to use redirection with an
+- Fixed a crash that occurred when attempting to use redirection with an
   invalid file descriptor.
 
 2020-07-16:

--- a/docs/ksh/builtins.html
+++ b/docs/ksh/builtins.html
@@ -472,7 +472,7 @@ be freed before returning from you built-in, because by default,
 <TT>ksh</TT> will terminate you built-in in the event of an
 interrupt and the memory will not be freed.
 <P>
-The best way to to allocate variable sized storage is
+The best way to allocate variable sized storage is
 through calls to the <STRONG>stak</STRONG> library
 which is included in <STRONG>libast</STRONG>
 and which is used extensively by <TT>ksh</TT> itself.

--- a/lib/package/INIT.README
+++ b/lib/package/INIT.README
@@ -424,7 +424,7 @@ All recorded changes follow.
 	 package.mk: add the runtime package type (no *.[ah])
 	 iffe.sh: fix key test reports
 04-08-26 Makefile: { add m2.c m3.c } -lm tests for { frexp[l] ldexp[l] }
-04-08-11 package.mk: handle HOSTTYPE for solaris > 9 
+04-08-11 package.mk: handle HOSTTYPE for solaris > 9
 	 package.sh: add `checkaout proto' for { make view }
 	 package.sh: check for { md5sum md5 }
 	 iffe.sh: add {if|elif|else|endif} test ...
@@ -525,7 +525,7 @@ All recorded changes follow.
 03-06-21 package.sh: fix INITROOT initialization bug
 	 package.sh: make sure admin logs exists before tail'ing
 03-06-11 probe.win32: fix $(BINDIR) typo that expanded in sh instead of make
-	 cc.mvs.390: return code 4 yields exit code 3 but its *really* ok
+	 cc.mvs.390: return code 4 yields exit code 3 but it's *really* ok
 	 package.sh: fix onpath function global var conflict
 	 make.probe: add CC.DIALECT { GNU -dD }
 	 package.mk: add Mamfile to lcl manifest
@@ -545,7 +545,7 @@ All recorded changes follow.
 03-05-05 package.mk: fix cygwin tarball names
 03-04-30 package.sh: move (cc|ld|ldd).$HOSTTYPE updates from Makefile
 03-04-27 make.probe: fix mvs CC.PREFIX.SHARED "lib" => ""
-	 make.probe: add CC.DLL.DIR = $(BINDIR) or $(LIBDIR) 
+	 make.probe: add CC.DLL.DIR = $(BINDIR) or $(LIBDIR)
 	 make.probe: add { CC.LD.LAZY CC.LD.NOLAZY CC.LD.RECORD CC.LD.NORECORD }
 	 probe.win32: sync with latest CC.*
 03-04-25 mamprobe.sh: add args to `. $makeprobe' for ancient sh
@@ -553,7 +553,7 @@ All recorded changes follow.
 03-04-22 probe.win32: CC.DIALECT += "LIBPP -I-" for all cc's
 	 package.sh: fix admin write binary tarball snarf
 03-04-21 package.mk: package covered *.@(pkg|lic) too
-03-04-15 package.mk: don't generate incremental archives for lcl 
+03-04-15 package.mk: don't generate incremental archives for lcl
 	 package.mk: add incremental=[source:1 binary:0] archive control
 	 package.sh: generate $INSTALLROOT/bin/cc wrapper for CC != cc
 	 package.sh: admin must ditto lib/package/*.@(pkg|lic) too
@@ -644,7 +644,7 @@ All recorded changes follow.
 02-09-11 make.probe: move from nmake src to be part of mamprobe.sh
 	 mamprobe: generate from mamprobe.beg C.probe make.probe mamprobe.end
 	 mamake.c: pass cc absolute path to mamprobe
-	 package.sh: generate mamprobe -- yuk (at least its confined to INIT)
+	 package.sh: generate mamprobe -- yuk (at least it's confined to INIT)
 	 iffe.sh: lcl,nxt: drop default sys/ check
 	 ditto.sh: tw --logical by default; add --physical
 02-09-10 package.sh: SHELLMAGIC creeps into package too -- duh and fooey
@@ -735,7 +735,7 @@ All recorded changes follow.
 	 package.mk: tarball package.notice replaces `license accepted' prompt
 	 package.sh: eliminate `license accepted' prompt
 	 package.sh: add update to download latest from a url
-	 package.sh: use builtin arithmetic when we know its ksh
+	 package.sh: use builtin arithmetic when we know it's ksh
 	 iffe.sh: unkown -> unknown
 01-10-18 package.sh: convert to YYYY-MM-DD delta releases instead of NNNN
 	 package.mk: convert to YYYY-MM-DD delta releases instead of NNNN
@@ -758,7 +758,7 @@ All recorded changes follow.
 01-08-11 package.mk: handle single gz executable packages (e.g., for ksh)
 	 package.sh: fix package install to require nmake only if no *.sum
 	 iffe.sh: drop ancient menu and prompt actions; check ./hdr.h clash
-01-07-17 package: fix use cross compile test to generate files in /tmp 
+01-07-17 package: fix use cross compile test to generate files in /tmp
 01-06-27 ratz: handle hard and soft links if possible
 01-06-07 Makefile: fix :MAPLIB: for sco
 01-05-31 crossexec.sh: add
@@ -789,7 +789,7 @@ All recorded changes follow.
 01-02-26 iffe.sh: fix bug that omitted runtime #define for `mac' op
 01-02-22 cc.ibm.risc: handle SF_CLOSE clash in <sfio.h>
 01-02-14 cc.sgi.mips3,cc.sgi.mips4: handle -mips2 -mips3 -mips4 for cross cc
-	 C+probe: quote "$cc" when its an argument!
+	 C+probe: quote "$cc" when it's an argument!
 	 mamake: execute actions with $SHELL, ignored signals back to default
 	 package.sh: nmake check error output to /dev/null
 	 package.sh: fix INIT a.out updates for knr cc
@@ -810,7 +810,7 @@ All recorded changes follow.
 	 package.sh: add $SECONDS to the DEBUG trace prompt
 01-01-01 ratz.c: #ifdef for uwin ncc
 	 iffe.sh,package.sh: check PACKAGE_PATH for local installations
-	 package.sh: add psrinfo for osf.alpha host cpu 
+	 package.sh: add psrinfo for osf.alpha host cpu
 	 package.sh: change pax --meter probe; some hang on /dev/tty
 	 package.sh: fix `install flat ARCH'
 	 mamake: eliminate loops from scan order
@@ -863,7 +863,7 @@ All recorded changes follow.
 	 package: fix write delta source to use default pax format
 	 package: add disambiguating bias for sgi.mips3 over sgi.mips4
 	 package.mk: fix for directory content packages lib ast-locale
-00-05-01 iffe: fix invalid _LIB_ macro identifier 
+00-05-01 iffe: fix invalid _LIB_ macro identifier
 00-04-11 C+probe: uniq stdinclude and stdlib, fix usrinclude
 00-04-01 regress: fix explicit OUTPUT bug that didn't compare with expected
 00-03-17 package: all archives are .tgz for binary download
@@ -944,7 +944,7 @@ All recorded changes follow.
 98-11-11 regress: fix UNIT PATH lookup
 98-11-01 regress: add PROG
 98-10-01 hostinfo: add unixware.*
-	 use: export PACKAGE_* 
+	 use: export PACKAGE_*
 98-08-11 C.probe: add /usr/include check (for sco CC)
 	 hostinfo: handle uwin uname update
 98-05-01 regress: fix bug sometimes didn't list last test

--- a/lib/package/INIT.html
+++ b/lib/package/INIT.html
@@ -386,7 +386,7 @@ All recorded changes follow.
 	 package.mk: add the runtime package type (no *.&#0091;ah&#0093;)
 	 iffe.sh: fix key test reports
 04-08-26 Makefile: { add m2.c m3.c } -lm tests for { frexp&#0091;l&#0093; ldexp&#0091;l&#0093; }
-04-08-11 package.mk: handle HOSTTYPE for solaris &gt; 9 
+04-08-11 package.mk: handle HOSTTYPE for solaris &gt; 9
 	 package.sh: add `checkaout proto' for { make view }
 	 package.sh: check for { md5sum md5 }
 	 iffe.sh: add {if|elif|else|endif} test ...
@@ -487,7 +487,7 @@ All recorded changes follow.
 03-06-21 package.sh: fix INITROOT initialization bug
 	 package.sh: make sure admin logs exists before tail'ing
 03-06-11 probe.win32: fix $(BINDIR) typo that expanded in sh instead of make
-	 cc.mvs.390: return code 4 yields exit code 3 but its *really* ok
+	 cc.mvs.390: return code 4 yields exit code 3 but it's *really* ok
 	 package.sh: fix onpath function global var conflict
 	 make.probe: add CC.DIALECT { GNU -dD }
 	 package.mk: add Mamfile to lcl manifest
@@ -507,7 +507,7 @@ All recorded changes follow.
 03-05-05 package.mk: fix cygwin tarball names
 03-04-30 package.sh: move (cc|ld|ldd).$HOSTTYPE updates from Makefile
 03-04-27 make.probe: fix mvs CC.PREFIX.SHARED "lib" =&gt; ""
-	 make.probe: add CC.DLL.DIR = $(BINDIR) or $(LIBDIR) 
+	 make.probe: add CC.DLL.DIR = $(BINDIR) or $(LIBDIR)
 	 make.probe: add { CC.LD.LAZY CC.LD.NOLAZY CC.LD.RECORD CC.LD.NORECORD }
 	 probe.win32: sync with latest CC.*
 03-04-25 mamprobe.sh: add args to `. $makeprobe' for ancient sh
@@ -515,7 +515,7 @@ All recorded changes follow.
 03-04-22 probe.win32: CC.DIALECT += "LIBPP -I-" for all cc's
 	 package.sh: fix admin write binary tarball snarf
 03-04-21 package.mk: package covered *.@(pkg|lic) too
-03-04-15 package.mk: don't generate incremental archives for lcl 
+03-04-15 package.mk: don't generate incremental archives for lcl
 	 package.mk: add incremental=&#0091;source:1 binary:0&#0093; archive control
 	 package.sh: generate $INSTALLROOT/bin/cc wrapper for CC != cc
 	 package.sh: admin must ditto lib/package/*.@(pkg|lic) too
@@ -606,7 +606,7 @@ All recorded changes follow.
 02-09-11 make.probe: move from nmake src to be part of mamprobe.sh
 	 mamprobe: generate from mamprobe.beg C.probe make.probe mamprobe.end
 	 mamake.c: pass cc absolute path to mamprobe
-	 package.sh: generate mamprobe -- yuk (at least its confined to INIT)
+	 package.sh: generate mamprobe -- yuk (at least it's confined to INIT)
 	 iffe.sh: lcl,nxt: drop default sys/ check
 	 ditto.sh: tw --logical by default; add --physical
 02-09-10 package.sh: SHELLMAGIC creeps into package too -- duh and fooey
@@ -629,7 +629,7 @@ All recorded changes follow.
 02-06-14 package.sh: fix admin_action to not include qualifiers
 	 package.sh: fix help/html doc typo
 02-06-11 package.sh: fix ditto update doc to `PACKAGEROOT field matching *:*'
-02-06-07 WWW.mk: change substitute $(") to 
+02-06-07 WWW.mk: change substitute $(") to
 02-06-06 package.sh: clarify output streams for help/html
 02-05-22 mamake.c: fix executable file check to use (S_IXUSR|S_IXGRP|S_IXOTH)
 02-04-04 package.sh: fix update to differentiate *.sun4 and sun4
@@ -697,7 +697,7 @@ All recorded changes follow.
 	 package.mk: tarball package.notice replaces `license accepted' prompt
 	 package.sh: eliminate `license accepted' prompt
 	 package.sh: add update to download latest from a url
-	 package.sh: use builtin arithmetic when we know its ksh
+	 package.sh: use builtin arithmetic when we know it's ksh
 	 iffe.sh: unkown -&gt; unknown
 01-10-18 package.sh: convert to YYYY-MM-DD delta releases instead of NNNN
 	 package.mk: convert to YYYY-MM-DD delta releases instead of NNNN
@@ -720,7 +720,7 @@ All recorded changes follow.
 01-08-11 package.mk: handle single gz executable packages (e.g., for ksh)
 	 package.sh: fix package install to require nmake only if no *.sum
 	 iffe.sh: drop ancient menu and prompt actions; check ./hdr.h clash
-01-07-17 package: fix use cross compile test to generate files in /tmp 
+01-07-17 package: fix use cross compile test to generate files in /tmp
 01-06-27 ratz: handle hard and soft links if possible
 01-06-07 Makefile: fix :MAPLIB: for sco
 01-05-31 crossexec.sh: add
@@ -751,7 +751,7 @@ All recorded changes follow.
 01-02-26 iffe.sh: fix bug that omitted runtime #define for `mac' op
 01-02-22 cc.ibm.risc: handle SF_CLOSE clash in &lt;sfio.h&gt;
 01-02-14 cc.sgi.mips3,cc.sgi.mips4: handle -mips2 -mips3 -mips4 for cross cc
-	 C+probe: quote "$cc" when its an argument!
+	 C+probe: quote "$cc" when it's an argument!
 	 mamake: execute actions with $SHELL, ignored signals back to default
 	 package.sh: nmake check error output to /dev/null
 	 package.sh: fix INIT a.out updates for knr cc
@@ -772,7 +772,7 @@ All recorded changes follow.
 	 package.sh: add $SECONDS to the DEBUG trace prompt
 01-01-01 ratz.c: #ifdef for uwin ncc
 	 iffe.sh,package.sh: check PACKAGE_PATH for local installations
-	 package.sh: add psrinfo for osf.alpha host cpu 
+	 package.sh: add psrinfo for osf.alpha host cpu
 	 package.sh: change pax --meter probe; some hang on /dev/tty
 	 package.sh: fix `install flat ARCH'
 	 mamake: eliminate loops from scan order
@@ -825,7 +825,7 @@ All recorded changes follow.
 	 package: fix write delta source to use default pax format
 	 package: add disambiguating bias for sgi.mips3 over sgi.mips4
 	 package.mk: fix for directory content packages lib ast-locale
-00-05-01 iffe: fix invalid _LIB_ macro identifier 
+00-05-01 iffe: fix invalid _LIB_ macro identifier
 00-04-11 C+probe: uniq stdinclude and stdlib, fix usrinclude
 00-04-01 regress: fix explicit OUTPUT bug that didn't compare with expected
 00-03-17 package: all archives are .tgz for binary download
@@ -906,7 +906,7 @@ All recorded changes follow.
 98-11-11 regress: fix UNIT PATH lookup
 98-11-01 regress: add PROG
 98-10-01 hostinfo: add unixware.*
-	 use: export PACKAGE_* 
+	 use: export PACKAGE_*
 98-08-11 C.probe: add /usr/include check (for sco CC)
 	 hostinfo: handle uwin uname update
 98-05-01 regress: fix bug sometimes didn't list last test

--- a/src/cmd/INIT/MAPLIB.mk
+++ b/src/cmd/INIT/MAPLIB.mk
@@ -6,7 +6,7 @@
  * if Giji not specified then G11 == L
  * the first Ti.c that compiles/links with group -lGi1 ... -lGin
  * but does not compile/link with no libraries maps
- * -lL to to require -lGi1 ... -lGin
+ * -lL to require -lGi1 ... -lGin
  * otherwise -lL is not required and maps to "no library required"
  */
 

--- a/src/cmd/INIT/Makefile
+++ b/src/cmd/INIT/Makefile
@@ -338,7 +338,7 @@ socket :MAPLIB: socket.c nsl.c
  * this is why unix is starting to look like windows
  * this map allows makefiles to use -ldbm on all systems
  *
- * and this just in: sometimes its <gdbm-ndbm.h> and possibly -lgdbm_compat
+ * and this just in: sometimes it's <gdbm-ndbm.h> and possibly -lgdbm_compat
  *
  * at least the -l* buck stops here
  */

--- a/src/cmd/INIT/RELEASE
+++ b/src/cmd/INIT/RELEASE
@@ -329,7 +329,7 @@
 	 package.mk: add the runtime package type (no *.[ah])
 	 iffe.sh: fix key test reports
 04-08-26 Makefile: { add m2.c m3.c } -lm tests for { frexp[l] ldexp[l] }
-04-08-11 package.mk: handle HOSTTYPE for solaris > 9 
+04-08-11 package.mk: handle HOSTTYPE for solaris > 9
 	 package.sh: add `checkaout proto' for { make view }
 	 package.sh: check for { md5sum md5 }
 	 iffe.sh: add {if|elif|else|endif} test ...
@@ -430,7 +430,7 @@
 03-06-21 package.sh: fix INITROOT initialization bug
 	 package.sh: make sure admin logs exists before tail'ing
 03-06-11 probe.win32: fix $(BINDIR) typo that expanded in sh instead of make
-	 cc.mvs.390: return code 4 yields exit code 3 but its *really* ok
+	 cc.mvs.390: return code 4 yields exit code 3 but it's *really* ok
 	 package.sh: fix onpath function global var conflict
 	 make.probe: add CC.DIALECT { GNU -dD }
 	 package.mk: add Mamfile to lcl manifest
@@ -450,7 +450,7 @@
 03-05-05 package.mk: fix cygwin tarball names
 03-04-30 package.sh: move (cc|ld|ldd).$HOSTTYPE updates from Makefile
 03-04-27 make.probe: fix mvs CC.PREFIX.SHARED "lib" => ""
-	 make.probe: add CC.DLL.DIR = $(BINDIR) or $(LIBDIR) 
+	 make.probe: add CC.DLL.DIR = $(BINDIR) or $(LIBDIR)
 	 make.probe: add { CC.LD.LAZY CC.LD.NOLAZY CC.LD.RECORD CC.LD.NORECORD }
 	 probe.win32: sync with latest CC.*
 03-04-25 mamprobe.sh: add args to `. $makeprobe' for ancient sh
@@ -458,7 +458,7 @@
 03-04-22 probe.win32: CC.DIALECT += "LIBPP -I-" for all cc's
 	 package.sh: fix admin write binary tarball snarf
 03-04-21 package.mk: package covered *.@(pkg|lic) too
-03-04-15 package.mk: don't generate incremental archives for lcl 
+03-04-15 package.mk: don't generate incremental archives for lcl
 	 package.mk: add incremental=[source:1 binary:0] archive control
 	 package.sh: generate $INSTALLROOT/bin/cc wrapper for CC != cc
 	 package.sh: admin must ditto lib/package/*.@(pkg|lic) too
@@ -549,7 +549,7 @@
 02-09-11 make.probe: move from nmake src to be part of mamprobe.sh
 	 mamprobe: generate from mamprobe.beg C.probe make.probe mamprobe.end
 	 mamake.c: pass cc absolute path to mamprobe
-	 package.sh: generate mamprobe -- yuk (at least its confined to INIT)
+	 package.sh: generate mamprobe -- yuk (at least it's confined to INIT)
 	 iffe.sh: lcl,nxt: drop default sys/ check
 	 ditto.sh: tw --logical by default; add --physical
 02-09-10 package.sh: SHELLMAGIC creeps into package too -- duh and fooey
@@ -640,7 +640,7 @@
 	 package.mk: tarball package.notice replaces `license accepted' prompt
 	 package.sh: eliminate `license accepted' prompt
 	 package.sh: add update to download latest from a url
-	 package.sh: use builtin arithmetic when we know its ksh
+	 package.sh: use builtin arithmetic when we know it's ksh
 	 iffe.sh: unkown -> unknown
 01-10-18 package.sh: convert to YYYY-MM-DD delta releases instead of NNNN
 	 package.mk: convert to YYYY-MM-DD delta releases instead of NNNN
@@ -663,7 +663,7 @@
 01-08-11 package.mk: handle single gz executable packages (e.g., for ksh)
 	 package.sh: fix package install to require nmake only if no *.sum
 	 iffe.sh: drop ancient menu and prompt actions; check ./hdr.h clash
-01-07-17 package: fix use cross compile test to generate files in /tmp 
+01-07-17 package: fix use cross compile test to generate files in /tmp
 01-06-27 ratz: handle hard and soft links if possible
 01-06-07 Makefile: fix :MAPLIB: for sco
 01-05-31 crossexec.sh: add
@@ -694,7 +694,7 @@
 01-02-26 iffe.sh: fix bug that omitted runtime #define for `mac' op
 01-02-22 cc.ibm.risc: handle SF_CLOSE clash in <sfio.h>
 01-02-14 cc.sgi.mips3,cc.sgi.mips4: handle -mips2 -mips3 -mips4 for cross cc
-	 C+probe: quote "$cc" when its an argument!
+	 C+probe: quote "$cc" when it's an argument!
 	 mamake: execute actions with $SHELL, ignored signals back to default
 	 package.sh: nmake check error output to /dev/null
 	 package.sh: fix INIT a.out updates for knr cc
@@ -715,7 +715,7 @@
 	 package.sh: add $SECONDS to the DEBUG trace prompt
 01-01-01 ratz.c: #ifdef for uwin ncc
 	 iffe.sh,package.sh: check PACKAGE_PATH for local installations
-	 package.sh: add psrinfo for osf.alpha host cpu 
+	 package.sh: add psrinfo for osf.alpha host cpu
 	 package.sh: change pax --meter probe; some hang on /dev/tty
 	 package.sh: fix `install flat ARCH'
 	 mamake: eliminate loops from scan order
@@ -768,7 +768,7 @@
 	 package: fix write delta source to use default pax format
 	 package: add disambiguating bias for sgi.mips3 over sgi.mips4
 	 package.mk: fix for directory content packages lib ast-locale
-00-05-01 iffe: fix invalid _LIB_ macro identifier 
+00-05-01 iffe: fix invalid _LIB_ macro identifier
 00-04-11 C+probe: uniq stdinclude and stdlib, fix usrinclude
 00-04-01 regress: fix explicit OUTPUT bug that didn't compare with expected
 00-03-17 package: all archives are .tgz for binary download
@@ -849,7 +849,7 @@
 98-11-11 regress: fix UNIT PATH lookup
 98-11-01 regress: add PROG
 98-10-01 hostinfo: add unixware.*
-	 use: export PACKAGE_* 
+	 use: export PACKAGE_*
 98-08-11 C.probe: add /usr/include check (for sco CC)
 	 hostinfo: handle uwin uname update
 98-05-01 regress: fix bug sometimes didn't list last test

--- a/src/cmd/ksh93/COMPATIBILITY
+++ b/src/cmd/ksh93/COMPATIBILITY
@@ -34,7 +34,7 @@ omitted features that are completely upward compatible.
 	interpreted literally.  Now it is an ANSI-C string.  You
 	must quote the dollar sign to get the previous behavior.
 	Also, a $ in front of a " indicates that the string needs
-	to be translated for locales other than C or POSIX.  The $ 
+	to be translated for locales other than C or POSIX.  The $
 	is ignored in the C and POSIX locale.
 
 7.	With ksh-88, tilde expansion did not take place inside ${...}.
@@ -55,7 +55,7 @@ omitted features that are completely upward compatible.
 	in your PATH, and you have a program named test in your
 	directory, it will be executed when you type test; the
 	built-in version will be run at the point /bin is found
-	in your PATH. 
+	in your PATH.
 
 11.	Some undocumented combinations of argument passing to ksh
 	builtins no longer works since ksh-93 is getopts conforming
@@ -72,7 +72,7 @@ omitted features that are completely upward compatible.
 14.	If the file name following a redirection symbol contain pattern
 	characters they will only be expanded for interactive shells.
 
-15.	The arguments to a dot script will be restored when it completes. 
+15.	The arguments to a dot script will be restored when it completes.
 
 16.	The list of tracked aliases is not displayed with alias unless
 	the -t option is specified.
@@ -85,7 +85,7 @@ omitted features that are completely upward compatible.
 18.	The ^T directive of emacs mode has been changed to work the
 	way it does in gnu-emacs.
 
-19.	ksh-88 allowed unbalanced parenthes within ${name op val} whereas
+19.	ksh-88 allowed unbalanced parentheses within ${name op val} whereas
 	ksh-93 does not.  Thus, ${foo-(} needs to be written as ${foo-\(}
 	which works with both versions.
 
@@ -100,7 +100,7 @@ omitted features that are completely upward compatible.
 	the end-of-options is reached to conform to the POSIX standard.
 
 23.	Since the POSIX standard requires that octal constants be
-	recongnized, doing arithmetic on typeset -Z variables can
+	recognized, doing arithmetic on typeset -Z variables can
 	yield different results that with ksh-88.  Most of these
 	differences were eliminated in ksh-93o.  Starting in ksh-93u+, the
 	let command no longer recognizes octal constants starting with 0
@@ -109,7 +109,7 @@ omitted features that are completely upward compatible.
 24.	Starting after ksh-93l, If you run ksh name, where name does
 	not contain a /, the current directory will be searched
 	before doing a path search on name as required by the POSIX
-	shell standard.  
+	shell standard.
 
 25.	In ksh-93, cd - will output the directory that it changes
 	to on standard output as required by X/Open.  With ksh-88,

--- a/src/cmd/ksh93/DESIGN
+++ b/src/cmd/ksh93/DESIGN
@@ -46,7 +46,7 @@ Directory layout:
 	The  data/bash_pre_rc.sh is a startup script used when emulating
 	bash if the shell is compiled with SHOPT_BASH and the shell
 	is invoked as bash.  The bash emulation is not complete.
- 
+
 Include directory:
 	1.	argnod.h contains the type definitions for command
 		nodes, io nodes, argument nodes, and for positional
@@ -60,11 +60,11 @@ Include directory:
 		don't fit elsewhere and it includes several other
 		headers.  It defines a structure that contains ksh
 		global data, sh, and a structure that contains per
-		function data, sh.st. 
+		function data, sh.st.
 	4.	edit.h contains definitions that are common to both
 		vi and emacs edit modes.
 	5.	env.h contains an alternative interfaces for creating and
-		modifying environment variables. 
+		modifying environment variables.
 	6.	fault.h contains prototypes for signal related
 		functions and trap and fault handling.
 	7.	fcin.h contains macro and function definitions for

--- a/src/cmd/ksh93/OBSOLETE
+++ b/src/cmd/ksh93/OBSOLETE
@@ -96,7 +96,7 @@ variable should contains the name of this directory.
 They may also
 be specified in the
 .B ENV
-file with the 
+file with the
 .B \-xf
 option of
 .BR typeset .

--- a/src/cmd/ksh93/RELEASE
+++ b/src/cmd/ksh93/RELEASE
@@ -1,5 +1,5 @@
 12-08-01  --- Release ksh93u+ ---
-12-08-01  A bug that ignored interrupts for some builtins (e.g. cmdtst::grep) 
+12-08-01  A bug that ignored interrupts for some builtins (e.g. cmdtst::grep)
 	  that read from stdin has been fixed.
 12-08-01  A bug that interpreted "cd .foo" as "cd foo" has been fixed.
 12-07-30  Added automatic restart for EINTR for ioctl, tcgetattr, and tcsetattr.
@@ -38,7 +38,7 @@
 12-06-19  Tab completion after a / when there is only one match not completes
 	  with that match rather than generating a menu of matches.
 12-06-19  A bug in which patterns containing {...} where not processed
-	  correctly inside ${var/pattern/string} has been fixed.  
+	  correctly inside ${var/pattern/string} has been fixed.
 12-06-18  Code modified to eliminate fts_notify variable.
 12-06-15  Change the .paths plugin/builtin library variable name from
 	  BUILTIN_LIB to PLUGIN_LIB to prevent new plugin_version() aware
@@ -81,12 +81,12 @@
 12-05-24  When the redirection operatory >; is directed to a symlink, it now
 	  overwrites the file named by the link rather than the link.
 12-05-21 +Added printf formats %(type)q where type can be html, url, pattern,
-	  ere, or csv. 
+	  ere, or csv.
 12-05-18  A bug with appending elements to an indexed array has been fixed.
 12-05-18  The exit status from getopts --man interactively was 0 instead of 2
 	  and has been fixed.
 12-05-18  Another bug with SHOPT_EDPREDICT which could cause a core dump has
-	  been fixed.  
+	  been fixed.
 12-05-17  A bug with fixed size arrays which could cause a core dump has been
 	  fixed.
 12-05-17  A bug in which the here-document <<< $(<file) was not processed
@@ -98,10 +98,10 @@
 	  been fixed.
 12-05-15  Fixed a .paths bug in which only the first BUILTIN_LIB assignment worked.
 12-05-14  Arithmetic expressions and subexpressions that are not floating point
-	  now treat -0 as 0, so that $((-0)) is 0 and $((-0.0)) is -0. 
-12-05-11  'unset .sh' now fails with readonly message instead of coredump. 
+	  now treat -0 as 0, so that $((-0)) is 0 and $((-0.0)) is -0.
+12-05-11  'unset .sh' now fails with readonly message instead of coredump.
 12-05-11  A bug which left an associative array arr containing one element in
-	  the wrong state after expanding with ${arr[@]} has been fixed. 
+	  the wrong state after expanding with ${arr[@]} has been fixed.
 12-05-10  A bug in which typeset -f did not display options that called getopts
 	  has been fixed.
 12-05-08  Fixed a number of potential bugs uncovered by valgrind.
@@ -127,8 +127,8 @@
 12-04-23 +The -L option was added to kill.  The -L option is the same as -l
 	  except that without arguments the output format is in the form of
 	  a select menu.
-12-04-23  A bug in which the exit status for an interactive shell was always 
-	  0 has been fixed. 
+12-04-23  A bug in which the exit status for an interactive shell was always
+	  0 has been fixed.
 12-04-20  Entering blank lines interactively no longer resets the exit status.
 12-04-18  A bug in file completion in which the second tab completion on a file
 	  would list the completion rather than inserting the completion has
@@ -202,7 +202,7 @@
 12-03-18  A bug in which unset foo where foo is a name reference to a compound
 	  variable defined inside a function is not unset has been fixed.
 12-03-18  A bug with SHOPT_EDPREDICT which could cause a core dump when the
-	  list of matches became empty has been fixed.  
+	  list of matches became empty has been fixed.
 12-03-15  The assignment, typeset -C foo=(a b c) now generates a syntax
 	  error since a is not an assignment command.
 12-03-16  A bug in which an unset discipline from a variable defined in a
@@ -211,7 +211,7 @@
 	  of two elements rather than an array of one element which is
 	  a compound variable.
 12-03-02 +The vi and emacs edit modes now list all the entries in a directory
-	  when entering a <tab> for completion after a /.  
+	  when entering a <tab> for completion after a /.
 12-03-02  A bug in which a program that exits with value 12 when called
 	  from a command substitution in which standard output has been
 	  redirected caused the shell to hang has been fixed.
@@ -238,7 +238,7 @@
 	  from the KEYBD trap.  Now read options -N, -n, and -t should work
 	  when called from a KEYBD trap.
 12-02-13  If FCEDIT is not set and fc is invoked without the -e option,
-	  ed will be invoked if found instead of /bin/ed. 
+	  ed will be invoked if found instead of /bin/ed.
 12-02-10  Another bug in the saving and restoring of IFS in a subshell
 	  that caused a core dump has been fixed.
 12-02-08  A bug in which .sh.fun disciplines could be cleared after a
@@ -275,11 +275,11 @@
 12-01-01  A timing problem with >; has been fixed.
 12-01-01  A macro expansion memory leak has been fixed.
 11-12-26  A bug in array assignments of the form arr=( $arr[i] ...) in which
-	  arr was not unset before the assignment has been fixed. 
+	  arr was not unset before the assignment has been fixed.
 11-12-20  A number of code changes were made based on the results of errors
 	  indicated by static code analysis.
-11-12-13  In vi edit mode a lteral <TAB> can now be entered by preceding it
-	  with a backshash.
+11-12-13  In vi edit mode a literal <TAB> can now be entered by preceding it
+	  with a backslash.
 11-12-13  When tab is entered for completion after a ' or ", the ' and "
 	  characters are no longer deleted.
 11-12-07  A bug in which a program in the current directory with a . in the
@@ -329,7 +329,7 @@
 11-09-16  The characters ! + - % and @ in file names are no longer escaped with
 	  file name completion.
 11-09-13  The let command no longer treats numbers starting with 0 as octal
-	  constants.  
+	  constants.
 11-09-08  A bug in which printf "%R" could cause a core dump for invalid shell
 	  patterns has been fixed.
 11-08-09  With set -u, ${var#pattern} reported that var was unset for special
@@ -366,7 +366,7 @@
 	  an array instance when the array has been declared a compound variable
 	  array.
 11-05-31  A bug in which typeset -m of an array instance did not remove the
-	  original instance has been fixed. 
+	  original instance has been fixed.
 11-05-28  A bug in which typeset -m dest=src fails when src and are passed as
 	  name references was fixed.
 11-05-28  A bug in which typeset -m "c.board[1][i]=el", where el is a compound
@@ -380,7 +380,7 @@
 11-05-24  A bug in unsetting arrays of compound variables that could lead to
 	  a core dump has been fixed.
 11-05-24  A scoping bug in with typeset -m for variables passed as references
-	  has been fixed. 
+	  has been fixed.
 11-05-09  A bug in which 'typeset +p array[$i]' in a subshell could cause an
 	  exception has been fixed.
 11-05-03  Two more scoping bugs with name references and read -C were fixed.
@@ -409,7 +409,7 @@
 11-04-18  A bug in which name references to array elements could fail has
 	  been fixed.
 11-04-15 +A compile option, SHOPT_2DMATCH, has been added which causes
-	  .sh.match to be a two dimensional array after ${var//pat/str} 
+	  .sh.match to be a two dimensional array after ${var//pat/str}
 	  where the first dimension is the pattern number and the second is
 	  the match instance.
 11-04-11  A bug in which readonly var, where var is exported could cause var
@@ -461,7 +461,7 @@
 11-02-18  A bug in which the value of $0 in a function defined by name()
 	  was changed to name has been fixed.
 11-02-17  A bug in which the declaration typeset var[100] did not work
-	  correctly has been fixed. 
+	  correctly has been fixed.
 11-02-15  A bug in which [[ -v sh.match ]] did not work correctly has been
 	  fixed.
 
@@ -498,7 +498,7 @@
 	  i > ${#var} has been fixed.
 10-12-16 +sleep now treats . as decimal point even in locales that use comma.
 10-12-16 +typeset -M mapname was added to generalize on toupper and tolowwer
-	  mapping as provided with wctrans(). 
+	  mapping as provided with wctrans().
 10-12-10  A bug in which typeset -l displayed namespaces as well as lower case
 	  variables has been fixed.
 10-12-06  A bug in which a pipeline could terminate prematurely for a pipeline
@@ -521,7 +521,7 @@
 10-11-24  A bug in which a name reference is make to arr[0] when arr is not
 	  an array has been fixed.
 10-11-23  If a type definition is made without a compound variable assignment it
-	  produces an error message and no longer shows up as a defined type. 
+	  produces an error message and no longer shows up as a defined type.
 10-11-22  The handling of \ inside [...] for for shell and ~(E) patterns has
 	  been fixed.
 10-11-22  A patch was made to pfsh to handle an error case.
@@ -595,7 +595,7 @@
 	  with no members as an element of a compound variable did not work
 	  has been fixed.
 10-10-08  A bug in which killing the last command in a function defined
-	  with function name, terminated the calling script has been fixed. 
+	  with function name, terminated the calling script has been fixed.
 10-10-08  A bug which could cause a core dump if IFS is unset inside a function
 	  has been fixed.
 10-10-07 +To reduce unwanted side effects, invoking typeset without the export
@@ -605,7 +605,7 @@
 	  character follows it.
 10-10-04  The change for $'...' expansion on 10-08-09 did not expand parameters
 	  contained in the error message and this has been fixed.
-10-10-04  A bug in which a declaration of indexed array (-a_ in a type
+10-10-04  A bug in which a declaration of indexed array (-a) in a type
 	  definition would be displayed as a compound indexed array (-C -a)
 	  has been fixed.
 10-09-30  The C99 math function ldexp has been added.
@@ -658,7 +658,7 @@
 10-08-27 +When running a subshell, the current pool is unset.
 10-08-27  A bug in which jobs started from within for or while lists in
 	  interactive shells could generate completion messages has been fixed.
-10-08-25  Fixed a couple of bugs related to job pools. 
+10-08-25  Fixed a couple of bugs related to job pools.
 10-08-24 +[[ -e /dev/xxx/ ]] can be used to check whether special files of
 	  those names are handled by the shell.
 10-08-24  A bug in the running of a compiled dot script in which only the
@@ -771,7 +771,7 @@
 10-05-27  Rewrote the subshell code to avoid using pipes an many cases.
 10-05-24  Fixed a bug which cause an exception when both -l and -s were
 	  specified with typeset -i.
-10-05-21  Inputting of three dimensional indexed arrays with ( ( (...)...)...) 
+10-05-21  Inputting of three dimensional indexed arrays with ( ( (...)...)...)
           was not working and has been fixed.
 10-05-21  A bug in which adding the attributes -Ai to a variable via a name
 	  reference could cause the value to display incorrectly has been fixed.
@@ -788,7 +788,7 @@
 	  functions in arithmetic expressions has been fixed.
 10-05-19  <<< with an empty string no longer gives an error.
 10-05-19  A bug in arithmetic evaluation when a name reference to an array
-	  instance was used has been fixed. 
+	  instance was used has been fixed.
 10-05-14  A bug in which the shell treats a valid index array assignment,
 	  typeset -a x=(foo (x=3;y=4) bar) as a syntax error has been fixed.
 10-05-13  A bug in creating name references to associative array variable
@@ -838,7 +838,7 @@
 10-04-15  A bug which caused scripts containing user defined math functions to
 	  fail to compile with shcomp has been fixed.
 10-04-15 +Job pools have been added with the SHOPT_COSHELL compilation option.
-	  A job pool allows a collection of background jobs to run either locally 
+	  A job pool allows a collection of background jobs to run either locally
 	  or remotely and to be managed as a unit.  The command '& name ...'
 	  creates or uses a named job pool for subsequent background jobs.
 	  kill, wait, and jobs allow the pool name as operands.
@@ -954,7 +954,7 @@
 	  overwrite the prompt.
 09-11-17 +Change .paths parse to handle BUILTIN_LIB=foo BUILTIN_LIB=foo-1.2.
 09-11-17  Inside a function, typeset foo.bar will bind foo to global variable
-	  foo if local variable foo does not exist, instead of creating a 
+	  foo if local variable foo does not exist, instead of creating a
 	  local variable.
 09-11-17  "read -n1" from the terminal has been fixed to read exactly one character.
 09-11-11  Job control now works for subshell commands, (...).
@@ -988,7 +988,7 @@
 09-09-17  A bug in which unsetting SVLVL could cause a script invoked by
 	  name without #! to core dump has been fixed.
 09-09-16  A bug in which a pipeline in a here-document could hang when the
-	  pipefail option was on has been fixed. 
+	  pipefail option was on has been fixed.
 09-09-09  A bug in the processing of line joining in here documents which
 	  occurred when a buffer began with <escape><new-line> has been fixed.
 09-09-09 +A leading ; with commands in a brace group or parenthesis group
@@ -1032,7 +1032,7 @@
 	  type variables when reference with a name reference has been fixed.
 09-08-10  Several memory leaks were fixed primarily related to subshells.
 09-08-06  A bug in which setting the trap on CHLD to ignore could cause
-	  a script to hang has been fixed. 
+	  a script to hang has been fixed.
 09-07-08  A bug in the processing of name reference assignments when it
 	  contained pattern expansions with quoting has been fixed.
 09-06-22 +The default width for typeset -X has been changed so that there
@@ -1064,7 +1064,7 @@
 	  would be listed with trap -p.
 09-06-12  A bug in vi edit mode in which hitting the up arrow key at the
 	  end of a line longer than 40 characters which caused a core dump
-	  has been fixed. 
+	  has been fixed.
 09-06-11  A bug in which "eval non-builtin &" would create two processes,
 	  one for the & and another for non-builtin has been fixed.
 09-06-08  When var is an identifier and is unset, ${var} no longer tries to
@@ -1278,7 +1278,7 @@
 	  the same array.
 08-09-09  The exit status of 2 from the DEBUG trap causes the next command
 	  to be skipped.  An exit value of 255 from a DEBUG trap called from
-	  a function causes the function to return. 
+	  a function causes the function to return.
 08-09-08  A bug in which a coprocess created in a subshell that did not
 	  complete when the subshell terminated could prevent a coprocess
 	  from being created in the parent shell has been fixed.
@@ -1294,13 +1294,13 @@
 08-08-25 +For an indexed array, a negative subscript now refers to offsets
 	  from the end so that -1 refers to the last element.
 08-08-24  An alignment error for shorts on 64 bit architectures has been fixed.
-08-08-22  If oldvar is a compound variable, typeset -C newvar=oldvar creates 
+08-08-22  If oldvar is a compound variable, typeset -C newvar=oldvar creates
 	  newvar as a copy of oldvar.
 08-08-19 +The ALRM signal no longer cause the sleep builtin to terminate.
-08-08-13  When used in an arithmetic expression, the .sh.version variable  
+08-08-13  When used in an arithmetic expression, the .sh.version variable
 	  now produces a number that will be increasing for each release.
 08-08-11  A bug in which type instantiation with a compound assignment in
-	  a dot script in which the type is defined has been fixed. 
+	  a dot script in which the type is defined has been fixed.
 08-08-07 +The -m option has been added to typeset to move or rename a
 	  variable.  Not documented yet.
 08-08-06  A bug in read when used in a loop when a prompt was specified
@@ -1326,7 +1326,7 @@
 08-07-08 +The %B format now outputs compound variables and arrays.  The
 	  alternate flag # can be used to cause output into a single line.
 08-07-03  When the window change signal, WINCH, is received, the current
-	  edit line is redrawn in place. 
+	  edit line is redrawn in place.
 08-07-01  A bug in the handling of shared variables when inside an embedded
 	  type has been fixed.
 08-06-29  A bug in multiline edit mode which occurred when the prompt length
@@ -1386,7 +1386,7 @@
 	  result from an expansion.
 08-05-15  The trap on SIGCLD is no longer triggered by the completion of
 	  the foreground job as with ksh88.
-08-05-14  A bug in the implementation of the editing feature added on 
+08-05-14  A bug in the implementation of the editing feature added on
 	  07-09-19 in emacs mode has been fixed.
 08-05-12  A bug in processing the test built-in with parenthesis has been
 	  fixed.
@@ -1435,7 +1435,7 @@
 	  specific data used by discipline functions.
 08-03-27  A bug in which the terminal group was not given back to the parent
 	  shell when the last part of a pipeline was handled by the parent shell
-	  and the other parts of the pipeline complete has been fixed. 
+	  and the other parts of the pipeline complete has been fixed.
 	  The symptom was that the pipeline became uninterruptible.
 08-03-25  A bug in restricted mode introduced in ksh93s that caused scripts
 	  that did not use #! to executed in restricted mode has been fixed.
@@ -1492,7 +1492,7 @@
 08-01-31  The prefix expansion operator @ has been added.  ${@name}
 	  expands to the type of name or yields the attributes.
 07-11-15  A bug in the macro expander for multibyte characters in which
-	  part of the character contains a file pattern byte has been fixed. 
+	  part of the character contains a file pattern byte has been fixed.
 07-10-03  A bug in which : was not allowed as part of an alias name has been
 	  fixed.
 07-09-26  A bug in which appending a compound variable to a compound variable
@@ -1538,16 +1538,16 @@
 08-01-16  Incomplete arithmetic assignments, for example ((x += )), now
 	  generate an error message.
 08-01-16  A bug in which a set discipline defined for a variable before
-	  an array assignment could cause a core dump has been fixed. 
+	  an array assignment could cause a core dump has been fixed.
 08-01-03  A bug in on some systems in which exit status 0 is incorrectly
-	  returned by a process that catches the SIGCONT signal is stopped 
+	  returned by a process that catches the SIGCONT signal is stopped
 	  and then continued.
 07-12-13  A race condition in which a program that has been stopped and then
 	  continued could loose the exit status has been fixed.
 07-12-12  Code to check for file system out of space write errors for all
 	  writes has been added.
 07-12-11  A bug in the macro expander for multibyte characters in which
-	  part of the character contains a file pattern byte has been fixed. 
+	  part of the character contains a file pattern byte has been fixed.
 07-12-06  A bug in the emacs edit mode when multiline was set that output
 	  a backspace before the newline to the screen has been fixed.
 07-12-04  A bug in which using <n>TAB after a variable name listing expansion
@@ -1629,7 +1629,7 @@
 	  an exit status of 127 when pipefail was enabled has been fixed.
 07-07-09 +The SHOPT_AUDIT compile option has been added for keyboard logging.
 07-06-25  In vi insert mode, ksh no longer emits a backspace character
-	  before the carriage return when the newline is entered. 
+	  before the carriage return when the newline is entered.
 07-06-25  A bug in which pipefail would cause a command to return 0
 	  when the pipeline was the last command and the failure happened
 	  on a component other than the last has been fixed.
@@ -1669,7 +1669,7 @@
 	  the exit status of the stop signal number.
 07-02-26 +M-^L added to emacs mode to clear the screen.
 07-02-26  A bug in which setting a variable readonly in a subshell would
-	  cause an unset error when the subshell completed has been fixed. 
+	  cause an unset error when the subshell completed has been fixed.
 07-02-19 +The format with printf uses the new = flag to center the output.
 07-02-19  A bug in which ksh93 did not allow multibyte characters in
 	  identifier names has been fixed.
@@ -1684,14 +1684,14 @@
 
 06-12-29  --- Release ksh93s  ---
 06-12-29  A bug in which the value of IFS could be changed after a command
-	  substitution has been fixed. 
+	  substitution has been fixed.
 06-12-22 +/dev/(tcp|udp|sctp)/HOST/SEVRICE now handles IPv6 addresses on
 	  systems that provide getaddrinfo(3).
 06-12-19 +A -v option was added to read.  With this option the value of
 	  the first variable name argument will become the default value
-	  when read from a terminal device. 
+	  when read from a terminal device.
 06-11-20  A bug in which "${foo[@]:1}}" expands a null argument (instead of
-	  no argument), when foo[0] is not empty has been fixed. 
+	  no argument), when foo[0] is not empty has been fixed.
 06-11-16  The discipline functions have been modified to allow each subscript
 	  to act independently.  Currently the discipline function will not
 	  be called when called from a discipline function of the same variable.
@@ -1734,7 +1734,7 @@
 	  select condition can be preceded by a semi-colon which will
 	  be ignored when showme is off.  When showme is on, any command
 	  preceded by a colon will be traced but not executed.
-06-08-16 +As a new feature, a leading ~(N) on a pattern has no effect 
+06-08-16 +As a new feature, a leading ~(N) on a pattern has no effect
 	  except when used for file expansion.  In this case if not
 	  matches are found, the pattern is replaced by nothing rather
 	  than itself.
@@ -1756,13 +1756,13 @@
 06-07-20  The ability to use egrep, grep, and fgrep expressions within
 	  shell patterns has been documented.
 06-07-17  A bug with arithmetic command expressions for locales in which
-	  the comma is a thousands separator has been fixed. 
+	  the comma is a thousands separator has been fixed.
 06-07-13 +The default HISTSIZE was increased from 128 to 512.
 06-07-13  A multibyte problem with locales that use shift codes has been fixed.
 06-06-23  A number of bug fixes for command, file, and variable completion
 	  have been mode.
 06-06-20 +Floating point division by zero now yields the constant Inf or -Inf
-	  and floating functions with invalid arguments yield NaN. 
+	  and floating functions with invalid arguments yield NaN.
 06-06-20 +The floating point constants Inf and NaN can be used in arithmetic
 	  expressions.
 06-06-20 +The functions isinf(), isnan(), tanhl() have been added for
@@ -1777,7 +1777,7 @@
 06-06-04  Modified built-in binding so that for systems for which /bin
           and /usr/bin are the same, a builtin bound to /bin will get
 	  selected when either /bin or /usr/bin is scanned.
-06-06-04 +Added literal-next character processing for emacs/gmacs mode. 
+06-06-04 +Added literal-next character processing for emacs/gmacs mode.
 	  This change is not compatible with earlier versions of ksh93
           and ksh88 when the stty lnext is control-v.  The sequence
 	  escape-control-v will display the shell version.
@@ -1787,7 +1787,7 @@
 	  the completion with the corresponding item.
 06-05-19 +Modified arithmetic so that conversions to strings default to
 	  the maximum number of precision digits.
-06-05-16  Bug fixes for multibyte locales. 
+06-05-16  Bug fixes for multibyte locales.
 06-05-10  The =~ operator was added to [[...]] and  [[ string ~= ERE ]]
 	  is equivalent to [[ string == ~(E)ERE ]].
 06-04-25  A bug in the vi edit mode which could cause the shell to core dump
@@ -1800,7 +1800,7 @@
 	  integers.
 06-03-28  A bug in which variables assignment lists before functions
 	  defined with function name were not passed on the functions
-	  invoked by this function has been fixed. 
+	  invoked by this function has been fixed.
 06-03-28  A bug in which name references defined within a function defined
 	  with function  name could not be used with compound variables has
 	  been fixed.
@@ -1808,7 +1808,7 @@
 	  (output) pipe to close before reading from (after writing to)
           it has been fixed.
 06-02-28  A bug in which stopping a job created with the hist builtin command
-	  would create a job that could not be restarted has been fixed.  
+	  would create a job that could not be restarted has been fixed.
 
 06-01-24  --- Release ksh93r  ---
 06-01-24  A bug in which running commands with standard output closed would
@@ -1819,7 +1819,7 @@
 	  the colon was an assignment.
 05-12-24  A bug which could lead to a core dump when elements of a compound
 	  variable were array elements, i.e. foo=(bar=(1 2)), has been fixed.
-05-12-13  An arithmetic bug in which x+=y+=z was not working has been fixed. 
+05-12-13  An arithmetic bug in which x+=y+=z was not working has been fixed.
 05-12-13  An arithmetic bug in which x||y was returning x when x was non-zero
 	  rather than 1 has been fixed.
 05-12-07 +The aliases for integer and float have been changed to use attributes
@@ -1913,7 +1913,7 @@
 05-02-12  A bug in which the lib_init() function for .paths BUILTIN_LIB
 	  libraries was not called has been fixed.
 05-02-06  A bug on some systems in which moving the write end of a co-process
-	  to a numbered file descriptor could cause it to close has been fixed. 
+	  to a numbered file descriptor could cause it to close has been fixed.
 05-02-06  A bug in the vi-edit mode in which the character under the cursor
 	  was not deleted in some cases with the d% directive has been fixed.
 05-02-06  A bug where external builtin stdout/stderr redirection corrupted
@@ -1954,7 +1954,7 @@
 	  'BUILTIN_LIB=libname'.  When a command is searched for this directory,
 	  the shared library named by libname will first be searched for a
 	  built-in version of the command.
-04-09-03  <<< here documents now handle quotes in the word token correctly. 
+04-09-03  <<< here documents now handle quotes in the word token correctly.
 04-08-08 +The maximum size for read -n and and read -N was increased from
 	  4095 to 32M.
 04-08-04 +printf %q was modified so that if an no operand was supplied, no
@@ -1996,7 +1996,7 @@
 04-03-29 +The preset alias source='command .' has been added.
 04-03-29  A bug introduced in ksh93p on some systems in which invoked by
 	  name with #! on the first line would not get the signals handling
-	  initialized correctly has been fixed. 
+	  initialized correctly has been fixed.
 04-03-29  A bug introduced in ksh93p in which a HUP signal received by
 	  a shell that is a session group leader was not passed down to
 	  its children has been fixed.
@@ -2013,10 +2013,10 @@
 04-01-20  A bug in which an unset discipline function could cause a core
 	  dump on some systems has been fixed.
 04-01-12  A bug in which a continue or break called outside a loop from
-	  inside a function defined with name() syntax could affect 
+	  inside a function defined with name() syntax could affect
 	  the invoking function has been fixed.
 04-01-08  If a command name begins with ~, only filename completion will be
-	  attempted rather than pathname completion using the builtin editors. 
+	  attempted rather than pathname completion using the builtin editors.
 04-01-08  A bug in the vi edit mode in which the wrong repeat count on
 	  multiple word replacements with the . directive has been fixed.
 04-01-06  Backspace characters are now handled correctly in prompt strings.
@@ -2027,7 +2027,7 @@
 03-12-15  A bug in which a quoted string ending with an unescaped $ would
 	  delete the ending $ in certain cases has been fixed.
 03-12-05  A bug in which the shell could hang when set -x tracing a command
-	  when an invalid multibyte character is encountered has been fixed. 
+	  when an invalid multibyte character is encountered has been fixed.
 03-12-05  On some systems, if the KEYBD trap is set, then commands that use
 	  the meta key were not processed until return was hit.  This
 	  has been fixed.
@@ -2039,7 +2039,7 @@
 03-12-05 +If ENV is not specified, the shell will default to $HOME/.kshrc
 	  for interactive shells.
 03-11-21  A bug introduced in ksh93o in which the DEBUG trap could get
-	  disabled after it triggered has been fixed. 
+	  disabled after it triggered has been fixed.
 03-11-04  A bug in which using arithmetic prefix operators ++ or -- on a
 	  non-lvalue could cause a core dump has been fixed.
 03-11-04  A bug in which leading zeros were stripped from variable
@@ -2065,7 +2065,7 @@
 03-08-07  A bug in which the KEYBD trap was not being invoked when
 	  characters with the 8th bit set has been fixed.
 03-08-02  A parser bug introduced in ksh93o which caused the character
-	  after () in a Posix function definition to be skipped 
+	  after () in a Posix function definition to be skipped
 	  when reading from standard input has been fixed.
 03-08-01  A bug in which "${foo#pattern}(x)" treated (x) as if it were
 	  part of the pattern has been fixed.
@@ -2111,7 +2111,7 @@
 	  matches all files and any number of directory levels.
 03-05-30  A bug in which the PATH search could give incorrect results when
 	  run from directory foo and PATH contained .:foo:xxx has been fixed.
-03-05-29 +Some changes were made to the code that displays the prompt in edit 
+03-05-29 +Some changes were made to the code that displays the prompt in edit
 	  mode to better handle escape sequences in the prompt.
 03-05-27  I added = to the list of characters that mark the beginning of
 	  a word for edit completion so that filenames in assignments
@@ -2121,7 +2121,7 @@
 03-05-19  A bug in which the output of uname from a command substitution
 	  would go to the standard output of the invoking command when
 	  uname was invoked with a non-standard option has been fixed.
-03-05-19  A job control bug which would cause the shell to exit because 
+03-05-19  A job control bug which would cause the shell to exit because
 	  it hadn't take back the terminal has been fixed.  The bug
 	  could occur when running a function that contained a pipeline
 	  whose last element was a function.
@@ -2129,7 +2129,7 @@
 	  which could cause a pipeline to hang if the first component
 	  completed quickly has been fixed.
 03-05-13 +The read builtin has been modified so that the builtin editors
-	  will not overwrite output from a previous incomplete line. 
+	  will not overwrite output from a previous incomplete line.
 03-05-13  A bug in which the name of an identifier could have the string
 	  .sh. prefixed to it after expanding a variable whose name begins
 	  with .sh. has been fixed.
@@ -2192,7 +2192,7 @@
 03-01-09  A bug in which using ${.sh.match} multiple times could lead to
 	  a memory exception has been fixed.
 03-01-06  A bug in the expansion of ${var/pattern/$string} in the case that
-	  $string contains \digit has been fixed. 
+	  $string contains \digit has been fixed.
 03-01-02 +A -P option was added for systems such as Solaris 8 that support
 	  profile shell.
 03-01-02  For backward compatibility with ksh88, arithmetic expansion
@@ -2215,7 +2215,7 @@
 	  a signal is received so that cleanup can be performed.
 02-10-31 +User applications can now trap the ALRM signal.  Previously,
 	  the ALRM signal was used internally and could not be used
-	  by applications. 
+	  by applications.
 02-10-31  A bug in which signals received while reading from a coprocess
 	  for which traps were set was not handled correctly has been fixed.
 02-10-31  A bug in which a file opened with exec inside a subshell could
@@ -2224,7 +2224,7 @@
 	  take effect has been fixed.
 02-10-21  A bug which could cause a core dump when a local SECONDS variable
 	  is defined in a function has been fixed.
-02-10-15  A bug in which the associate array name operator ${!array[@]}
+02-10-15  A bug in which the associative array name operator ${!array[@]}
 	  could return the same name multiple times has been fixed.
 02-10-15  A bug in which the zero'th element of an associative array was
 	  not getting set when an assignment was made without a subscript
@@ -2241,7 +2241,7 @@
 02-09-27  A bug in which the error message for ${var?message} when var was
 	  null or unset did not contain the variable name var has been fixed.
 02-09-27  A bug in which closing file descriptors 0 through 2 could
-	  cause a subsequent here document to fail has been fixed. 
+	  cause a subsequent here document to fail has been fixed.
 02-09-14  A bug in whence which occurs when the specified name contained
 	  a / has been fixed.
 02-09-14  A bug in the parser for strings of the form name$((expr))=value
@@ -2250,9 +2250,9 @@
 	  an array was treated as an invariant has been fixed.
 02-09-09  A bug in which redirection or closing of a file descriptor between
 	  3 and 9 could cause a subsequent here document to fail has been
-	  fixed. 
+	  fixed.
 02-09-09  A bug in which a background job was not removed from the job list
-	  when a subshell completed has been fixed, for example (prog&). 
+	  when a subshell completed has been fixed, for example (prog&).
 02-09-03  A bug in which an assignment of the form name=(integer x=3)
 	  could be interpreted as an array assignment rather than a
 	  compound variable assignment has been fixed.
@@ -2283,8 +2283,8 @@
 02-06-17  A bug in which background job completion could cause the sleep
 	  builtin to terminate prematurely has been fixed.
 02-06-17  A bug in which the shell could core dump if getopts was called
-	  when the OPTIND variable contained a negative value has been fixed. 
-02-06-10 +The edit mode prompt has been modified to handle escape sequences.  
+	  when the OPTIND variable contained a negative value has been fixed.
+02-06-10 +The edit mode prompt has been modified to handle escape sequences.
 02-06-10  A bug which occurred for interactive shells in which the builtin
 	  cat command was used in command substitution on a file whose
 	  size was larger than PIPE_BUF has been fixed.
@@ -2319,7 +2319,7 @@
 	  by name from within a function has been fixed.
 02-01-08  A bug in which a shell script executed from within a subshell
 	  could cause this script to have an invalid pointer leading
-	  to a memory fault has been fixed. 
+	  to a memory fault has been fixed.
 02-01-07 +Added here documents of the form <<< word (as per zsh) which
 	  is equivalent to << delim\nword\ndelim.
 02-01-07  A bug in which the first word of a compound assignment,
@@ -2331,7 +2331,7 @@
 	  been added.  When this options is set, all commands implemented
 	  in libcmd become shell builtin commands by default.
 02-01-07  A bug in which builtin foo, where foo is already a builtin
-	  would result in the builtin foo getting removed has been fixed. 
+	  would result in the builtin foo getting removed has been fixed.
 02-01-07  A bug which the shell executed a command found in the current
 	  directory when PATH have no valid directories has been fixed.
 01-11-28  The value of $? was not being set when called with exit.
@@ -2364,7 +2364,7 @@
 01-09-27  Two bugs relating to multibyte history searches and to find
 	  have been fixed.
 01-09-27  A bug introduced in ksh93k in which the PATH searching was
-	  not restored after running a command with an assignment list 
+	  not restored after running a command with an assignment list
 	  has been fixed.
 01-09-26  A bug in which a zero filled field was treated as octal when
 	  converted to integer has been fixed.
@@ -2379,7 +2379,7 @@
 	  offsets which cause offsets to be measured from the end.
 01-09-25  Some spelling errors in the documentation were corrected.
 01-09-24 +The /dev/tcp/host/port and /dev/udp/host/port now allow
-	  the ports to be specified by service name. 
+	  the ports to be specified by service name.
 01-09-24 +The change staring with ksh93g in which the the appropriate
 	  library path variable is prepended with a corresponding library
 	  directory has been modified.  With the new method, only the
@@ -2430,7 +2430,7 @@
 	  name references to be treated as invariants has been fixed.
 01-07-09  A bug in which a discipline function applied to a local variable
 	  could cause a shell exception has been fixed.  Discipline
-	  functions can only be specified for global variables. 
+	  functions can only be specified for global variables.
 
 01-06-18  --- Release ksh93l  ---
 01-06-18  A bug in assigning integers larger than can be represented as
@@ -2453,14 +2453,14 @@
 01-05-20 +The shell allows *-(pattern), +-(pattern),  ?-(pattern),
 	  {m,n}-(pattern}, and @-(pattern) to cause the minimal
 	  match of pattern to be selected whenever possible rather
-	  than the maximal (greedy) match. 
+	  than the maximal (greedy) match.
 01-05-20 +The character class [:word:] has been added to patterns.
 	  The word class is the union of [:alnum:] and the character _.
 01-05-20 +Inside (...) pattern groups, the \ character is now treated
 	  specially even when in an enclosing character class.  The
 	  sequences, \w, \d, \s are equivalent to the character classes
 	  word, digit, and space respectively.  The sequences \W, \D,
-	  and \S are their complement sets. 
+	  and \S are their complement sets.
 01-05-20 +The shell now recognizes pattern groups of the form
 	  ~(options:pattern) where options or :pattern can be omitted.
 	  Options use the letters + and - to enable and disable options
@@ -2477,16 +2477,16 @@
 	  performing the completion, expansion, or listing.
 01-05-14  A small memory leak from subshells has been fixed.
 01-05-10  A bug in which open files were not restored after a subshell
-	  that had used exec to replace a file has been fixed. 
-01-05-10 +Redirection to a null file name now generates an error message. 
+	  that had used exec to replace a file has been fixed.
+01-05-10 +Redirection to a null file name now generates an error message.
 01-05-09  The shell now rejects some invalid parameter substitutions that
 	  were previously processed in undefined ways.
 01-05-09  A bug in which the output of select was not flushed before the
-	  read when input did not come from the terminal has been fixed. 
+	  read when input did not come from the terminal has been fixed.
 01-05-08  A bug in which job ids would not be freed for interactive shells
 	  when subshells ran built-ins in the background has been fixed.
 01-05-08 +The FPATH variable now requires an explicit . to cause the
-	  current directory to be treated as a function directory. 
+	  current directory to be treated as a function directory.
 01-05-08  A bug in read -n when echo mode was disabled has been fixed.
 01-05-07  A bug in which function definitions could be listed as part
 	  of the history has been fixed.
@@ -2496,7 +2496,7 @@
 	  for while and until loops.
 01-04-30 +The variable .sh.match is set after each pattern match (# % or /)
 	  in a variable substitution.  The variable .sh.match is an
-	  indexed array with element 0 being the complete match. 
+	  indexed array with element 0 being the complete match.
 	  The array is only valid until the next subsequent pattern
 	  match or until the value of the variable changes which ever
 	  comes first.
@@ -2537,7 +2537,7 @@
 01-04-02  On some systems the wcwith() function was returning a wrong
 	  value for characters and caused characters to be displayed
 	  incorrectly from the shell edit modes.  A work around for
-	  this problem has been added. 
+	  this problem has been added.
 01-03-26  A bug in which valid scripts could produce syntax errors
 	  when run with locales that considered characters such as "'"
 	  to be space characters has been fixed.
@@ -2580,14 +2580,14 @@
 	  it results in null string rather than nothing.
 01-02-02  memory leak problem with local variables in functions fixed.
 01-01-25 +allow arithmetic expressions with float%int and treat them
-	  as ((int)float)%int rather than as an error. 
+	  as ((int)float)%int rather than as an error.
 01-01-19  read -n1 was not working and has been fixed.
 01-01-17 +ksh now handles the case in which a here document in command
 	  substitution $() is terminated by the trailing ).  Previously,
-	  a new-line was needed at the end of the delimiter word. 
+	  a new-line was needed at the end of the delimiter word.
 01-01-02  A bug in which a KEYBD trap would cause a multi-line token
 	  to be processed incorrectly has been fixed.
-00-12-10 +Arithmetic integer constants can now have L and U suffices. 
+00-12-10 +Arithmetic integer constants can now have L and U suffices.
 00-12-10  A bug in the processing of arithmetic expressions with compound
 	  variables when the -n option is on has been fixed.
 00-12-08  A bug in M-f and M-b from emacs mode has been fixed.  This
@@ -2641,10 +2641,10 @@
 	  R replace directive in vi-mode has been fixed.
 00-06-12 +Added variable name completion/expansion/listing  to the set of
 	  completions.  Variable name completions begin with $ or "$ followed
-	  by a letter. 
+	  by a letter.
 00-05-09  --- Release ksh93j  ---
 00-05-09  Modified command substitution to avoid using /tmp files when
-          run on read-only file systems. 
+          run on read-only file systems.
 00-04-17 +Modified printf to handle '%..Xc' and '%..Xs' options where X
 	  is not an alpha character.  Previous versions core dumped with this.
 00-04-10 +Changes to multibyte editing code were made to use standard
@@ -2662,11 +2662,11 @@
 00-03-28  A bug in which the set and trap commands invoked with --name
 	  type arguments would terminate the invoking script  has
 	  been fixed.
-00-03-27  A bug in which the library path variable was not updated  
+00-03-27  A bug in which the library path variable was not updated
 	  correctly on some systems as described in the 'g' point
-	  release has been fixed. 
+	  release has been fixed.
 00-03-07  printf now returns a non-zero exit status when one of
-          its arguments cannot be converted to the given type. 
+          its arguments cannot be converted to the given type.
 00-03-05  The return value and error message for a command that
           was found on the path but was not executable was set
           incorrectly.
@@ -2706,7 +2706,7 @@
 99-03-31  A bug in shcomp for compilation of unary operators with [[...]]
 	  has been fixed.
 99-03-31  A bug in which the value of $? was changed when executing
-	  a keyboard trap has been fixed. 
+	  a keyboard trap has been fixed.
 99-03-31  The handling of SIGCHLD has been changed so that the
 	  trap is not triggered while executing trap commands
 	  to avoid recursive trap calls.
@@ -2752,7 +2752,7 @@
 	  evaluation has been fixed.
 98-04-30  A bug when a name reference with a shorter name than
           the variable it references was the subject of a compound
-	  assignment has been fixed. 
+	  assignment has been fixed.
 98-04-30  A bug which in which assignment to array variables in
 	  a subshell could effect the parent shell has been
 	  fixed.
@@ -2767,7 +2767,7 @@
 	  fixed.
 98-04-30  The default base when not specified with typeset -i is
 	  10 in accordance with the documentation.  Previously,
-	  the value was determined by the first assignment.   
+	  the value was determined by the first assignment.
 98-04-30  A parsing bug in which a # preceded alphanumeric
 	  characters inside a command substitution caused
 	  a syntax error to be reported has been fixed.
@@ -2849,7 +2849,7 @@
           has been revamped.
 96-07-31  Empty command substitutions of the form $() now work.
 	  whence -v foo now gives the correct result after calling
-	  builtin -d foo. 
+	  builtin -d foo.
 96-07-31  A bug in right to left arithmetic assignment for which
 	  the arithmetic expression (( y = x = 1.5 )) did not
 	  yield 1 for y when x was declared typeset -i was fixed.
@@ -2960,7 +2960,7 @@
 95-04-31  Variables that were unset but had attributes such as readonly
 	  and export were not listed with readonly, export and typeset.
 95-04-31  Several problems with signals have been fixed.
-95-04-31  A bug which prevented ulimit -t from working has been fixed. 
+95-04-31  A bug which prevented ulimit -t from working has been fixed.
 	  Also, a bug in which failed ulimits could cause a core dump
 	  has also been fixed.
 95-04-31  A bug in expansion of the form ${name/#pattern/string} and
@@ -3072,7 +3072,7 @@
 94-06-30  If foo is a function, and not a program, then command foo
 	  now reports that foo isn't found rather than invoking foo.
 94-06-30  The previous version incorrectly listed -A as an
-	  invocation option.  The -A option is only for set. 
+	  invocation option.  The -A option is only for set.
 94-06-30  A bug was fixed which caused ksh to loop when execution trace
 	  was enabled and the PS4 prompt required command substitution.
 94-06-30  A bug which could cause the job control switch character

--- a/src/cmd/ksh93/RELEASE88
+++ b/src/cmd/ksh93/RELEASE88
@@ -3,7 +3,7 @@ of ksh.
 
 1.  New features in 12/28/93
     a.	Associative arrays.  The new version of ksh supports both
-        associate arrays and the older indexed arrays with the same
+        associative arrays and the older indexed arrays with the same
 	array syntax.  A new -A option of typeset is used to declare
 	an array to be associative.  As with indexed arrays, $name is
 	equivalent to ${name[0]}.  The prefix operator ! was added
@@ -72,10 +72,10 @@ of ksh.
 	assignment_list can be one of the following:
 	1.  A list of words.  In this case each word is expanded as
 	    in a for list and the resulting items become elements
-	    of the indexed array varname. 
+	    of the indexed array varname.
 	2.  A list of subscript assignments in the form
-	    [subscript]=value.  In this, these elements become 
-	    elements of the associative array varname. 
+	    [subscript]=value.  In this, these elements become
+	    elements of the associative array varname.
 	3.  A list of assignments; simple or compound.  In this
 	    case, each assignment is made to varname.name, where
 	    name is the name of the enclosed assignment.
@@ -103,7 +103,7 @@ of ksh.
 
     h.	On systems that support dynamic loading with dlopen(), it is
 	now possible to add built-in commands at runtime with the
-	a builtin command named builtin. 
+	a builtin command named builtin.
 
     i.	The following builtins have been added:
 	1.  command name [ ... ]
@@ -314,7 +314,7 @@ of ksh.
 	
     n.	The trap command has been changed as follows:
 	1.  Trap names can be either upper case or lower case.
-	2.  Trap -p cause only the specified trap values to be displayed. 
+	2.  Trap -p only causes the specified trap values to be displayed.
 	3.  The value of trap in a subshell will be the value in the parent
 	    shell until a call to trap which changes the trap settings has
 	    been made.  Thus, savetraps=$(trap) works as required by the
@@ -339,7 +339,7 @@ of ksh.
 	uses for the given command name to be reported.
 
     u.  unalias has -a option to clear all the aliases.
- 
+
     v.	The times built-in command has been removed.  The time
 	reserved word, without a command, gives time cumulative
 	time for the shell and its children.  A built-in alias

--- a/src/cmd/ksh93/RELEASE93
+++ b/src/cmd/ksh93/RELEASE93
@@ -1,5 +1,5 @@
 This is a list of changes that have been made since the 12/28/93 version
-of ksh. 
+of ksh.
 
 1.	New features in 12/28/93b
 	a.  If IFS contains two consecutive identical characters belonging
@@ -65,7 +65,7 @@ of ksh.
 	f.  If foo is a function, and not a program, then command foo
 	    now reports that foo isn't found rather than invoking foo.
 	g.  The previous version incorrectly listed -A as an
-	    invocation option.  The -A option is only for set. 
+	    invocation option.  The -A option is only for set.
 	h.  A bug was fixed which caused ksh to loop when execution trace
 	    was enabled and the PS4 prompt required command substitution.
 	i.  A bug which could cause the job control switch character
@@ -179,7 +179,7 @@ of ksh.
 	n.  Variables that were unset but had attributes such as readonly
 	    and export were not listed with readonly, export and typeset.
 	o.  Several problems with signals have been fixed.
-	p.  A bug which prevented ulimit -t from working has been fixed. 
+	p.  A bug which prevented ulimit -t from working has been fixed.
 	    Also, a bug in which failed ulimits could cause a core dump
 	    has also been fixed.
 	q.  A bug in expansion of the form ${name/#pattern/string} and
@@ -225,7 +225,7 @@ of ksh.
 11.	Bugs fixed in 12/28/93e for default OPTIONS
 	a.  Empty command substitutions of the form $() now work.
 	b.  whence -v foo now gives the correct result after calling
-	    builtin -d foo. 
+	    builtin -d foo.
 	c.  A bug in right to left arithmetic assignment for which
 	    the arithmetic expression (( y = x = 1.5 )) did not
 	    yield 1 for y when x was declared typeset -i was fixed.
@@ -247,7 +247,7 @@ of ksh.
 	j.  A bug that caused side effects in subscript evaluation
 	    when tracing was enabled for subscripts using ++ or --
 	    has been fixed.
-	k.  To conform to the Posix standard getopts has been changed
+	k.  To conform to the POSIX standard getopts has been changed
 	    so that the option char is set to ? when it returns with
 	    a non-zero exit status.
 	l.  The handling of \} inside ${name...} has been fixed so
@@ -333,7 +333,7 @@ of ksh.
 	    evaluation has been fixed.
 	d.  A bug when a name reference with a shorter name than
             the variable it references was the subject of a compound
-	    assignment has been fixed. 
+	    assignment has been fixed.
 	e.  A bug which in which assignment to array variables in
 	    a subshell could effect the parent shell has been
 	    fixed.
@@ -348,7 +348,7 @@ of ksh.
 	    fixed.
 	m.  The default base when not specified with typeset -i is
 	    10 in accordance with the documentation.  Previously,
-	    the value was determined by the first assignment.   
+	    the value was determined by the first assignment.
 	n.  A parsing bug in which a # preceded alphanumeric
 	    characters inside a command substitution caused
 	    a syntax error to be reported has been fixed.
@@ -362,7 +362,7 @@ of ksh.
 	a.  I bug in shcomp for compilation of unary operators with [[...]]
 	    has been fixed.
 	b.  A bug in which the value of $? was changed when executing
-	    a keyboard trap has been fixed. 
+	    a keyboard trap has been fixed.
 	c.  The handling of SIGCHLD has been changed so that the
 	    trap is not triggered while executing trap commands
 	    to avoid recursive trap calls.
@@ -449,7 +449,7 @@ of ksh.
 	    or built-in.
 	k.  A callback function can be installed which will give
 	    notification of file duplications and file closes.
-	    
+
 18.	Incompatibilities with 12/28/93 version.
 	None intentional.
 

--- a/src/cmd/ksh93/TYPES
+++ b/src/cmd/ksh93/TYPES
@@ -92,7 +92,7 @@ can be used.  Unlike (and ) which are always special, the { and } are
 reserved words and require the space after { and a newline or ; before }.
 Unlike $(), the ${ ;} command substitution executes the command in
 the current shell context saving the need to save and restore
-changes, therefore also allowing side effects. 
+changes, therefore also allowing side effects.
 
 When trying to expand an element of a type, if the element does not exist,
 ksh will look for a discipline function with that name and treat this as if

--- a/src/cmd/ksh93/builtins.mm
+++ b/src/cmd/ksh93/builtins.mm
@@ -464,7 +464,7 @@ be freed before returning from you built-in, because by default,
 \f5ksh\fP will terminate you built-in in the event of an
 interrupt and the memory will not be freed.
 .P
-The best way to to allocate variable sized storage is
+The best way to allocate variable sized storage is
 through calls to the \fBstak\fP library
 which is included in \fBlibast\fP
 and which is used extensively by \f5ksh\fP itself.

--- a/src/cmd/ksh93/edit/vi.c
+++ b/src/cmd/ksh93/edit/vi.c
@@ -292,7 +292,7 @@ int ed_viread(void *context, int fd, register char *shbuf, int nchar, int reedit
 	    {
 		register int c = shbuf[0];
 
-		/*** Save and remove the last character if its an eol, ***/
+		/*** Save and remove the last character if it's an eol, ***/
 		/* changing '\r' to '\n' */
 
 		if( i == 0 )

--- a/src/cmd/ksh93/sh.1
+++ b/src/cmd/ksh93/sh.1
@@ -93,7 +93,7 @@ command interpreter
 .if \nZ=0 .IR sh ;
 .if \nZ=1 .IR ksh ;
 .if \nZ=2 .IR ksh93 ;
-it is used to to execute commands with the attributes specified by
+it is used to execute commands with the attributes specified by
 the user's profiles (see
 .IR pfexec (1)).
 See
@@ -106,7 +106,7 @@ A
 is one of the following characters:
 .PP
 .RS
-\f3;   &   (   )   \(bv   <   >   new-line   space   tab\fP
+\f3;   &   (   )   |   <   >   new-line   space   tab\fP
 .RE
 .PP
 A
@@ -197,7 +197,7 @@ A
 is a sequence of one or more
 .I commands\^
 separated by
-.BR \(bv .
+.BR | .
 The standard output of each command but the last
 is connected by a
 .IR pipe (2)
@@ -224,29 +224,29 @@ pipelines
 separated by
 .BR ; ,
 .BR & ,
-.BR \(bv& ,
+.BR |& ,
 .BR && ,
 or
-.BR \(bv\|\(bv ,
+.BR |\|| ,
 and optionally terminated by
 .BR ; ,
 .BR & ,
 or
-.BR \(bv& .
+.BR |& .
 Of these five symbols,
 .BR ; ,
 .BR & ,
 and
-.B \(bv&
+.B |&
 have equal precedence,
 which is lower than that of
 .B &&
 and
-.BR \(bv\|\(bv .
+.BR |\|| .
 The symbols
 .B &&
 and
-.B \(bv\|\(bv
+.B |\||
 also have equal precedence.
 A semicolon
 .RB ( ; )
@@ -256,7 +256,7 @@ causes asynchronous execution of the preceding pipeline (i.e., the shell does
 .I not\^
 wait for that pipeline to finish).
 The symbol
-.B \(bv&
+.B |&
 causes asynchronous execution of the preceding pipeline
 with a two-way pipe established to the parent shell;
 the standard input and output of the spawned pipeline
@@ -278,7 +278,7 @@ and
 described later.
 The symbol
 .B &&
-.RB (\| \(bv\|\(bv \^)
+.RB (\| |\|| \^)
 causes the
 .I list\^
 following it to be executed only if the preceding
@@ -421,7 +421,7 @@ displaying the
 .B PS3
 prompt for the next selection.
 .TP
-\f3case\fP \f2word\^\fP \f3in\fP \*(OK \*(OK\f3(\fP\*(CK\f2pattern\^\fP \*(OK \(bv \f2pattern\^\fP \*(CK .\|.\|. \f3)\fP \f2list\^\fP \f3;;\fP \*(CK .\|.\|. \f3esac\fP
+\f3case\fP \f2word\^\fP \f3in\fP \*(OK \*(OK\f3(\fP\*(CK\f2pattern\^\fP \*(OK | \f2pattern\^\fP \*(CK .\|.\|. \f3)\fP \f2list\^\fP \f3;;\fP \*(CK .\|.\|. \f3esac\fP
 A
 .B case
 command executes the
@@ -945,7 +945,7 @@ is a
 .IR variable ,
 one or more digits,
 or any of the characters
-.BR \(** ,
+.BR * ,
 .BR @ ,
 .BR # ,
 .BR ? ,
@@ -1164,7 +1164,7 @@ enclosed in braces.
 If
 .I parameter\^
 is
-.B \(**
+.B *
 or
 .BR @ ,
 then all the positional
@@ -1175,7 +1175,7 @@ are substituted
 If an array
 .I vname\^
 with last subscript
-.B \(**
+.B *
 .BR @ ,
 or for index arrays of the form
 .I sub1\^
@@ -1189,7 +1189,7 @@ elements between
 and
 .I sub2\^
 inclusive (or all elements for
-.B \(**
+.B *
 and
 .BR @ )
 is substituted,
@@ -1203,7 +1203,7 @@ the value of
 If
 .I parameter\^
 is
-.B \(**
+.B *
 or
 .BR @ ,
 the number of positional parameters is substituted.
@@ -1362,11 +1362,11 @@ to prevent the shell from interpreting the operator as
 If
 .I parameter\^
 is
-.B \(**
+.B *
 or
 .BR @ ,
 or is an array name indexed by
-.B \(**
+.B *
 or
 .BR @ ,
 then
@@ -1379,7 +1379,7 @@ A negative
 .I offset\^
 is taken relative to one greater than the highest subscript
 for indexed arrays.
-The order for associate arrays is unspecified.
+The order for associative arrays is unspecified.
 .TP
 .PD 0
 \f3${\fP\f2parameter\^\fP\f3#\fP\f2pattern\^\fP\f3}\fP
@@ -1911,7 +1911,7 @@ The first character of the
 .B IFS
 variable is used to separate arguments for the
 .B
-"$\(**"
+"$*"
 substitution (see
 .I Quoting
 below).
@@ -2399,7 +2399,7 @@ and
 .BR z04cx .
 .SS File Name Generation.
 Following splitting, each field is scanned for the characters
-.BR \(** ,
+.BR * ,
 .BR ? ,
 .BR ( ,
 and
@@ -2455,14 +2455,13 @@ are not treated specially.
 .PD 0
 .RS
 .TP
-.B \(**
+.B *
 Matches any string, including the null string.
 When used for filename expansion,
 if the
 .B globstar
-option is on, two adjacent
-.BR \(** 's
-by itself
+option is on, an isolated pattern of two adjacent
+.BR * 's
 will match all files and zero or more directories
 and subdirectories.
 If followed by a
@@ -2526,11 +2525,11 @@ is a list of one or more patterns separated from each other
 with a
 .B &
 or
-.BR \(bv .
+.BR | .
 A
 .B &
 signifies that all patterns must be matched whereas
-.BR \(bv
+.BR |
 requires that only one pattern be matched.
 Composite patterns can be formed with one or more of the following sub-patterns:
 .PD 0
@@ -2607,7 +2606,7 @@ Each
 is a two character sequence which cannot contain
 .B &
 or
-.BR \(bv .
+.BR | .
 The first
 .I pattern-pair\^
 specifies the starting and ending characters for the match.
@@ -2814,14 +2813,14 @@ in front of a double quoted string will be ignored
 in the "C" or "POSIX" locale, and may cause
 the string to be replaced by a locale specific string otherwise.
 The meaning of
-.B "$\(**"
+.B "$*"
 and
 .B "$@"
 is identical when not quoted or when used as a variable assignment value
 or as a file name.
 However, when used as a command argument,
 .B
-"$\(**"
+"$*"
 is equivalent to
 \f3"$1\fP\f2d\fP\f3\|$2\fP\f2d\fP\|.\|.\|.\f3"\fP,
 where
@@ -2922,7 +2921,7 @@ can be used within an arithmetic expression:
 .if n abs acos acosh asin asinh atan atan2 atanh cbrt ceil copysign cos cosh erf erfc exp exp2 expm1 fabs fpclassify fdim finite floor fma fmax fmin fmod hypot ilogb int isfinite sinf isnan isnormal issubnormal issubordered iszero j0 j1 jn lgamma log log10 log2 logb nearbyint nextafter nexttoward pow remainder rint round scanb signbit sin sinh sqrt tan tanh tgamma trunc y0 y1 yn
 .if t abs   acos   acosh   asin   asinh   atan   atan2   atanh   cbrt   ceil copysign   cos   cosh   erf  erfc   exp   exp2   expm1   fabs   fpclassify fdim   finite   floor  fma   fmax   fmod   j0      j1      jn      hypot   ilogb   int   isfinite   isinf   isnan   isnormal  issubnormal   issubordered   iszero lgamma   log   log10 log2   logb   nearbyint   nextafter   nexttoward  pow   rint   round   scalb   signbit sin   sinh   sqrt   tan   tanh   tgamma   trunc   y0      y1      yn
 .if t .RE
-In addition, arithmetic functions can be define as shell functions with a
+In addition, arithmetic functions can be defined as shell functions with a
 variant of the
 .B function
 .I name\^
@@ -2965,7 +2964,7 @@ option causes the expansion to be represented as a floating decimal number
 when it is expanded.
 The
 .B \-X
-option cause the expansion to be represented using the
+option causes the expansion to be represented using the
 .B %a
 format defined by ISO C-99.
 The optional option argument
@@ -3328,7 +3327,7 @@ and
 .I expression2\^
 are both true.
 .TP
-\f2expression1\fP \f3\(bv\(bv\fP \f2expression2\fP
+\f2expression1\fP \f3||\fP \f2expression2\fP
 True, if either
 .I expression1\^
 or
@@ -4430,7 +4429,7 @@ or commands that match a partially entered word.
 When applied to the first word on the line,
 or the first word after a
 .BR ; ,
-.BR \(bv ,
+.BR | ,
 .BR & ,
 or
 .BR ( ,
@@ -5097,7 +5096,7 @@ Cursor backward one word.
 [\f2count\fP]\f3B\fP
 Cursor to preceding blank separated word.
 .TP 10
-[\f2count\fP]\f3\(bv\fP
+[\f2count\fP]\f3|\fP
 Cursor to column
 .IR count .
 .TP 10
@@ -5631,7 +5630,7 @@ A built-in specified by a pathname will only be executed when that pathname
 would be found during the path search.  Built-ins found in libraries loaded
 via the
 .B .paths
-file will be associate with the pathname of the directory containing the
+file will associate with the pathname of the directory containing the
 .B .paths
 file.
 .P
@@ -5959,7 +5958,7 @@ Does nothing, and exits 1. Used with
 for infinite loops.
 .TP
 .PD 0
-\f3fc\fP \*(OK \f3\-e\fP \f2ename\^\fP \ \*(CK \*(OK \f3\-nlr\^\fP \*(CK \*(OK \f2first\^\fP \*(OK \f2last\^\fP \*(CK \*(CK
+\f3fc\fP \*(OK \f3\-e\fP \f2ename\^\fP \ \*(CK \*(OK \f3\-N\fP \f2num\^\fP \*(CK \*(OK \f3\-nlr\^\fP \*(CK \*(OK \f2first\^\fP \*(OK \f2last\^\fP \*(CK \*(CK
 .TP
 \f3fc \-s \fP \*(OK \f2old\fP\f3\=\fP\f2new\^\fP \*(CK \*(OK \f2command\^\fP \*(CK
 .PD
@@ -6128,7 +6127,7 @@ option empties the hash table. This can also be achieved by resetting
 .BR PATH.
 .TP
 .PD 0
-\f3hist\fP \*(OK \f3\-e\fP \f2ename\^\fP \ \*(CK \*(OK \f3\-nlr\^\fP \*(CK \*(OK \f2first\^\fP \*(OK \f2last\^\fP \*(CK \*(CK
+\f3hist\fP \*(OK \f3\-e\fP \f2ename\^\fP \ \*(CK \*(OK \f3\-N\fP \f2num\^\fP \*(CK \*(OK \f3\-nlr\^\fP \*(CK \*(OK \f2first\^\fP \*(OK \f2last\^\fP \*(CK \*(CK
 .TP
 \f3hist \-s \fP \*(OK \f2old\fP\f3\=\fP\f2new\^\fP \*(CK \*(OK \f2command\^\fP \*(CK
 .PD
@@ -6201,8 +6200,15 @@ The resulting command is executed
 after the optional substitution
 \f2old\^\fP\f3=\fP\f2new\^\fP
 is performed.
+The option
+.B \-N
+causes
+.BR hist
+to start
+.I num
+commands back.
 .TP
-\f3history\fP \*(OK \f3\-nr\^\fP \*(CK \*(OK \f2first\^\fP \*(OK \f2last\^\fP \*(CK \*(CK
+\f3history\fP \*(OK \f3\-N\fP \f2num\^\fP \*(CK \*(OK \f3\-nr\^\fP \*(CK \*(OK \f2first\^\fP \*(OK \f2last\^\fP \*(CK \*(CK
 Lists commands in the history file.
 The same as
 .BR hist\ \-l .
@@ -6412,7 +6418,7 @@ The
 option causes the
 arguments to be written onto the pipe
 of the process spawned with
-.B \(bv&
+.B |&
 instead of standard output.
 The
 .B \-v
@@ -6708,7 +6714,7 @@ option causes the input line
 to be taken from the input pipe
 of a process spawned by the shell
 using
-.BR \(bv& .
+.BR |& .
 If the
 .B \-s
 option is present,
@@ -6838,10 +6844,6 @@ is used, the variable
 is not unset first.
 .TP 8
 .B \-B
-Enable brace pattern field generation.
-This is the default behavior.
-.TP 8
-.B \-B
 Enable brace group expansion.  On by default.
 .TP 8
 .B \-C
@@ -6850,12 +6852,12 @@ Prevents redirection
 from truncating existing files.
 Files that are created are opened with the O_EXCL mode.
 Requires
-.B >\(bv
+.B >|
 to truncate a file when turned on.
 .TP 8
 .B \-G
 Causes the pattern
-.B \(**\(**
+.B **
 by itself to match files and zero or more directories and sub-directories
 when used for file name generation.
 If followed by a
@@ -6876,7 +6878,7 @@ state rather than waiting for the next prompt.
 .TP 8
 .B \-e
 Unless contained in a
-.B \(bv\(bv
+.B ||
 or
 .B &&
 command, or the command following an
@@ -7086,7 +7088,7 @@ Sort the positional parameters lexicographically.
 Treat unset parameters as an error when substituting.
 .B "$@"
 and
-.B "$\(**"
+.B "$*"
 are exempt.
 .TP 8
 .B \-v
@@ -7152,10 +7154,22 @@ can be any arithmetic expression that evaluates to a non-negative
 number less than or equal to
 .BR $# .
 .TP
-\f3sleep\fP \f2seconds\^\fP
+\f3sleep\fP \*(OK \f3\-s\^\fP \*(CK \f2duration\^\fP
 Suspends execution for the number of decimal seconds or fractions of a
 second given by
-.IR seconds .
+.IR duration .
+.I duration
+can be an integer, floating point value or ISO 8601 duration specifying
+the length of time to sleep.
+The option
+.B \-s
+causes the sleep builtin to terminate when it receives any signal.
+If
+.I duration
+is not specified in conjunction with
+.BR \-s ,
+.BR sleep
+will wait for a signal indefinitely.
 .TP
 \f3source\fP \f2name\^\fP \*(OK \f2arg\^\fP .\|.\|. \*(CK
 Same as
@@ -7318,7 +7332,7 @@ Does nothing, and exits 0. Used with
 .B while
 for infinite loops.
 .TP
-\f3type\fP \*(OK \f3\-afp\fP \*(CK \f2name\^\fP .\|.\|.
+\f3type\fP \*(OK \f3\-afpq\fP \*(CK \f2name\^\fP .\|.\|.
 The same as
 .BR whence\ \-v .
 .TP
@@ -7703,7 +7717,7 @@ that have attributes
 are printed.
 .RE
 .TP
-\f3ulimit\fP \*(OK \f3\-HSacdfmnpstv\fP \*(CK \*(OK \f2limit\^\fP \*(CK
+\f3ulimit\fP \*(OK \f3\-HSaMctdfxlqenupmrbiswTv\fP \*(CK \*(OK \f2limit\^\fP \*(CK
 Set or display a resource limit.
 The available resource limits are listed below.
 Many systems do not support one or more of these limits.
@@ -7742,15 +7756,30 @@ name and unit is printed before the value.
 .B \-a
 Lists all of the current resource limits.
 .TP
+.B \-b
+The socket buffer size in bytes.
+.TP
 .B \-c
 The number of 512-byte blocks on the size of core dumps.
 .TP
 .B \-d
 The number of K-bytes on the size of the data area.
 .TP
+.B \-e
+The scheduling priority.
+.TP
 .B \-f
 The number of 512-byte blocks on files that can be written by the
 current process or by child processes (files of any size may be read).
+.TP
+.B \-i
+The signal queue size.
+.TP
+.B \-l
+The locked address space in K-bytes.
+.TP
+.B \-M
+The address space limit in K-bytes.
 .TP
 .B \-m
 The number of K-bytes on the size of physical memory.
@@ -7761,14 +7790,32 @@ The number of file descriptors plus 1.
 .B \-p
 The number of 512-byte blocks for pipe buffering.
 .TP
+.B \-q
+The message queue size in K-bytes.
+.TP
+.B \-r
+The max real time priority.
+.TP
 .B \-s
 The number of K-bytes on the size of the stack area.
+.TP
+.B \-T
+The number of threads.
 .TP
 .B \-t
 The number of CPU seconds to be used by each process.
 .TP
+.B \-u
+The number of processes.
+.TP
 .B \-v
 The number of K-bytes for virtual memory.
+.TP
+.B \-w
+The swap size in K-bytes.
+.TP
+.B \-x
+The number of file locks.
 .PD
 .PP
 If no option is given,
@@ -7883,7 +7930,7 @@ See
 for a description of the format of
 .IR job .
 .TP
-\f3whence\fP \*(OK \f3\-afpv\fP \*(CK \f2name\^\fP .\|.\|.
+\f3whence\fP \*(OK \f3\-afpqv\fP \*(CK \f2name\^\fP .\|.\|.
 For each
 .IR name ,
 indicate how it
@@ -7907,6 +7954,14 @@ The
 option turns off the
 .B \-v
 option.
+The
+.B \-q
+option causes
+.BR whence
+to enter quiet mode.
+.BR whence
+will return zero if all arguments are built-ins, functions, or
+are programs found on the path.
 The
 .B \-a
 option
@@ -8251,7 +8306,7 @@ command to correct this situation.
 Some very old shell scripts contain a
 .B ^
 as a synonym for the pipe character
-.BR \(bv .
+.BR | .
 .PP
 Using the
 .B hist\^

--- a/src/cmd/ksh93/sh/name.c
+++ b/src/cmd/ksh93/sh/name.c
@@ -3522,7 +3522,7 @@ void nv_setref(register Namval_t *np, Dt_t *hp, int flags)
 
 /*
  * get the scope corresponding to <index>
- * whence uses the same values as lseeek()
+ * whence uses the same values as lseek()
  */
 Shscope_t *sh_getscope(int index, int whence)
 {

--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -3024,7 +3024,7 @@ Sfdouble_t sh_mathfun(Shell_t *shp,void *fp, int nargs, Sfdouble_t *arg)
 /*
  * This routine is used to execute the given function <fun> in a new scope
  * If <fun> is NULL, then arg points to a structure containing a pointer
- *  to a function that will be executed in the current environment.
+ * to a function that will be executed in the current environment.
  */
 int sh_funscope(int argn, char *argv[],int(*fun)(void*),void *arg,int execflg)
 {

--- a/src/cmd/ksh93/tests/basic.sh
+++ b/src/cmd/ksh93/tests/basic.sh
@@ -601,7 +601,7 @@ then	actual=$(
 		"(expected $(printf %q "$expect"), got $(printf %q "$actual"))"
 fi
 
-#"======
+# ======
 # Expansion of multibyte characters after expansion of single-character names $1..$9, $?, $!, $-, etc.
 function exptest
 {

--- a/src/lib/libast/README
+++ b/src/lib/libast/README
@@ -34,7 +34,7 @@ hash:			generic, scoped hash table support
 
 include/ast:		libast support headers
 
-	align.h		compile time type alignmnent support
+	align.h		compile time type alignment support
 	dirent.h	POSIX directory(3) interface definitions
 	error.h		error() interface definitions
 	ftw.h		ftwalk() interface definitions

--- a/src/lib/libast/RELEASE
+++ b/src/lib/libast/RELEASE
@@ -1,7 +1,7 @@
 12-07-25 pathprobe.c: fix read() loop to handle EINTR
 12-06-28 vmalloc/malloc.c: use sbrk() unless VMALLOC_OPTIONS=mmap or asoinit(0,0,0)!=0 (workaround until next malloc update)
 12-06-28 aso/aso.c: asoinit(0,0,0): 0: no specific init, 1: app initialized
-12-06-27 sfio/sfvprintf.c: allow { L* z* } aliases for I* -- posix will probably pick one
+12-06-27 sfio/sfvprintf.c: allow { L* z* } aliases for I* -- POSIX will probably pick one
 12-06-26 regex/regnexec.c: fix uninitialized variable reference
 12-06-26 comp/setlocale.c: utf8_wctomb() now calls (the correct) wc2utf8()
 12-06-25 string/chresc.c: accept \u[U+<hex>] and \u{U+<hex>}
@@ -10,7 +10,7 @@
 12-06-18 sfio/_sfopen.c: add 'e' => O_CLOEXEC
 12-06-18 features/fcntl.c: add #define O_CLOEXEC 0 if not defined
 12-06-13 features/float: handle __mips c99 peculiarities
-12-06-13 features/standards: handle __MACH__ posix peculiarities
+12-06-13 features/standards: handle __MACH__ POSIX peculiarities
 12-06-08 sfio/sfclose.c,sfmode.c: sfclose() for sfopopen() stream returns sh-compatible $?
 12-06-08 comp/strtold.c: fix header botch that missed ldexpl() prototype -- ouch
 12-06-06 misc/proclib.h: partially undo <ast_standards.h> for leaked ancient bsd-isms
@@ -143,7 +143,7 @@
 10-08-11 misc/conformance.c: check ast_env_serial for dynamic astconf() changes
 10-08-11 port/lcgen.c: remember to fudge Table_t.count for synthesized entries
 10-08-04 include/ast.h,comp/setlocale.c: add { debug C.UTF-8 } mbalpha() mbwidth()
-10-08-02 misc/translate.c: add NLSPATH message cache check 
+10-08-02 misc/translate.c: add NLSPATH message cache check
 10-07-29 string/fmtint.c: fix nasty bug that rendered "1000" as "1"
 10-07-27 setlocale,lsgen,localeconv: handle C vs C_EU decimal thousands sep
 10-07-26 misc/optget.c: fix interaction with nested plugin/builtin calls
@@ -213,7 +213,7 @@
 10-01-01 ast_std.h: add { AST_LC_internal AST_LC_setenv }
 09-12-24 comp/setlocale.c: fix setlocale(LC_ALL,"") when already initialized
 09-12-17 misc/optget.c: handle mixed solaris usage="x:f:(in)yo:(out)"
-09-12-11 regex/regcomp.c: posix semantics for [z-a]
+09-12-11 regex/regcomp.c: POSIX semantics for [z-a]
 09-12-11 regex/regcomp.c: fix BRE/ERE ^^ logic
 09-12-11 regex/regcomp.c: fix regcomb() for REG_LEFT|REG_RIGHT
 09-12-11 regex/regcomp.c: bm complete=0 if REX_END
@@ -304,7 +304,7 @@
 08-07-21 include/glob.h,misc/glob.c: GLOB_STARSTAR only forces lstat on chdir
 08-07-17 sfio: sync with kpv
 08-07-17 misc/optget.c: call astwinsize() each time terminal width required
-08-07-16 sfio/sfvscanf.c: fix %% to skip leading space per posix
+08-07-16 sfio/sfvscanf.c: fix %% to skip leading space per POSIX
 08-07-16 vmalloc/vmbest.c: add VMCHECK=m, VM_mmap to favor mmap() alloc
 08-07-16 features/stdio,stdio/f(read|write).c: size_t return value!! ouch
 08-06-24 tm/tmxfmt.c: fix %z to handle tm_isdst -- doh
@@ -330,7 +330,7 @@
 08-03-06 misc/optget.c: ---* and +++* are now operands
 08-03-06 misc/errorx.c: fix old error_info.translate workaround
 08-02-05 regex/regcomp.c: allow REG_SHELL {,n}... => {0,n}...
-08-02-27 misc/stk.c: top element during allocation relocated to top 
+08-02-27 misc/stk.c: top element during allocation relocated to top
 08-02-18 include/ip6.h,string/strtoip6.c,fmtip6.c: add ipv6 addr support
 08-02-14 regex/regsubexec.c: fix null match (tricky)
 08-02-14 regex/regsubcomp.c: fix SRE to match ksh
@@ -403,12 +403,12 @@
 07-02-14 include/int.h: drop
 07-02-14 include/sfio.h: add SF_WCWIDTH
 07-02-12 comp/conf.sh: fix CONF_LIMIT bug that missed ULONG_MAX etc.
-07-02-12 comp/conf.tab: *LONGLONG* => *LLONG* to match posix
-07-02-12 features/float: *LONGLONG* => *LLONG* to match posix
+07-02-12 comp/conf.tab: *LONGLONG* => *LLONG* to match POSIX
+07-02-12 features/float: *LONGLONG* => *LLONG* to match POSIX
 07-02-12 port/astconf.c: handle CONF_LIMITS_DEF with no deferral
 07-02-12 stdio/vasprintf.c: add trailing '\0' -- doh
 07-02-04 string/fmtelapsed.c: fix naive multi month/year logic
-07-02-02 misc/optget.c: add --??posix for getopts(1)/getopt(3)
+07-02-02 misc/optget.c: add --??POSIX for getopts(1)/getopt(3)
 07-01-26 string/chresc.c: use mbchar()
 07-01-26 misc/optget.c: handle "o:-:" usage for old-style long options
 07-01-22 sfio/sfdisc.c,sfpool.c: handle push on streams with pending peek
@@ -502,7 +502,7 @@
 06-06-27 features/float,sfio/sfcvt.c: fix Nan logic
 06-06-27 port/astmath.c: fix long double isnan() test
 06-06-27 features/map.c: _map_libc for std => _ast_std
-06-06-25 string/strperm.c: handle posix = w.r.t. umask
+06-06-25 string/strperm.c: handle POSIX = w.r.t. umask
 06-06-19 port/mnt.c,features/fs: handle netbsd getmntent api change
 06-06-18 regex/regstat.c: add REG_LITERAL check
 06-06-11 cdt/dtview.c: update from kpv
@@ -750,9 +750,9 @@
 	 vmalloc/malloc.c: _AST_mem_method==_mem_* to force mem get method
 	 sfio/sfputr.c: __ia64 memccpy is bogus -- how many tries do they get?
 	 path/pathshell.c: verify abs path and access(path,X_OK) -- duh
-	 vmalloc/vmhdr.h: add private _Vmessage() for non-sfio ASSERT() 
+	 vmalloc/vmhdr.h: add private _Vmessage() for non-sfio ASSERT()
 	 port/astconf.c: fix bug that always returned the minmax value
-03-06-11 comp/*.c: reorder macro hding for mvs.390 and <ast_map.h> 
+03-06-11 comp/*.c: reorder macro hding for mvs.390 and <ast_map.h>
 	 features/vmalloc: add _lib_brk and _lib_sbrk verification
 	 include/ast_std.h,etc.: add _map_malloc for malloc => _ast_malloc
 	 comp/conf.sh: fix SI_* and *_SI_* macro redefs
@@ -774,7 +774,7 @@
 03-05-24 misc/optget.c: fix (ancient) argv null dereference
 03-05-23 comp/getcwd.c: don't intercept on _WINIX -- unreliable st_ino
 03-05-22 sfio/sfsprintf.c: n<0 => don't append '\0'
-03-05-18 misc/fts.c: re-stat FTS_DP to update nlink/times 
+03-05-18 misc/fts.c: re-stat FTS_DP to update nlink/times
 	 misc/fts.c: add FTSENT.stack to eliminate getlist() recursion
 	 regex/ucs_names.h: use "..." catenation to placate some cc's
 03-05-11 string/strtoi.h: handle "-" "+" "0x" "11#"
@@ -1429,7 +1429,7 @@
 98-06-19 tokscan: add %f %g
 98-06-01 disc/sf*.c: memset(0) after disc malloc()
 98-05-11 strelapsed: y==Y
-	 fts: pathcanon() top list 
+	 fts: pathcanon() top list
 98-04-01 error: error_info.time for all msgs, just after cmd id
 	 error: no sfsync(sfstdin)
 	 sfio: sfpool, Sffmt_t update
@@ -1539,7 +1539,7 @@
 	 sfio.h,stdio.h,ast_common.h: pollution cleanup
 	 magic.c: add | op for switch
 	 Makefile: stdio.h was on both HEADERSRC and HEADERGEN -- don't do that
-	 drop pp:notice to get <sfio.h> ... <ast.h> to work 
+	 drop pp:notice to get <sfio.h> ... <ast.h> to work
 	 regex: add [[:<:]]==\< and [[:>:]]==\> for bsd compat
 	 mime.c: ignore X-* headers while scanning for Content-*
 	 magic.c: check for negative indirect offsets
@@ -1549,7 +1549,7 @@
 	 magic.c: MAGIFILE is now a : file list
 	 mnt.c: another 4.4 bsd fix -- users must include <sys/crap.h>
 	 common: fix _WIN32 chicken&egg with va_copy
-	 sfio: forgot to set f->val along with _Sfi in sfexcept() 
+	 sfio: forgot to set f->val along with _Sfi in sfexcept()
 	 Makefile: add mini target for uwin libmini.a
 	 sfcvt.c: workaround for flaky long double optimizers
 	 features/common: fix to work with va_list==void*
@@ -1562,7 +1562,7 @@
 	 regerror: fix for xopen
 	 getopt: fix for xopen
 	 magic: add ciao virtual database
-	 astconf: posix/strict/xopen implies "standard" conformance
+	 astconf: POSIX/strict/xopen implies "standard" conformance
 	 fs3d.h: hide mount prototype
 	 ast_std.h,mnt.c,features/fs: ncr port tweaks
 96-10-31 version 5.0
@@ -1694,7 +1694,7 @@
 	 oops object / shared library compat with _sfgetl2 _sfgetu2
 95-09-11 add getopt() compatibility
 	 add fstat,lstat,mknod,stat fixes for _x versions in sys/stat.h
-	 add getconf CONFORMANCE - posix for things that aren't ast default
+	 add getconf CONFORMANCE - POSIX for things that aren't ast default
 	 sfio_t.h: #ifndef _SFIO_H #include "sfio.h" #endif
 	 snarf vmalloc from kpv
 95-08-11 fix malloc bug in magic
@@ -1780,7 +1780,7 @@
 	 , treated like :space: between stropt() options
 	 fix procopen() fd dup to ignore self-dups
 	 add library id[] to misc/state.c
-	 add ftwalk(FTW_METAPHYSICAL) for posix -H
+	 add ftwalk(FTW_METAPHYSICAL) for POSIX -H
 	 sfvprintf() now handles balanced () in %()
 	 add tmfmt() with buffer size check to replace tmform()
 	 add fmttime() calling tmfmt() to fit fmt*() mold
@@ -1789,9 +1789,9 @@
 	 add EXTTYPE extended header to tar.h
 95-02-14 sfmove() buffer size overflow fix
 	 add _SFSTDIO_H to sfio.h
-	 rename setenv() to setenviron() -- posix finally decided
+	 rename setenv() to setenviron() -- POSIX finally decided
 	 rename <option.h> opt_* to opt_info.*
-	 update features/unistd.c for _SC_* and _PC_* posix additions
+	 update features/unistd.c for _SC_* and _PC_* POSIX additions
 95-01-19 (char*)uchar cast in fmtesc()
 	 fix hash bucket memory leak in hashlook() [via John Mocenigo]
 	 update strings/strtape()

--- a/src/lib/libast/comp/memmove.c
+++ b/src/lib/libast/comp/memmove.c
@@ -38,7 +38,7 @@ memmove(void* to, const void* from, register size_t n)
 	if (n <= 0)	/* works if size_t is signed or not */
 		;
 	else if (in + n <= out || out + n <= in)
-		return(memcpy(to, from, n));	/* hope it's fast*/
+		return(memcpy(to, from, n));	/* hope it's fast */
 	else if (out < in)
 		do *out++ = *in++; while (--n > 0);
 	else

--- a/src/lib/libast/comp/omitted.c
+++ b/src/lib/libast/comp/omitted.c
@@ -529,7 +529,7 @@ runve(int mode, const char* path, char* const* argv, char* const* envv)
 	 *	(3) /c/(WINNT|WINDOWS)/system32 /c/(WINNT|WINDOWS)
 	 *	(4) the directories on $PATH
 	 * there are no cygwin dlls in (3), so if (1) and (2) fail
-	 * to produce the required dlls its up to (4)
+	 * to produce the required dlls it's up to (4)
 	 *
 	 * the standard allows PATH to be anything once the path
 	 * to an executable is determined; this code ensures that PATH

--- a/src/lib/libast/features/lib
+++ b/src/lib/libast/features/lib
@@ -241,7 +241,7 @@ tst	real_vfork note{ vfork child shares data with parent }end execute{
 	}
 }end
 
-tst	lib_posix_spawn unistd.h stdlib.h spawn.h -Dfork=______fork note{ posix_spawn exists and it works and its worth using }end status{
+tst	lib_posix_spawn unistd.h stdlib.h spawn.h -Dfork=______fork note{ posix_spawn exists, it works and it's worth using }end status{
 	#include <sys/types.h>
 	#include <sys/stat.h>
 	#include <sys/wait.h>
@@ -304,7 +304,7 @@ tst	lib_posix_spawn unistd.h stdlib.h spawn.h -Dfork=______fork note{ posix_spaw
 			NOTE("SIGHUP ignored in parent not ignored in child");
 			_exit(0);
 		}
-		/* must return exec-type errors or its useless to us *unless* there is no [v]fork() */
+		/* must return exec-type errors or it's useless to us *unless* there is no [v]fork() */
 		n = strlen(cmd[0]);
 		if (n >= (sizeof(tmp) - 3))
 		{

--- a/src/lib/libast/man/LIBAST.3
+++ b/src/lib/libast/man/LIBAST.3
@@ -75,7 +75,7 @@ is ANSI, K&R and C++ compatible and includes or defines the equivalent of
 .L <string.h>
 and
 .LR <unistd.h> .
-Other libraries that depend on 
+Other libraries that depend on
 .B libast
 may also have headers installed in the
 .L include/ast

--- a/src/lib/libast/man/aso.3
+++ b/src/lib/libast/man/aso.3
@@ -134,7 +134,7 @@ on the same \f5dest\fP with values, say \fIv1\fP and \fIv2\fP.
 The eventual value in \f5dest\fP
 will be as if \f5*dest += 2\fP was performed in a single-threaded execution.
 
-That should be constrasted with a situation where, instead of \f5asoinc32()\fP or \f5asodec32()\fP,
+That should be contrasted with a situation where, instead of \f5asoinc32()\fP or \f5asodec32()\fP,
 only normal increment (++) or decrement (--) were used.
 Then, the end result could be either \f5*dest += 1\fP or \f5*dest += 2\fP,
 depending on states of the hardware cache and process scheduling.

--- a/src/lib/libast/man/ast.3
+++ b/src/lib/libast/man/ast.3
@@ -76,7 +76,7 @@ is
 then
 \f5"/"\fP
 is used.
-Otherwise if 
+Otherwise if
 .I path
 is not
 .L 0
@@ -136,7 +136,7 @@ command options.
 .TP
 .L UNIVERSE
 .L ucb
-for 
+for
 .I Berkeley
 style and
 .L att
@@ -168,7 +168,7 @@ relative to
 .IR path .
 If
 .I notify
-returns 
+returns
 .L 0
 then the configuration parameter value is not changed.
 .PP
@@ -188,7 +188,7 @@ or
 .L R_OK|W_OK
 then all configuration parameters are listed.
 .L R_OK
-lists the readonly configuration parameters and 
+lists the readonly configuration parameters and
 .L W_OK
 lists the settable configuration parameters.
 .L X_OK

--- a/src/lib/libast/man/cdt.3
+++ b/src/lib/libast/man/cdt.3
@@ -340,7 +340,7 @@ the key as defined by the \f5Dtdisc_t.size\fP field.
 .PP
 .Ss "  Void_t* (*memoryf)(Dt_t* dt, Void_t* addr, size_t size, Dtdisc_t* disc)"
 If not \f5NULL\fP, \f5memoryf\fP is used to allocate and free memory.
-When \f5addr\fP is \f5NULL\fP, a memory segment of size \f5size\fP is requested. 
+When \f5addr\fP is \f5NULL\fP, a memory segment of size \f5size\fP is requested.
 If \f5addr\fP is not \f5NULL\fP and \f5size\fP is zero, \f5addr\fP is to be freed.
 If \f5addr\fP is not \f5NULL\fP and \f5size\fP is positive,
 \f5addr\fP is to be resized to the given size.
@@ -485,7 +485,7 @@ For \f5Dtset\fP, \f5Dtbag\fP, \f5Dtrhset\fP and \f5Dtrhbag\fP,
 objects are ordered by some internal order defined at the time when these
 functions are called.
 
-Objects in a dictionary or a viewpath can be walked using 
+Objects in a dictionary or a viewpath can be walked using
 a \f5for(;;)\fP loop as below.
 .Cs
     for(obj = dtfirst(dt); obj; obj = dtnext(dt,obj))

--- a/src/lib/libast/man/chr.3
+++ b/src/lib/libast/man/chr.3
@@ -57,7 +57,7 @@ is not 0 then
 is set to point to the next character in
 .I s
 on return.
-0 is returned and 
+0 is returned and
 .I e
 is not modified when the end of
 .I s
@@ -77,9 +77,9 @@ value until up to the number of characters in an
 .I int
 is reached.
 This operation is inherently machine-dependent,
-but at least its defined in one place.
+but at least it's defined in one place.
 .PP
-The following 
+The following
 .B \e
 escape sequences are recognized:
 .TP

--- a/src/lib/libast/man/error.3
+++ b/src/lib/libast/man/error.3
@@ -73,7 +73,7 @@ A
 is appended to the message text, so none should appear in the
 .L printf
 format.
-If 
+If
 .I error_info.id
 is not
 .L 0
@@ -92,7 +92,7 @@ returns the
 argument, but on some systems it may do language translation via lookup
 on the original source text.
 .RL ( error
-calls 
+calls
 .L ERROR_translate
 with a 0
 .L flag
@@ -107,7 +107,7 @@ Debug messages are prefixed with
 .BI debug level.
 If
 .I "errno != error_info.last_errno"
-then 
+then
 .I error_info.last_errno
 is set to
 .I errno
@@ -164,7 +164,7 @@ to the message after
 A usage message is emitted.
 .TP
 .L ERROR_PROMPT
-The trailing 
+The trailing
 .I newline
 is suppressed.
 .TP
@@ -179,7 +179,7 @@ The message is from a library routine.
 The elements of the global struct
 .I error_info
 control error output and actions.
-Parts of 
+Parts of
 .I error_info
 can be initialized from the
 .L ERROR_OPTIONS
@@ -192,14 +192,14 @@ options, described below.
 .I "int core"
 If
 .I "error_info.core != 0"
-then 
+then
 .I "level >= error_info.core"
 generates a core dump.
 Initialized by
 .EX
 ERROR_OPTIONS="core=\fIlevel\fP"
 .EE
-where 
+where
 .I level
 can be a number or one of
 .LR error ,
@@ -247,7 +247,7 @@ are defined
 .RL ( _TRACE_
 is defined by
 .I makerules
-when 
+when
 .L CCFLAGS
 contains
 .LR \-g ).
@@ -264,7 +264,7 @@ and
 .L message
 call
 .L liberror
-and 
+and
 .L error
 respectively if
 .IR "error_info.trace<0" .

--- a/src/lib/libast/man/find.3
+++ b/src/lib/libast/man/find.3
@@ -57,18 +57,18 @@ via
 or
 .IR at .
 .PP
-.L findopen 
-returns a handle to a 
+.L findopen
+returns a handle to a
 .I fastfind
-stream for the 
-.I ksh 
+stream for the
+.I ksh
 file pattern
 .IR pattern .
 .L findnext
 returns the next pathname that matches the pattern specified by
 .IR handle .
 .L findnext
-returns 
+returns
 .L 0
 when no more pathnames match the pattern.
 Finally,
@@ -78,7 +78,7 @@ closes the
 stream for
 .IR handle .
 .SH BUGS
-These rotuines are only as good as the
+These routines are only as good as the
 .I fastfind
 information which is in the system administration domain.
 .SH "SEE ALSO"

--- a/src/lib/libast/man/fmt.3
+++ b/src/lib/libast/man/fmt.3
@@ -167,7 +167,7 @@ mode string for the file mode bits in
 .IR mode .
 If
 .I "external != 0"
-then 
+then
 .I mode
 is
 .IR modecanon (3)
@@ -191,7 +191,7 @@ pattern
 .L fmtsignal
 returns the signal name, sans
 .LR SIG ,
-for the signal number 
+for the signal number
 .IR sig .
 If
 .I "sig < 0"

--- a/src/lib/libast/man/fmtls.3
+++ b/src/lib/libast/man/fmtls.3
@@ -51,7 +51,7 @@ formats
 .IR ls (1)
 style file information into the buffer
 .IR buf .
-A pointer to the trailing 0 in 
+A pointer to the trailing 0 in
 .I buf
 is returned.
 .I name
@@ -130,7 +130,7 @@ The user and group fields are each
 .B LS_W_NAME
 characters wide,
 the
-.B LS_INUMBER 
+.B LS_INUMBER
 field is
 .B LS_W_INUMBER
 characters wide,

--- a/src/lib/libast/man/ftwalk.3
+++ b/src/lib/libast/man/ftwalk.3
@@ -114,7 +114,7 @@ The \fIuserf\fP prototype is:
     char*          path;    /* full pathname */
     short          pathlen; /* strlen(path) */
     unsigned short info;    /* type of object */
-    unsigned short status;  /* status of object */ 
+    unsigned short status;  /* status of object */
     short          level;   /* depth of object on the search path */
     short          namelen; /* strlen(name) */
     char           name[];  /* file name of object */
@@ -206,7 +206,7 @@ The \fIcomparf\fP prototype is:
 \fIFtwalk\fR normally returns 0.
 On hard errors such as running out of memory, it returns -1.
 \fIFtwalk\fR may also return other values as discussed with respect
-to \fIuserf\fR. 
+to \fIuserf\fR.
 .PP
 \fIFtwflags\fR returns a combination of \fB0, FTW_META, FTW_PHYSICAL\fR
 according to the

--- a/src/lib/libast/man/getcwd.3
+++ b/src/lib/libast/man/getcwd.3
@@ -49,7 +49,7 @@ char* getcwd(char* \fIbuf\fP, size_t \fIlen\fP);
 .L getcwd
 copies the absolute path name of the current directory info into
 .I buf
-of length 
+of length
 .IR len .
 The return path may be longer than
 .LR PATH_MAX .
@@ -57,10 +57,10 @@ If
 .I "buff == 0"
 then space is allocated via
 .IR malloc (3)
-and 
+and
 .I len
 extra characters are reserved after the generated path name.
-A pointer to the path name is returned, 
+A pointer to the path name is returned,
 .L 0
 on error.
 .SH "SEE ALSO"

--- a/src/lib/libast/man/hash.3
+++ b/src/lib/libast/man/hash.3
@@ -52,7 +52,7 @@ and its
 .IR value .
 A
 .I key
-is a sequence of 
+is a sequence of
 .L char
 elements and a
 .I value
@@ -116,7 +116,7 @@ The number of lookup collisions.
 .RE
 .TP
 .L "Hash_table_t* scope"
-The table that this scope covers, 
+The table that this scope covers,
 .L NULL
 if the table is not a scope.
 .TP
@@ -215,11 +215,11 @@ if
 is specified and
 .IR strcmp (3)
 otherwise.
-The first argument is the 
+The first argument is the
 .I key
-from the current hash bucket on the 
+from the current hash bucket on the
 .I "collision chain"
-and the second argument is the user supplied 
+and the second argument is the user supplied
 .IR key .
 .TP
 .L "HASH_free, (int(*)()) free"
@@ -230,7 +230,7 @@ If
 was set in
 .L hashalloc
 then the hash bucket pointer is passed, otherwise the bucket
-.L value 
+.L value
 pointer is passed.
 .TP
 .L "HASH_hash, (int(*)()) hash"
@@ -275,7 +275,7 @@ Changes the hash table flags by
 .IR or ing
 in
 .LR flags .
-The flags, which may be 
+The flags, which may be
 .IR or ed
 together, are:
 .RS
@@ -321,7 +321,7 @@ in the hash table
 .L tab
 according to
 .L flags
-and 
+and
 .LR value .
 A
 .L Hash_bucket_t
@@ -408,7 +408,7 @@ value is returned.
 For
 .L HASH_LOOKUP
 the bucket
-.L value 
+.L value
 field is returned,
 .L NULL
 if the bucket is not found.
@@ -481,7 +481,7 @@ in the hash table
 .LR tab .
 If
 .L flags
-is 
+is
 .L HASH_NOSCOPE
 then only the top level hash table is used, otherwise the walk includes
 all scope covered tables.
@@ -514,7 +514,7 @@ pointer for a sequential scan on the hash table
 .LR tab .
 If
 .L flags
-is 
+is
 .L HASH_NOSCOPE
 then only the top level hash table is used, otherwise the scan includes
 all scope covered tables.
@@ -534,9 +534,9 @@ If no elements remain then
 is returned.
 .TP
 .L "void hashdone(Hash_position_t* pos)"
-Completes a scan initiated by 
+Completes a scan initiated by
 .L hashscan()
-on 
+on
 .LR pos .
 .TP
 .L "int hashset(Hash_table_t* tab, int flags)"
@@ -567,14 +567,14 @@ may be cleared.
 Dumps hash table accounting info to standard error.
 If
 .L tab
-is 
+is
 .L NULL
 then all allocated hash tables are dumped, otherwise only information on
 .L tab
 is dumped.
 If
 .L flags
-is 
+is
 .L HASH_BUCKET
 then the hash bucket
 .I key-value

--- a/src/lib/libast/man/magic.3
+++ b/src/lib/libast/man/magic.3
@@ -62,7 +62,7 @@ These routines provide an interface to the
 command magic file.
 .L magicopen
 returns a magic session handle that is passed to all of the other routines.
-.I flags 
+.I flags
 may be
 .TP
 .L MAGIC_MIME
@@ -94,13 +94,13 @@ loads the magic file named by
 .I path
 into the magic session.
 .I flags
-are the same as with 
+are the same as with
 .LR magicopen .
 More than one magic file can be loaded into a session;
 the files are searched in load order.
 If
 .I path
-is 
+is
 .L 0
 then the default magic file is loaded.
 .PP
@@ -133,7 +133,7 @@ flag then
 .I st
 is assumed to contain valid stat information, otherwise
 .L magictype
-calls 
+calls
 .L stat
 on
 .IR st .
@@ -150,7 +150,7 @@ However, with the extended format it is possible to write a single
 magic file that works on all platforms.
 Most of the net magic files floating around work with
 .LR magic ,
-but they usually double up on 
+but they usually double up on
 .I le
 and
 .I be
@@ -227,7 +227,7 @@ field is either the offset into the data upon which the current entry operates
 or a file metadata identifier.
 Offsets are either integer constants or offset expressions.
 An offset expression is contained in (...) and is a combination of
-integral arithmetic operators and the 
+integral arithmetic operators and the
 .L @
 indirection operator.
 Indirections take the form
@@ -238,9 +238,9 @@ The size of the indirection value is taken either from one of the suffixes
 .LR H (short, 2 chars),
 .LR L (long, 4 chars),
 pr
-.LR Q (quead, 8 chars),
+.LR Q (quad, 8 chars),
 or from the
-.L type 
+.L type
 field.
 Valid file metadata identifiers are:
 .TP
@@ -372,7 +372,7 @@ field takes the form
 .LI & number
 where
 .I number
-is 
+is
 .I anded
 with the integral value at
 .L offset
@@ -389,13 +389,13 @@ field entries above.
 means any value and applies to all types.
 Integral
 .L type
-expression take the form [\fIoperator\fP] \fIoperand\P where 
+expression take the form [\fIoperator\fP] \fIoperand\P where
 .I operand
 is compared with the data value at
 .L offset
 using
 .IR operator .
-.I operator 
+.I operator
 may be one of
 .LR < .
 .LR <= ,
@@ -407,7 +407,7 @@ or
 defaults to
 .L ==
 if omitted.
-.I operand 
+.I operand
 may be an integral constant or one of the following builtin function calls:
 .TP
 .L magic()
@@ -415,7 +415,7 @@ A recursive call to the magic algorithm starting with the data at
 .LR offset .
 .TP
 \f5loop(\fIfunction\fP,\fIoffset\fP,\fIincrement\fP)\fR
-Call 
+Call
 .I function
 starting at
 .I offset
@@ -447,7 +447,7 @@ then a
 is placed between the descriptions
 (most optional descriptions start with
 .IR comma .)
-The data value at 
+The data value at
 .L offset
 can be referenced in the description using
 .L %s

--- a/src/lib/libast/man/mem.3
+++ b/src/lib/libast/man/mem.3
@@ -62,7 +62,7 @@ and
 may be the same.
 .PP
 .L memdup
-copies the 
+copies the
 .I n
 byte buffer
 .I buf
@@ -86,11 +86,11 @@ and
 may be the same.
 .PP
 .L memzero
-sets the first 
+sets the first
 .I n
 bytes in
 .I buf
-to 
+to
 .IR 0 .
 .SH "SEE ALSO"
 Proposed Bell Laboratories ASCII/EBCDIC standard, April 16, 1979.

--- a/src/lib/libast/man/mime.3
+++ b/src/lib/libast/man/mime.3
@@ -62,7 +62,7 @@ These routines provide an interface to the MIME type database.
 .L mimeopen
 returns a mime session handle that is passed to all of the other routines.
 The
-.I flags 
+.I flags
 argument is currently unused.
 .PP
 .L mimeclose
@@ -93,7 +93,7 @@ More than one mime file can be loaded into a session;
 the files are searched in load order.
 If
 .I path
-is 
+is
 .L 0
 then the default mime file is loaded.
 .PP

--- a/src/lib/libast/man/modecanon.3
+++ b/src/lib/libast/man/modecanon.3
@@ -98,7 +98,7 @@ The traditional bit access macro (\f5S_\fP prefix changes to \f5X_\fP) are:
 and
 .L X_IRWXO .
 .LI X_ITYPE( mode )
-returns the type bits for 
+returns the type bits for
 .IR mode .
 .SH "SEE ALSO"
 pax(1), stat(2)

--- a/src/lib/libast/man/path.3
+++ b/src/lib/libast/man/path.3
@@ -67,7 +67,7 @@ Path buffers are assumed to be of size
 .L <ast.h>
 always defines
 .LR PATH_MAX ,
-even if it indeterminant on the local system.
+even if it's indeterminate on the local system.
 Yes, this was probably a bad choice, but it was made about 10 years ago.
 We will probably move to a <stk.h> based implementation.
 .PP
@@ -80,7 +80,7 @@ with access
 .L mode
 using the
 .L :
-separated directories in 
+separated directories in
 .IR dirs .
 Both
 .I a
@@ -109,11 +109,11 @@ A regular file.
 .L PATH_ABSOLUTE
 Generated path name is rooted at
 .LR / .
-.I path 
+.I path
 is returned, 0 on error.
 .PP
 .L pathbin
-returns a pointer to the 
+returns a pointer to the
 .L :
 separated list of directories to search for executable commands.
 The
@@ -130,7 +130,7 @@ canonicalizes the path
 in place.
 A pointer to the trailing 0 in the canonicalized path is returned.
 A canonical path has:
-redundant 
+redundant
 .L .
 and
 .L /
@@ -156,7 +156,7 @@ Symbolic links are resolved at each component.
 If an error occurs and either of
 .L PATH_DOTDOT
 or
-.L PATH_EXISTS 
+.L PATH_EXISTS
 is set then
 .I path
 will contain the components following the failure point.
@@ -205,7 +205,7 @@ is longer than
 then it is split up into a sequence of relative paths and
 .I chdir
 is called on each of these.
-For any given system, if you got to a directory, then 
+For any given system, if you got to a directory, then
 .L pathcd
 can get you back, modulo permission and link changes.
 .PP
@@ -231,13 +231,13 @@ by converting non-standard dynamic link text to
 converts in the other direction.
 .PP
 .L pathkey
-generates in 
+generates in
 .I key
 a 14 character lookup key (plus terminating 0) for the language
 .I lang
 processor in
 .IR path .
-A poihter to the key is returned, 0 on error.
+A pointer to the key is returned, 0 on error.
 If
 .I "key == 0"
 then space is allocated via
@@ -270,9 +270,9 @@ and the
 environment variable (set by
 .IR ksh (1) )
 are used for related root searching.
-If 
+If
 .I p
-also contains a 
+also contains a
 .L /
 then
 .I ../p
@@ -367,14 +367,14 @@ where the length of
 if !=0, is limited to 5, the length of
 .I <pid>
 (the base 64 representation of the current process id)
-is limited to 3, and 
+is limited to 3, and
 .I <suf>
-(an internally generated suffix that avoid file confilicts)
+(an internally generated suffix that avoid file conflicts)
 is limited to 3.
 The generated path name conforms to the classic UNIX 14 char and the DOS
 .LR 8.3
 limitations.
-Both 
+Both
 .I dir
 and
 .I pfx

--- a/src/lib/libast/man/preroot.3
+++ b/src/lib/libast/man/preroot.3
@@ -92,10 +92,10 @@ In this case
 is set to indicate the error.
 .TP
 .L ispreroot
-Non-zero is returned if 
+Non-zero is returned if
 .I dir
 is the current process preroot.
-If 
+If
 .I dir
 is
 .B 0
@@ -124,7 +124,7 @@ with the process preroot set to
 must be a
 .BR 0 -terminated
 argument array.
-If 
+If
 .I argv
 is
 .B 0

--- a/src/lib/libast/man/proc.3
+++ b/src/lib/libast/man/proc.3
@@ -72,12 +72,12 @@ and flags in
 .IR flags .
 .PP
 .I command
-is searched for using the 
+is searched for using the
 .L PATH
 environment variable from the calling environment.
 If
 .I command
-is 
+is
 .L 0
 then the current shell is used (see
 .IR pathshell (3)).
@@ -85,7 +85,7 @@ If
 .I envv
 is not
 .L 0
-then it is a 
+then it is a
 .L 0
 terminated vector of
 \fIname\fP[=\fIvalue\fP]
@@ -110,9 +110,9 @@ and will appear at the top of the child environment.
 .PP
 If
 .I opv
-is not 
+is not
 .L 0
-then it is a 0 terminaled vector of operations to perform.
+then it is a zero-terminated vector of operations to perform.
 In the following
 .I context
 is a combination of
@@ -131,7 +131,7 @@ is closed in
 \f5PROC_FD_DUP(\fIfrom\fP,\fIto\fP,\fIcontext\fP)\fR
 The file descriptor
 .I from
-is 
+is
 .IR dup (2)'d
 into the file descriptor
 .I to
@@ -155,7 +155,7 @@ in the child context.
 \f5PROC_SYS_PGRP(\fIpgid\fP)\fR
 The child process group is set to
 .IR pgid .
-.I pgid 
+.I pgid
 may have the following values:
 .TP
 .L <0
@@ -190,7 +190,7 @@ when
 is a shell script.
 .TP
 .L PROC_BACKGROUND
-Standard shell 
+Standard shell
 .L &
 setup is done for the child process.
 .TP
@@ -241,7 +241,7 @@ if it is a shell script.
 .L PROC_PRIVELEGED
 If the effective user id is
 .L 0
-then the child real user id is set to 
+then the child real user id is set to
 .L 0
 and the child real group id is set to the effective group id.
 .TP
@@ -274,7 +274,7 @@ The child process id.
 .TP
 .L "pid_t \fIpgrp\fP"
 The child process group.
-.TP 
+.TP
 .L "int \fIrfd\fP"
 A read file descriptor connected to
 .IR command 's
@@ -308,9 +308,9 @@ Presumably some other mechanism will be used to wait for
 .IR proc.pid .
 .PP
 .L procrun
-combines 
+combines
 .L procopen
-and 
+and
 .L procclose
 with the flags
 .L PROC_GID|PROC_UID

--- a/src/lib/libast/man/re.3
+++ b/src/lib/libast/man/re.3
@@ -105,7 +105,7 @@ then the array
 is filled with character pointers to the substrings of
 .I source
 that correspond to the
-parenthesized subexpressions of 
+parenthesized subexpressions of
 .IR pattern :
 .I re\->match[i].sp
 points to the beginning and
@@ -128,12 +128,12 @@ are filled with zeros.
 Matches involving
 .LR * ,
 .LR + ,
-and 
+and
 .L ?
 are extended as far as possible.
 A maximum of 9 subexpressions will be matched.
 The structure of elements of
-.I re\->match 
+.I re\->match
 is:
 .nf
 .ta 8n
@@ -168,7 +168,7 @@ string delimited by
 .LI re\->match[ n ].sp
 and
 .LI re\->match[ n ].ep .
-Each instance of 
+Each instance of
 .L &
 is replaced by the string delimited by
 .I re\->match[0].sp

--- a/src/lib/libast/man/sfio.3
+++ b/src/lib/libast/man/sfio.3
@@ -165,7 +165,7 @@ long       sffmtversion(Sffmt_t* fe, type);
 .ft 5
 Void_t*    sfsetbuf(Sfio_t* f, Void_t* buf, size_t size);
 int        sfsync(Sfio_t* f);
-int        sfpoll(Sfio_t** flist, int n, int timeout); 
+int        sfpoll(Sfio_t** flist, int n, int timeout);
 Sfio_t*    sfpool(Sfio_t* f, Sfio_t* poolf, int mode);
 int        sfpurge(Sfio_t* f);
 .ft 1
@@ -188,7 +188,7 @@ SF_DPUSH
 SF_DPOP
 SF_DPOLL
 SF_DBUFFER
-SF_SYNC	
+SF_SYNC
 SF_PURGE
 SF_FINAL
 SF_READY
@@ -283,7 +283,7 @@ stream pools for automatic data synchronization.
 Applications can extend the \f5sfprintf()/sfscanf()\fP functions
 to define their own conversion patterns as well as redefine existing ones.
 .PP
-A discipline defines analogues of 
+A discipline defines analogues of
 the system calls \f5read(2), write(2)\fP and \f5lseek(2)\fP.
 Such system calls or their discipline replacements are used to process stream data.
 Henceforth, ``\fIsystem call\fP'' will refer to either a system call
@@ -455,8 +455,8 @@ no longer behave as macros. Thus, an application that requires such fast macro f
 should leave \f5SF_MTSAFE\fP off and performs explicit locking with \f5sfmutex()\fP.
 .Tp
 \f5SF_IOINTR\fP:
-This flag indicates that I/O system calls should not be resumed 
-after being interrupted by signals. It is useful for 
+This flag indicates that I/O system calls should not be resumed
+after being interrupted by signals. It is useful for
 aborting I/O operations on such interruptions. Note, however,
 that certain operating systems (e.g., BSD Unix systems) may automatically
 resume interrupted system calls outside the scope of the library. On such systems,
@@ -784,7 +784,7 @@ from input stream \f5fr\fP to output stream \f5fw\fP.
 
 An object can be either a byte if the record separator argument
 \f5rsc\fP is negative or a record of \f5rsc\fP is non-negative.
-In the latter case, a record is incomplete if it does not end in \f5rsc\fP. 
+In the latter case, a record is incomplete if it does not end in \f5rsc\fP.
 Generally speaking, a stream can have at most one incomplete record.
 If \f5n\fP is negative, all complete objects of \f5fr\fP will be moved.
 Otherwise, \f5n\fP indicates the number of objects to move.
@@ -866,7 +866,7 @@ call can be obtained in another \f5sfreserve()\fP call with the argument
 \f5type\fP being \f5SF_LASTR\fP. The second argument \f5n\fP
 to \f5sfreserve()\fP will be ignored in this case.
 
-A \f5sfreserve()\fP call is successful if it can obtain a data block 
+A \f5sfreserve()\fP call is successful if it can obtain a data block
 of size at least the absolute value of \f5n\fP.
 For a \f5SF_READ\fP atream, the argument \f5n\fP is treated as follows:
 .Tp
@@ -986,7 +986,7 @@ which contains the following elements:
 
     char*        form;   /* format string to stack     */
     va_list      args;   /* corresponding arg list     */
-        
+
     int          fmt;    /* pattern being processed    */
     ssize_t      size;   /* object size                */
     int          flags;  /* formatting control flags   */
@@ -1100,7 +1100,7 @@ Arguments are always processed in order and
 \f5fe->extf\fP is called exactly once per argument.
 Note that, when \f5pos$\fP (below) is not used anywhere in a format string,
 each argument is used exactly once per a corresponding pattern.
-In that case, \f5fe->extf\fP is called 
+In that case, \f5fe->extf\fP is called
 as soon as the pattern is recognized and before any scanning or formatting.
 On the other hand, when \f5pos$\fP is used in a format string,
 an argument may be used multiple times.
@@ -1257,7 +1257,7 @@ In the second case, a given decimal value would define a size while
 Then, if the conversion specifier is \f5s\fP, this size defines the
 length of the string or strings being formatted (see the discussion of \f5base\fP below).
 For integer and floating point patterns,
-the size is used to select a type from one of the below lists as 
+the size is used to select a type from one of the below lists as
 indicated by the conversion specifier:
 
 .nf
@@ -1270,7 +1270,7 @@ indicated by the conversion specifier:
 
 The selection algorithm always matches types from left to right in any given list.
 Although selection is generally based on sizes in bytes,
-for compatibility with Microsoft-C, the size 64 
+for compatibility with Microsoft-C, the size 64
 is matched with an appropriate type with the same number of bits, if any.
 If the given size does not match any of the listed types,
 it shall match one of \f5int\fP, \f5unsigned int\fP, and \f5double\fP
@@ -1517,7 +1517,7 @@ indicated by the conversion specifier:
 
 The selection algorithm always matches types from left to right in any given list.
 Although selection is generally based on sizes in bytes,
-for compatibility with Microsoft-C, the size 64 
+for compatibility with Microsoft-C, the size 64
 is matched with an appropriate type with the same number of bits, if any.
 If the given size does not match any of the listed types,
 it shall match one of \f5int\fP, \f5unsigned int\fP, and \f5double\fP
@@ -1738,7 +1738,7 @@ the discipline that was pushed down.
 
 Note that a discipline can be used on only one stream at a time.
 An application should take care to allocate different discipline
-structures for use with different streams. 
+structures for use with different streams.
 A discipline structure is of the type \f5Sfdisc_t\fP which
 contains the following public fields:
 
@@ -1854,7 +1854,7 @@ I/O modes are ready.
 .Tp
 \f5SF_SYNC\fP, \f5SF_PURGE\fP:
 If \f5SF_IOCHECK\fP is set,
-these events are raised respectively for a \f5sfsync()\fP or \f5sfpurge()\fP call. 
+these events are raised respectively for a \f5sfsync()\fP or \f5sfpurge()\fP call.
 In each case, the respective event is raised once before the appropriate
 operation (synchronization or purging) with \f5((int)value)\fP being \f51\fP
 and once after with \f5((int)value)\fP being \f50\fP.
@@ -2066,7 +2066,7 @@ On such a call, if the return value is negative, \f5sfwalk()\fP will terminate.
 Otherwise, it returns the return value from the last invocation of \f5walkf()\fP.
 
 As an example, the call \f5sfwalk(walkf, data, SF_READ)\fP will iterate over all streams
-opened for reading. Similarly, \f5sfwalk(walkf, data, SF_READ|SF_WRITE)\fP 
+opened for reading. Similarly, \f5sfwalk(walkf, data, SF_READ|SF_WRITE)\fP
 iterates over all streams opened for both reading and writing.
 Lastly, \f5sfwalk(walkf, data, 0)\fP iterates over all streams.
 

--- a/src/lib/libast/man/spawnveg.3
+++ b/src/lib/libast/man/spawnveg.3
@@ -90,7 +90,7 @@ do this on systems that don't support
 .IR fork (2).
 This makes porting to NT and Windows a snap: a simple
 .IR iffe (1)
-probe provides a 
+probe provides a
 .L spawnveg
 implementation using the NT or Windows process primitives.
 .SH "SEE ALSO"

--- a/src/lib/libast/man/stak.3
+++ b/src/lib/libast/man/stak.3
@@ -56,14 +56,14 @@ install it as the active stack.
 A stack is created with the \f5stakcreate\fP() function.
 A \fIflags\fP argument of \f5STAK_SMALL\fP indicates that unused
 space on the stack should be freed whenever this stack ceases
-to be the active stack. 
+to be the active stack.
 If successful,
 \f5stakcreate\fP() returns a pointer to a stack whose reference
 count is 1.
 Otherwise, \f5stakcreate\fP() returns a null pointer.
 The \f5staklink\fP() function increases the reference count for the
 given \fIstack\fP.
-The \f5stakinstall\fP() function 
+The \f5stakinstall\fP() function
 makes the specified \fIstack\fP the active stack and returns a pointer
 to the previous active stack.
 When the \fIoverflow\fP argument is not null,
@@ -113,7 +113,7 @@ If \fIaddress\fP is not the address of an object on the
 stack the result is undefined.
 .PP
 The remaining functions are used to build the current object incrementally.
-An object that is built incrementally on the stack will  
+An object that is built incrementally on the stack will
 always occupy contiguous memory within a stack frame but
 until \f5stakfreeze\fP() is called,
 the location in memory for the object can change.
@@ -123,7 +123,7 @@ Initially, this offset is zero, and the offset changes as a result
 of the operations you specify.
 The \f5stakseek\fP() function is used set the offset for the
 current object.
-The \fIoffset\fP argument to \f5stakseek\fP() specifies the new 
+The \fIoffset\fP argument to \f5stakseek\fP() specifies the new
 offset for the current object.
 The frame will be extended or moved
 if \f5offset\fP causes the new current offset to extend beyond the

--- a/src/lib/libast/man/stk.3
+++ b/src/lib/libast/man/stk.3
@@ -57,14 +57,14 @@ install it as the active stack.
 A stack is created with the \f5stkopen\fP() function.
 A \fIflags\fP argument of \f5STK_SMALL\fP indicates that unused
 space on the stack should be freed whenever this stack ceases
-to be the active stack. 
+to be the active stack.
 If successful,
 \f5stkopen\fP() returns a pointer to a stack whose reference
 count is 1.
 Otherwise, \f5stkopen\fP() returns a null pointer.
 The \f5stklink\fP() function increases the reference count for the
 given \fIstack\fP.
-The \f5stkinstall\fP() function 
+The \f5stkinstall\fP() function
 makes the specified \fIstack\fP the active stack and returns a pointer
 to the previous active stack.
 When the \fIoverflow\fP argument is not null,
@@ -115,7 +115,7 @@ stack the result is undefined.
 .PP
 The \f5sfio\fP(3) output functions can be used to build
 current object incrementally.
-An object that is built incrementally on the stack will  
+An object that is built incrementally on the stack will
 always occupy contiguous memory within a stack frame but
 until \f5stkfreeze\fP() is called,
 the location in memory for the object can change.
@@ -125,7 +125,7 @@ Initially, this offset is zero, and the offset changes as a result
 of the operations you specify.
 The \f5stkseek\fP() function is used set the offset for the
 current object.
-The \fIoffset\fP argument to \f5stkseek\fP() specifies the new 
+The \fIoffset\fP argument to \f5stkseek\fP() specifies the new
 offset for the current object.
 The frame will be extended or moved
 if \f5offset\fP causes the new current offset to extend beyond the

--- a/src/lib/libast/man/stresc.3
+++ b/src/lib/libast/man/stresc.3
@@ -43,7 +43,7 @@ stresc \- convert character constants in string
 .L "int stresc(char* s)"
 .SH DESCRIPTION
 .I stresc
-converts 
+converts
 .L \e
 character constant expressions in the nul-terminated string
 .I s

--- a/src/lib/libast/man/strmatch.3
+++ b/src/lib/libast/man/strmatch.3
@@ -66,7 +66,7 @@ Except for
 .I &
 and
 .IR ! ,
-each shell pattern has an equivalent 
+each shell pattern has an equivalent
 .IR egrep (1)
 construct.
 .EX

--- a/src/lib/libast/man/stropt.3
+++ b/src/lib/libast/man/stropt.3
@@ -74,7 +74,7 @@ where
 .I name
 must be one of the option names in
 .IR tab ,
-.I value 
+.I value
 is an optional value, and
 .B no
 is for Boolean options.
@@ -108,7 +108,7 @@ is not found in
 .I tab
 then
 .I fun
-is called with 
+is called with
 .I p
 pointing to an internal
 .I namval

--- a/src/lib/libast/man/strperm.3
+++ b/src/lib/libast/man/strperm.3
@@ -48,7 +48,7 @@ applies a file permission expression in the nul-terminated string
 to the initial file permission mask
 .IR p .
 The new permission mask is returned.
-If 
+If
 .I e
 not 0 then
 .I *e

--- a/src/lib/libast/man/strsort.3
+++ b/src/lib/libast/man/strsort.3
@@ -56,7 +56,7 @@ elements using the comparison function
 .I compare
 returns
 .L \-1
-if 
+if
 .I a
 is lexicographically less than
 .IR b ,
@@ -67,7 +67,7 @@ is equal to
 .IR b ,
 and
 .L 1
-if 
+if
 .I a
 is lexicographically greater than
 .IR b .

--- a/src/lib/libast/man/strtape.3
+++ b/src/lib/libast/man/strtape.3
@@ -47,7 +47,7 @@ converts the generic tape device specification in the nul-terminated string
 .I s
 to a local tape device pathname.
 A pointer to the device pathname is returned.
-If 
+If
 .I e
 not 0 then
 .I *e

--- a/src/lib/libast/man/strton.3
+++ b/src/lib/libast/man/strton.3
@@ -46,7 +46,7 @@ strton \- convert string to long integer
 converts the nul-terminated string
 .I s
 to a long integer.
-If 
+If
 .I e
 not 0 then
 .I *e
@@ -63,7 +63,7 @@ All but
 are optional.
 .I sign
 may be \+ or \-.
-.I base 
+.I base
 may be:
 .TP
 .B 0x

--- a/src/lib/libast/man/swap.3
+++ b/src/lib/libast/man/swap.3
@@ -60,7 +60,7 @@ and
 .PP
 .L swapop
 returns the swap operation required to convert the
-.L width 
+.L width
 byte integer
 .L external
 to the
@@ -85,7 +85,7 @@ and
 .L 1
 with bytes
 .L 2
-and 
+and
 .LR 3 .
 .TP
 .L 4
@@ -101,7 +101,7 @@ in the header
 described in
 .IR int (3).
 .PP
-.L swapget 
+.L swapget
 returns the
 .L width
 byte integer in the buffer
@@ -109,7 +109,7 @@ byte integer in the buffer
 swapped according to
 .LR op .
 .PP
-.L swapput 
+.L swapput
 copies the
 .L width
 byte integer
@@ -122,16 +122,16 @@ swapped according to
 is returned.
 .PP
 .L swapmem
-swaps 
+swaps
 .L n
 bytes from the buffer
 .L from
 to the buffer
 .L to
-according to 
+according to
 .LR op .
 .L to
-and 
+and
 .L from
 may be the same.
 .SH "SEE ALSO"

--- a/src/lib/libast/man/tab.3
+++ b/src/lib/libast/man/tab.3
@@ -42,8 +42,8 @@ tab \- simple table lookup routines
 .SH SYNOPSIS
 .L "#include <ast.h>"
 .sp
-.L "int tabindex(const void* tab, int size, const char* name);" 
-.L "void* tablook(const void* tab, int size, const char* name);" 
+.L "int tabindex(const void* tab, int size, const char* name);"
+.L "void* tablook(const void* tab, int size, const char* name);"
 .SH DESCRIPTION
 These routines do linear lookups in
 .I small

--- a/src/lib/libast/man/tm.3
+++ b/src/lib/libast/man/tm.3
@@ -46,7 +46,7 @@ The
 .I tm
 library supports conversion between
 string date specifications,
-seconds reolution
+seconds resolution
 .L time_t
 clock values and
 .LR Tm_t .
@@ -356,7 +356,7 @@ The nanosecond part of the time.
 \fB%Q\fP\fI<delim>recent<delim>distant<delim>\fP
 Recent dates are formatted with
 .I recent
-and distand dates are formatted with
+and distant dates are formatted with
 .IR distant ,
 where
 .I <delim>
@@ -400,7 +400,7 @@ character.
 .IR hh : mm : ss .
 .TP
 .B u
-Weeday number with 1 for Monday, 7 for Sunday.
+Weekday number with 1 for Monday, 7 for Sunday.
 .TP
 .B U
 Week number with Sunday as the first day.
@@ -507,9 +507,9 @@ then it specifies a time zone other that the local time zone.
 .TP
 .L "void tmset(Tm_zone_t* zone);"
 .L tmset
-sets the reference timezoe to
+sets the reference timezone to
 .LR zone .
-.L tm_info.local 
+.L tm_info.local
 points to the local timezone and
 .L tm_info.zone
 points to the current reference timezone.

--- a/src/lib/libast/man/tmx.3
+++ b/src/lib/libast/man/tmx.3
@@ -385,9 +385,9 @@ then it specifies a time zone other that the local time zone.
 .TP
 .L "void tmset(Tm_zone_t* zone);"
 .L tmset
-sets the reference timezoe to
+sets the reference timezone to
 .LR zone .
-.L tm_info.local 
+.L tm_info.local
 points to the local timezone and
 .L tm_info.zone
 points to the current reference timezone.

--- a/src/lib/libast/man/tok.3
+++ b/src/lib/libast/man/tok.3
@@ -84,7 +84,7 @@ then it will point to the next unread character in
 on return.
 The number of scanned tokens is returned.
 .L \-1
-is returned if 
+is returned if
 .L string
 was not empty and
 .L format
@@ -116,7 +116,7 @@ is a line splice.
 .L %
 in
 .L format
-prefixes format conversion characters; each conversion character 
+prefixes format conversion characters; each conversion character
 corresponds to a
 .L tokscan
 argument following the
@@ -125,7 +125,7 @@ argument.
 The format conversions are:
 .TP
 .L %c
-A single 
+A single
 .LR char .
 .TP
 .L "%hd %d %ld"
@@ -185,7 +185,7 @@ to
 .L tokscan
 above converts quoted
 .I carriage-return
-back to 
+back to
 .IR newline ),
 and deletes
 .I "# ... newline"
@@ -206,7 +206,7 @@ then
 is a 0 terminated string;
 otherwise
 .L input
-is an open 
+is an open
 .L Sfio_t*
 stream.
 If

--- a/src/lib/libast/man/vecargs.3
+++ b/src/lib/libast/man/vecargs.3
@@ -53,7 +53,7 @@ loads a string vector from lines in
 .LR string .
 .L string
 may be modified upon return.
-Each line in 
+Each line in
 .L string
 is treated as a new vector element.
 Lines with
@@ -64,15 +64,15 @@ joins consecutive lines.
 A string vector pointer is returned, 0 on error.
 .PP
 .L vecfile
-constructs a string vector by calling 
-.L vecload 
+constructs a string vector by calling
+.L vecload
 on the contents of the file named by
 .LR path .
 The string vector pointer is returned, 0 on error.
 .PP
 .L vecstring
-constructs a string vector by calling 
-.L vecload 
+constructs a string vector by calling
+.L vecload
 on a copy of
 .LR string .
 The string vector pointer is returned, 0 on error.
@@ -92,7 +92,7 @@ inserts the string vector
 .L vecload
 or
 .LR vecstring )
-between 
+between
 .L "(*argvp)[0]"
 and
 .LR "(*argvp)[1]" ,
@@ -108,7 +108,7 @@ is called before the return.
 is returned if the insertion failed.
 .SH EXAMPLES
 .L vecargs
-is commonly used to modify command 
+is commonly used to modify command
 .L argv
 from fixed files.
 For example,

--- a/src/lib/libast/man/vmalloc.3
+++ b/src/lib/libast/man/vmalloc.3
@@ -53,7 +53,7 @@ vmalloc \- virtual memory allocation
 .MW "int vmstat(Vmalloc_t* vm, Vmstat_t* statb);"
 .MW "int vmtrace(int fd);"
 .MW "int vmtrbusy(Vmalloc_t* vm);"
-.MW "Void_t* vmdata(Vmalloc_t* vm);" 
+.MW "Void_t* vmdata(Vmalloc_t* vm);"
 .fi
 .SS "Malloc-compatible functions"
 .nf
@@ -268,7 +268,7 @@ a structure with these members:
 .fi
 .in -.5i
 .TP
-.MW round 
+.MW round
 If this value is positive, all size arguments to the
 \f5memoryf\fP function will be multiples of it.
 .TP
@@ -410,7 +410,7 @@ By default, this file descriptor is 2, the standard error.
 checks a region using \f5Vmdebug\fP or \f5Vmbest\fP for integrity.
 If \f5Vmdebug\fP, this also checks for block overwriting errors.
 On errors, \fIvmdbwarn\fP is called.
-If flag \f5VM_DBCHECK\fP is on, 
+If flag \f5VM_DBCHECK\fP is on,
 \fIvmdbcheck\fP is called at each invocation of
 \fIvmalloc\fP, \fIvmfree\fP, or \fIvmresize\fP.
 .PP

--- a/src/lib/libast/misc/fastfind.c
+++ b/src/lib/libast/misc/fastfind.c
@@ -24,7 +24,7 @@
  *	FF_dir	FF_gnu with sfgetl/sfputl and trailing / on dirs (FF_dir_magic)
  *	FF_typ	FF_dir with (mime) types (FF_typ_magic)
  *
- * the bigram encoding steals the eighth bit (that's why its FF_old)
+ * the bigram encoding steals the eighth bit (that's why it's FF_old)
  * maybe one day we'll limit it to readonly:
  *
  * 0-2*FF_OFF	 likeliest differential counts + offset to make nonnegative 

--- a/src/lib/libast/misc/procopen.c
+++ b/src/lib/libast/misc/procopen.c
@@ -599,7 +599,7 @@ procopen(const char* cmd, char** argv, char** envv, long* modv, int flags)
 			if (!fork())
 			{
 				sfsprintf(path, sizeof(path), "%d", getppid());
-				execlp("trace", "trace", "-p", path, NiL);
+				execlp("trace", "trace", "-p", path, NULL);
 				_exit(EXIT_NOTFOUND);
 			}
 			sleep(2);

--- a/src/lib/libcmd/RELEASE
+++ b/src/lib/libcmd/RELEASE
@@ -26,7 +26,7 @@
 10-06-14 rm.c: fix -rfu logic
 10-06-12 paste.c: repeat after me: do not modify argv[i]
 10-06-01 sync with ast api 20100601
-10-05-09 tail.c: fix -0f bug that inially listed the entire file
+10-05-09 tail.c: fix -0f bug that initially listed the entire file
 10-05-06 basename.c: add { -a,--all -s,--suffux=suffix } from BSD
 10-04-12 cat.c: fix -v bug that dumped core and make consistent with cmp --print-chars
 10-04-11 cmp.c: add --print-bytes, --count=n, --differences=n
@@ -77,12 +77,12 @@
 09-02-02 mktemp.c: add
 09-02-02 features/utsname: UWIN _UNAME_os_DEFAULT => UWIN
 09-01-31 dirname.c: add experimental { -f -r -x } for pathpath(3)
-09-01-05 cmp.c: fix EOF diagnostic to conform to posix
+09-01-05 cmp.c: fix EOF diagnostic to conform to POSIX
 09-01-03 mkfifo.c: fix --mode=mode logic
 08-12-07 date.c: add %[_][EO]K for [space pad] [full|long] iso docs
 08-11-10 stty.c: check for -t grouping so -tostop != -t -ostop
 08-10-15 rm.c: handle 'rm -f x x' => exit 0
-08-09-08 stty.c: #ifdef guard TAB[012] -- freebsd: damn the posix, full speed ahead
+08-09-08 stty.c: #ifdef guard TAB[012] -- FreeBSD: damn the POSIX, full speed ahead
 08-06-17 shcmd.h: move to libast
 08-04-24 uniq.c: add optget() 'n' option for -1 => -f1
 08-04-24 getconf.c: clarify diffs between "name - value" and "name = value"
@@ -135,8 +135,8 @@
 06-11-11 getconf.c: fix deferred getconf path search
 06-11-11 fmt.c: handle two char { \t \n } in --usage output
 06-10-31 global edit to eliminate most non-const static data0
-06-10-31 use <cmd.h> for all b_*() implementations; drop <cmdlib.h> 
-06-10-31 cmd.h: add CMD_ prefix to { BUILTIN DYNAMIC STANDALONE } 
+06-10-31 use <cmd.h> for all b_*() implementations; drop <cmdlib.h>
+06-10-31 cmd.h: add CMD_ prefix to { BUILTIN DYNAMIC STANDALONE }
 06-10-31 join.c: tone down /tmp usage vi SFSK_DISCARD
 06-10-31 cp.c,rm.c: update to <fts.h> to accommodate non-static data
 06-10-29 date.c: "...%H%..." => "...%H" "%..." to avoid SCCS conflict
@@ -162,7 +162,7 @@
 06-07-17 cut.c: handle last line with no newline
 06-07-17 cut.c: --output-delimiter == --line-delimiter
 06-06-25 chmod.c: mask -c output with S_IPERM
-06-05-09 uname.c: add -o; change -a to match linux
+06-05-09 uname.c: add -o; change -a to match Linux
 06-05-03 date.c: add --last -L to list last of multiple time args
 06-02-14 tail.c: fix -f bug that lost fast stream data
 06-02-11 getconf.c: exit 1 if name invalid -- duh
@@ -231,7 +231,7 @@
 02-08-19 chgrp.c: convert to use <cdt.h>
 02-07-23 join.c: fix comm snarf typo
 02-04-05 date.c: add %u
-02-01-24 stty.c: ifdef a few more macros for uts (yes, its still running)
+02-01-24 stty.c: ifdef a few more macros for uts (yes, it's still running)
 01-12-14 date.c: clarify %z doc
 01-10-31 mkdir.c: mkdir() on existing dir could fail with errno!=EEXIST
 	 uname.c: add execve() loop check for unknown options


### PR DESCRIPTION
Most of these fixes are for typos and to remove extra whitespace at the end of lines. These are the notable changes:
- Fixed a compatibility issue with how asterisks are displayed using certain fonts. Bug report: https://github.com/att/ast/issues/764
- Fixed a bug in the man page that caused searches for the '|' character to fail. Bug report: https://github.com/att/ast/issues/871
- Removed a duplicate description of `set -B` from the man page. Bug report: https://github.com/att/ast/issues/789
- Added documentation for options missing from the ksh man page (applies to `hist -N`, `sleep -s`, `whence -q` and many of the options for `ulimit`). Bug reports:
  https://github.com/att/ast/issues/948
  https://github.com/att/ast/issues/503#issuecomment-386649715
  https://github.com/att/ast/issues/507#issuecomment-507924608
- Applied the following ksh2020 documentation fixes:
  https://github.com/att/ast/pull/351
  https://github.com/att/ast/pull/352
- Fixed a minor GCC `-Wformat` warning in src/lib/libast/misc/procopen.c by changing a sentinel to `NULL`.