### PR TITLE
Fix a crash in the shbench fibonacci benchmark

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,12 @@ For full details, see the git log at: https://github.com/ksh93/ksh
 
 Any uppercase BUG_* names are modernish shell bug IDs.
 
+2020-08-11:
+
+- Partially fixed a crash that can occur after running a large number of
+  subshells in a script. Due to a bug in vmalloc this only applies when ksh
+  is compiled with -D_std_malloc.
+
 2020-08-10:
 
 - A number of fixes have been applied to the printf formatting directives
@@ -19,10 +25,6 @@ Any uppercase BUG_* names are modernish shell bug IDs.
 
 - Fixed a crash that occurred intermittently after running an external
   command from a command substitution expanded from the $PS1 shell prompt.
-
-- Partially fixed a crash that could occur after running a large number of
-  subshells in a script. Due to a bug in vmalloc this only applies when ksh
-  is compiled with -D_std_malloc.
 
 2020-08-09:
 

--- a/NEWS
+++ b/NEWS
@@ -6,8 +6,9 @@ Any uppercase BUG_* names are modernish shell bug IDs.
 2020-08-11:
 
 - Partially fixed a crash that can occur after running a large number of
-  subshells in a script. Due to a bug in vmalloc this only applies when ksh
-  is compiled with -D_std_malloc.
+  subshells in a script. This only applies on Linux and FreeBSD when ksh
+  is compiled with -D_std_malloc; ksh still crashes on macOS and with
+  vmalloc after running a large number of subshells in some scenarios.
 
 2020-08-10:
 

--- a/NEWS
+++ b/NEWS
@@ -20,6 +20,10 @@ Any uppercase BUG_* names are modernish shell bug IDs.
 - Fixed a crash that occurred intermittently after running an external
   command from a command substitution expanded from the $PS1 shell prompt.
 
+- Partially fixed a crash that could occur after running a large number of
+  subshells in a script. Due to a bug in vmalloc this only applies when ksh
+  is compiled with -D_std_malloc.
+
 2020-08-09:
 
 - File name generation (a.k.a. pathname expansion, a.k.a. globbing) now

--- a/NEWS
+++ b/NEWS
@@ -5,10 +5,7 @@ Any uppercase BUG_* names are modernish shell bug IDs.
 
 2020-08-11:
 
-- Partially fixed a crash that can occur after running a large number of
-  subshells in a script. This only applies on Linux and FreeBSD when ksh
-  is compiled with -D_std_malloc; ksh still crashes on macOS and with
-  vmalloc after running a large number of subshells in some scenarios.
+- Fixed an intermittent crash upon running a large number of subshells.
 
 2020-08-10:
 

--- a/src/cmd/ksh93/include/defs.h
+++ b/src/cmd/ksh93/include/defs.h
@@ -167,8 +167,8 @@ struct shared
 	Namval_t	*prev_table;	/* previous table used in nv_open  */ \
 	Sfio_t		*outpool;	/* output stream pool */ \
 	long		timeout;	/* read timeout */ \
-	long		curenv;		/* current subshell number */ \
-	long		jobenv;		/* subshell number for jobs */ \
+	unsigned int	curenv;		/* current subshell number */ \
+	unsigned int	jobenv;		/* subshell number for jobs */ \
 	int		infd;		/* input file descriptor */ \
 	short		nextprompt;	/* next prompt is PS<nextprompt> */ \
 	short		poolfiles; \

--- a/src/cmd/ksh93/include/defs.h
+++ b/src/cmd/ksh93/include/defs.h
@@ -167,8 +167,8 @@ struct shared
 	Namval_t	*prev_table;	/* previous table used in nv_open  */ \
 	Sfio_t		*outpool;	/* output stream pool */ \
 	long		timeout;	/* read timeout */ \
-	short		curenv;		/* current subshell number */ \
-	short		jobenv;		/* subshell number for jobs */ \
+	long		curenv;		/* current subshell number */ \
+	long		jobenv;		/* subshell number for jobs */ \
 	int		infd;		/* input file descriptor */ \
 	short		nextprompt;	/* next prompt is PS<nextprompt> */ \
 	short		poolfiles; \

