### PR TITLE
Fix a file descriptor leak when fstat errors out with EIO

### DIFF
--- a/src/cmd/ksh93/sh/path.c
+++ b/src/cmd/ksh93/sh/path.c
@@ -980,9 +980,9 @@ static int canexecute(Shell_t *shp,register char *path, int isfun)
 		errno = EISDIR;
 	else if((statb.st_mode&S_IXALL)==S_IXALL || sh_access(path,X_OK)>=0)
 		return(fd);
+err:
 	if(isfun && fd>=0)
 		sh_close(fd);
-err:
 	return(-1);
 }
 


### PR DESCRIPTION
This is a minor bugfix backported from ksh2020: att/ast@55cad1d. A file descriptor leak occurs in the `canexecute` function when `open` succeeds but `fstat` fails. `canexecute` only returns -1 on error, the file descriptor used by `fstat` is never closed because `goto err` skips `sh_close`:
https://github.com/ksh93/ksh/blob/9b45f2ccbecf88e1e237a2c118b3d8ffe84efba0/src/cmd/ksh93/sh/path.c#L951-L952
https://github.com/ksh93/ksh/blob/9b45f2ccbecf88e1e237a2c118b3d8ffe84efba0/src/cmd/ksh93/sh/path.c#L983-L986

The fix is to move the `err` label to include `sh_close`, preventing a file descriptor leak.