--- a/src/cmd/ksh93/include/jobs.h
+++ b/src/cmd/ksh93/include/jobs.h
@@ -68,7 +68,7 @@ struct process
 	unsigned short	p_exit;		/* exit value or signal number */
 	unsigned short	p_exitmin;	/* minimum exit value for xargs */
 	unsigned short	p_flag;		/* flags - see below */
-	long		p_env;		/* subshell environment number */
+	unsigned int	p_env;		/* subshell environment number */
 #ifdef JOBS
 	off_t		p_name;		/* history file offset for command */
 	struct termios	p_stty;		/* terminal state for job */

--- a/src/cmd/ksh93/include/jobs.h
+++ b/src/cmd/ksh93/include/jobs.h
@@ -68,7 +68,7 @@ struct process
 	unsigned short	p_exit;		/* exit value or signal number */
 	unsigned short	p_exitmin;	/* minimum exit value for xargs */
 	unsigned short	p_flag;		/* flags - see below */
-	int		p_env;		/* subshell environment number */
+	long		p_env;		/* subshell environment number */
 #ifdef JOBS
 	off_t		p_name;		/* history file offset for command */
 	struct termios	p_stty;		/* terminal state for job */

--- a/src/cmd/ksh93/include/nval.h
+++ b/src/cmd/ksh93/include/nval.h
@@ -75,7 +75,7 @@ struct Namfun
 {
 	const Namdisc_t	*disc;
 	char		nofree;
-	unsigned char	subshell;
+	unsigned int	subshell;
 	uint32_t	dsize;
 	Namfun_t	*next;
 	char		*last;

--- a/src/cmd/ksh93/include/shell.h
+++ b/src/cmd/ksh93/include/shell.h
@@ -143,7 +143,7 @@ struct Shell_s
 	int		exitval;	/* most recent exit value */
 	unsigned char	trapnote;	/* set when trap/signal is pending */
 	char		shcomp;		/* set when running shcomp */
-	short		subshell;	/* set for virtual subshell */
+	unsigned int	subshell;	/* set for virtual subshell */
 #ifdef _SH_PRIVATE
 	_SH_PRIVATE
 #endif /* _SH_PRIVATE */

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -17,4 +17,4 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                                                                      *
 ***********************************************************************/
-#define SH_RELEASE	"93u+m 2020-08-10"
+#define SH_RELEASE	"93u+m 2020-08-11"

--- a/src/cmd/ksh93/sh/init.c
+++ b/src/cmd/ksh93/sh/init.c
@@ -748,7 +748,8 @@ void sh_setmatch(Shell_t *shp,const char *v, int vsize, int nmatch, regoff_t mat
 {
 	struct match	*mp = &ip->SH_MATCH_init;
 	Namval_t	*np = nv_namptr(mp->node,0); 
-	register int	i,n,x, savesub=shp->subshell;
+	register int	i,n,x;
+	unsigned int savesub=shp->subshell;
 	Namarr_t	*ap = nv_arrayptr(SH_MATCHNOD);
 	shp->subshell = 0;
 #ifndef SHOPT_2DMATCH

--- a/src/cmd/ksh93/sh/init.c
+++ b/src/cmd/ksh93/sh/init.c
@@ -749,7 +749,7 @@ void sh_setmatch(Shell_t *shp,const char *v, int vsize, int nmatch, regoff_t mat
 	struct match	*mp = &ip->SH_MATCH_init;
 	Namval_t	*np = nv_namptr(mp->node,0); 
 	register int	i,n,x;
-	unsigned int savesub=shp->subshell;
+	unsigned int	savesub = shp->subshell;
 	Namarr_t	*ap = nv_arrayptr(SH_MATCHNOD);
 	shp->subshell = 0;
 #ifndef SHOPT_2DMATCH

--- a/src/cmd/ksh93/sh/jobs.c
+++ b/src/cmd/ksh93/sh/jobs.c
@@ -1647,7 +1647,7 @@ static struct process *job_unpost(register struct process *pwtop,int notify)
 	register struct process *pw;
 	/* make sure all processes are done */
 #ifdef DEBUG
-	sfprintf(sfstderr,"ksh: job line %4d: drop pid=%d critical=%d pid=%d env=%ld\n",__LINE__,getpid(),job.in_critical,pwtop->p_pid,pwtop->p_env);
+	sfprintf(sfstderr,"ksh: job line %4d: drop pid=%d critical=%d pid=%d env=%u\n",__LINE__,getpid(),job.in_critical,pwtop->p_pid,pwtop->p_env);
 	sfsync(sfstderr);
 #endif /* DEBUG */
 	pwtop = pw = job_byjid((int)pwtop->p_job);

--- a/src/cmd/ksh93/sh/jobs.c
+++ b/src/cmd/ksh93/sh/jobs.c
@@ -1647,7 +1647,7 @@ static struct process *job_unpost(register struct process *pwtop,int notify)
 	register struct process *pw;
 	/* make sure all processes are done */
 #ifdef DEBUG
-	sfprintf(sfstderr,"ksh: job line %4d: drop pid=%d critical=%d pid=%d env=%d\n",__LINE__,getpid(),job.in_critical,pwtop->p_pid,pwtop->p_env);
+	sfprintf(sfstderr,"ksh: job line %4d: drop pid=%d critical=%d pid=%d env=%ld\n",__LINE__,getpid(),job.in_critical,pwtop->p_pid,pwtop->p_env);
 	sfsync(sfstderr);
 #endif /* DEBUG */
 	pwtop = pw = job_byjid((int)pwtop->p_job);

--- a/src/cmd/ksh93/sh/macro.c
+++ b/src/cmd/ksh93/sh/macro.c
@@ -2716,6 +2716,7 @@ static char *sh_tilde(Shell_t *shp,register const char *string)
 	register int		c;
 	register struct passwd	*pw;
 	register Namval_t *np=0;
+	unsigned int save;
 	static Dt_t *logins_tree;
 	if(*string++!='~')
 		return(NIL(char*));
@@ -2771,10 +2772,10 @@ skip:
 		logins_tree = dtopen(&_Nvdisc,Dtbag);
 	if(np=nv_search(string,logins_tree,NV_ADD))
 	{
-		c = shp->subshell;
+		save = shp->subshell;
 		shp->subshell = 0;
 		nv_putval(np, pw->pw_dir,0);
-		shp->subshell = c;
+		shp->subshell = save;
 	}
 	return(pw->pw_dir);
 }

--- a/src/cmd/ksh93/sh/name.c
+++ b/src/cmd/ksh93/sh/name.c
@@ -2464,7 +2464,7 @@ static void table_unset(Shell_t *shp, register Dt_t *root, int flags, Dt_t *oroo
 		{
 			if(nv_cover(nq))
 			{
-				int subshell = shp->subshell;
+				unsigned int subshell = shp->subshell;
 				shp->subshell = 0;
 				if(nv_isattr(nq, NV_INTEGER))
 				{

--- a/src/cmd/ksh93/sh/nvtype.c
+++ b/src/cmd/ksh93/sh/nvtype.c
@@ -1318,8 +1318,8 @@ int nv_settype(Namval_t* np, Namval_t *tp, int flags)
 	char		*val=0;
 	Namarr_t	*ap=0;
 	Shell_t		*shp = sh_getinterp();
-	int		nelem=0;
-	unsigned int subshell=shp->subshell;
+	int		nelem = 0;
+	unsigned int	subshell = shp->subshell;
 #if SHOPT_TYPEDEF
 	Namval_t	*tq;
 	if(nv_type(np)==tp)

--- a/src/cmd/ksh93/sh/nvtype.c
+++ b/src/cmd/ksh93/sh/nvtype.c
@@ -1318,7 +1318,8 @@ int nv_settype(Namval_t* np, Namval_t *tp, int flags)
 	char		*val=0;
 	Namarr_t	*ap=0;
 	Shell_t		*shp = sh_getinterp();
-	int		nelem=0,subshell=shp->subshell;
+	int		nelem=0;
+	unsigned int subshell=shp->subshell;
 #if SHOPT_TYPEDEF
 	Namval_t	*tq;
 	if(nv_type(np)==tp)

--- a/src/cmd/ksh93/sh/subshell.c
+++ b/src/cmd/ksh93/sh/subshell.c
@@ -251,7 +251,7 @@ Namval_t *sh_assignok(register Namval_t *np,int add)
 	Dt_t			*dp= shp->var_tree;
 	Namval_t		*mpnext;
 	Namarr_t		*ap;
-	int			save;
+	unsigned int	save;
 	/* don't bother to save if in a ${ subshare; } */
 	if(sp->subshare)
 		return(np);

--- a/src/cmd/ksh93/sh/subshell.c
+++ b/src/cmd/ksh93/sh/subshell.c
@@ -103,7 +103,7 @@ static struct subshell
 	char		pwdclose;
 } *subshell_data;
 
-static long subenv;
+static unsigned int subenv;
 
 
 /*
@@ -176,7 +176,7 @@ void sh_subfork(void)
 {
 	register struct subshell *sp = subshell_data;
 	Shell_t	*shp = sp->shp;
-	long curenv = shp->curenv;
+	unsigned int curenv = shp->curenv;
 	pid_t pid;
 	char *trap = shp->st.trapcom[0];
 	if(trap)
@@ -456,7 +456,7 @@ Sfio_t *sh_subshell(Shell_t *shp,Shnode_t *t, volatile int flags, int comsub)
 	struct subshell sub_data;
 	register struct subshell *sp = &sub_data;
 	int jmpval,nsig=0,duped=0;
-	long savecurenv = shp->curenv;
+	unsigned int savecurenv = shp->curenv;
 	int savejobpgid = job.curpgid;
 	int *saveexitval = job.exitval;
 	char *savsig;
@@ -756,6 +756,7 @@ Sfio_t *sh_subshell(Shell_t *shp,Shnode_t *t, volatile int flags, int comsub)
 	{
 		shp->subshell--;		/* decrease level of virtual subshells */
 		SH_SUBSHELLNOD->nvalue.s--;	/* decrease ${.sh.subshell} */
+		subenv--;
 	}
 	subshell_data = sp->prev;
 	if(!argsav  ||  argsav->dolrefcnt==argcnt)

--- a/src/cmd/ksh93/sh/subshell.c
+++ b/src/cmd/ksh93/sh/subshell.c
@@ -103,7 +103,7 @@ static struct subshell
 	char		pwdclose;
 } *subshell_data;
 
-static int subenv;
+static long subenv;
 
 
 /*
@@ -176,7 +176,7 @@ void sh_subfork(void)
 {
 	register struct subshell *sp = subshell_data;
 	Shell_t	*shp = sp->shp;
-	int	curenv = shp->curenv;
+	long curenv = shp->curenv;
 	pid_t pid;
 	char *trap = shp->st.trapcom[0];
 	if(trap)
@@ -456,7 +456,7 @@ Sfio_t *sh_subshell(Shell_t *shp,Shnode_t *t, volatile int flags, int comsub)
 	struct subshell sub_data;
 	register struct subshell *sp = &sub_data;
 	int jmpval,nsig=0,duped=0;
-	int savecurenv = shp->curenv;
+	long savecurenv = shp->curenv;
 	int savejobpgid = job.curpgid;
 	int *saveexitval = job.exitval;
 	char *savsig;

--- a/src/cmd/ksh93/sh/subshell.c
+++ b/src/cmd/ksh93/sh/subshell.c
@@ -251,7 +251,7 @@ Namval_t *sh_assignok(register Namval_t *np,int add)
 	Dt_t			*dp= shp->var_tree;
 	Namval_t		*mpnext;
 	Namarr_t		*ap;
-	unsigned int	save;
+	unsigned int		save;
 	/* don't bother to save if in a ${ subshare; } */
 	if(sp->subshare)
 		return(np);

--- a/src/cmd/ksh93/sh/subshell.c
+++ b/src/cmd/ksh93/sh/subshell.c
@@ -103,6 +103,8 @@ static struct subshell
 	char		pwdclose;
 } *subshell_data;
 
+static unsigned int subenv;
+
 
 /*
  * This routine will turn the sftmp() file into a real /tmp file or pipe
@@ -472,11 +474,12 @@ Sfio_t *sh_subshell(Shell_t *shp,Shnode_t *t, volatile int flags, int comsub)
 	if(shp->curenv==0)
 	{
 		subshell_data=0;
-		shp->subshell = 0;
+		subenv = 0;
 	}
-	shp->curenv = ++shp->subshell; /* increase level of virtual subshells */
+	shp->curenv = ++subenv;
 	savst = shp->st;
 	sh_pushcontext(shp,&buff,SH_JMPSUB);
+	shp->subshell++;		/* increase level of virtual subshells */
 	SH_SUBSHELLNOD->nvalue.s++;	/* increase ${.sh.subshell} */
 	sp->prev = subshell_data;
 	sp->shp = shp;
@@ -753,6 +756,7 @@ Sfio_t *sh_subshell(Shell_t *shp,Shnode_t *t, volatile int flags, int comsub)
 	{
 		shp->subshell--;		/* decrease level of virtual subshells */
 		SH_SUBSHELLNOD->nvalue.s--;	/* decrease ${.sh.subshell} */
+		subenv--;
 	}
 	subshell_data = sp->prev;
 	if(!argsav  ||  argsav->dolrefcnt==argcnt)

--- a/src/cmd/ksh93/sh/subshell.c
+++ b/src/cmd/ksh93/sh/subshell.c
@@ -103,8 +103,6 @@ static struct subshell
 	char		pwdclose;
 } *subshell_data;
 
-static unsigned int subenv;
-
 
 /*
  * This routine will turn the sftmp() file into a real /tmp file or pipe
@@ -474,12 +472,11 @@ Sfio_t *sh_subshell(Shell_t *shp,Shnode_t *t, volatile int flags, int comsub)
 	if(shp->curenv==0)
 	{
 		subshell_data=0;
-		subenv = 0;
+		shp->subshell = 0;
 	}
-	shp->curenv = ++subenv;
+	shp->curenv = ++shp->subshell; /* increase level of virtual subshells */
 	savst = shp->st;
 	sh_pushcontext(shp,&buff,SH_JMPSUB);
-	shp->subshell++;		/* increase level of virtual subshells */
 	SH_SUBSHELLNOD->nvalue.s++;	/* increase ${.sh.subshell} */
 	sp->prev = subshell_data;
 	sp->shp = shp;
@@ -756,7 +753,6 @@ Sfio_t *sh_subshell(Shell_t *shp,Shnode_t *t, volatile int flags, int comsub)
 	{
 		shp->subshell--;		/* decrease level of virtual subshells */
 		SH_SUBSHELLNOD->nvalue.s--;	/* decrease ${.sh.subshell} */
-		subenv--;
 	}
 	subshell_data = sp->prev;
 	if(!argsav  ||  argsav->dolrefcnt==argcnt)

--- a/src/cmd/ksh93/sh/subshell.c
+++ b/src/cmd/ksh93/sh/subshell.c
@@ -756,7 +756,6 @@ Sfio_t *sh_subshell(Shell_t *shp,Shnode_t *t, volatile int flags, int comsub)
 	{
 		shp->subshell--;		/* decrease level of virtual subshells */
 		SH_SUBSHELLNOD->nvalue.s--;	/* decrease ${.sh.subshell} */
-		subenv--;
 	}
 	subshell_data = sp->prev;
 	if(!argsav  ||  argsav->dolrefcnt==argcnt)

--- a/src/cmd/ksh93/tests/subshell.sh
+++ b/src/cmd/ksh93/tests/subshell.sh
@@ -529,7 +529,8 @@ err() { return $1; }
 ( err 12 ) & pid=$!
 : $( $date)
 wait $pid
-[[ $? == 12 ]] || err_exit 'exit status from subshells not being preserved'
+exit_status=$?
+[[ $exit_status == 12 ]] || err_exit "exit status from subshells not being preserved (expected 12, got $exit_status)"
 
 if	cat /dev/fd/3 3</dev/null >/dev/null 2>&1 || whence mkfifo > /dev/null
 then	x="$(sed 's/^/Hello /' <(print "Fred" | sort))"

--- a/src/cmd/ksh93/tests/subshell.sh
+++ b/src/cmd/ksh93/tests/subshell.sh
@@ -760,26 +760,4 @@ SHELL=$SHELL "$SHELL" -c '
 || err_exit "setting PATH to readonly in subshell triggers an erroneous fork"
 
 # ======
-# Ksh shouldn't crash after running a large number of subshells.
-# NOTE: This test is disabled because it crashes with vmalloc and
-# macOS malloc, although it does work on Linux and FreeBSD.
-: <<\end_disabled
-subshell_crash="$tmp/subshell_crash.sh"
-cat >| "$subshell_crash" << EOF
-(
-	for ((n=0; n != 50000; n++)) do
-		(
-			function foo {
-				(true)
-			}
-			foo
-		)
-	done
-)
-EOF
-"$SHELL" "$subshell_crash" || err_exit 'ksh crashes after running a large number of subshells'
-fi
-end_disabled
-
-# ======
 exit $((Errors<125?Errors:125))

--- a/src/cmd/ksh93/tests/subshell.sh
+++ b/src/cmd/ksh93/tests/subshell.sh
@@ -759,4 +759,25 @@ SHELL=$SHELL "$SHELL" -c '
 || err_exit "setting PATH to readonly in subshell triggers an erroneous fork"
 
 # ======
+# Ksh shouldn't crash after running a large number of subshells.
+# NOTE: This test will always crash with vmalloc, so for now
+# it's disabled if vmstate is present.
+if ! builtin vmstate 2> /dev/null; then
+subshell_crash="$tmp/subshell_crash.sh"
+cat >| "$subshell_crash" << EOF
+(
+	for ((n=0; n != 50000; n++)) do
+		(
+			function foo {
+				(true)
+			}
+			foo
+		)
+	done
+)
+EOF
+"$SHELL" "$subshell_crash" || err_exit 'ksh crashes after running a large number of subshells'
+fi
+
+# ======
 exit $((Errors<125?Errors:125))

--- a/src/cmd/ksh93/tests/subshell.sh
+++ b/src/cmd/ksh93/tests/subshell.sh
@@ -761,9 +761,9 @@ SHELL=$SHELL "$SHELL" -c '
 
 # ======
 # Ksh shouldn't crash after running a large number of subshells.
-# NOTE: This test will always crash with vmalloc, so for now
-# it's disabled if vmstate is present.
-if ! builtin vmstate 2> /dev/null; then
+# NOTE: This test is disabled because it crashes with vmalloc and
+# macOS malloc, although it does work on Linux and FreeBSD.
+: <<\end_disabled
 subshell_crash="$tmp/subshell_crash.sh"
 cat >| "$subshell_crash" << EOF
 (
@@ -779,6 +779,7 @@ cat >| "$subshell_crash" << EOF
 EOF
 "$SHELL" "$subshell_crash" || err_exit 'ksh crashes after running a large number of subshells'
 fi
+end_disabled
 
 # ======
 exit $((Errors<125?Errors:125))


### PR DESCRIPTION
If the `fibslow` function in the [shbench fibonacci benchmark](https://github.com/ksh-community/shbench/blob/d3e5e9a8be45500e4d21ead330bde3fb1938d54d/bench/fibonacci.ksh) is run with an argument greater than 20, ksh will crash with a memory fault. Below is a diff that can be applied to shbench for this crash to occur:
```diff
--- a/bench/fibonacci.ksh
+++ b/bench/fibonacci.ksh
@@ -55,6 +55,6 @@ typeset -i para=19
 ((penalty > 0)) || penalty=1
 [[ $refshell == zsh ]] && ((penalty *= 3))
 typeset -i num=$((para - penalty/3))
-r1=$(fibslow $num)
+r1=$(fibslow 21)
 r2=$(fibfast $num)
 [[ $r1 == "$r2" ]] || exit 1
```
```sh
$ ksh ./bench/fibonacci.ksh
Memory fault
```
This was caused by subshell numbers only being 16-bits long, which isn't big enough when running a large number of subshells. Extending the subshell number length to 64-bit fixes this issue (`${.sh.subshell}` doesn't affect the crash, so it's unchanged), but with vmalloc a similar crash still occurs. The fibonacci benchmark no longer crashes with the above diff, but the regression test this pull request adds only works with standard malloc. With ksh93u+ vmalloc the following script still crashes:
```sh
$ cat ./vmalloc-subshell-crash.ksh
#!/bin/ksh
(
    for ((n=0; n != 50000; n++)) do
        (
            function foo {
                (true)
            }
            foo
         )
    done
)
$ ksh ./vmalloc-subshell-crash.ksh
Memory fault
```