### PR TITLE
Implement a better fix for readonly variables in subshells

### DIFF
--- a/src/cmd/ksh93/bltins/typeset.c
+++ b/src/cmd/ksh93/bltins/typeset.c
@@ -813,7 +813,7 @@ static int     setall(char **argv,register int flag,Dt_t *troot,struct tdata *tp
 			if (tp->aflag && (tp->argnum>0 || (curflag!=newflag)))
 			{
 				if(shp->subshell)
-					sh_assignok(np,3);
+					sh_assignok(np,2);
 				if(troot!=shp->var_tree)
 					nv_setattr(np,newflag&~NV_ASSIGN);
 				else

--- a/src/cmd/ksh93/sh/subshell.c
+++ b/src/cmd/ksh93/sh/subshell.c
@@ -497,6 +497,7 @@ Sfio_t *sh_subshell(Shell_t *shp,Shnode_t *t, volatile int flags, int comsub)
 	sp->options = shp->options;
 	sp->jobs = job_subsave();
 	sp->subdup = shp->subdup;
+	/* Save the state of NV_RDONLY for $_, ${.sh.name} and ${.sh.subscript} */
 	sp->larg_readonly = nv_isattr(L_ARGNOD, NV_RDONLY);
 	sp->shname_readonly = nv_isattr(SH_NAMENOD, NV_RDONLY);
 	sp->shsubscript_readonly = nv_isattr(SH_SUBSCRNOD, NV_RDONLY);
@@ -635,6 +636,7 @@ Sfio_t *sh_subshell(Shell_t *shp,Shnode_t *t, volatile int flags, int comsub)
 	}
 	if(!shp->savesig)
 		shp->savesig = -1;
+	/* If $_, ${.sh.name} or ${.sh.subscript} weren't originally readonly, unset NV_RDONLY */
 	if(!sp->larg_readonly)
 		nv_offattr(L_ARGNOD,NV_RDONLY);
 	if(!sp->shname_readonly)


### PR DESCRIPTION
The previous fix for readonly variables in virtual subshells (bd3e2a8) disabled the `sh_assignok` optimization for `$_`, `${.sh.name}` and `${.sh.subscript}`. This commit implements a different bugfix compatible with the `sh_assignok` optimization. The status of `NV_RDONLY` for each of these variables is saved when starting a virtual subshell, then when a virtual subshell finishes `NV_RDONLY` is unset if the variable wasn't originally readonly. `${.sh.level}` is still affected by a segfault when using the `sh_assignok` optimization (https://github.com/ksh93/ksh/pull/27#issuecomment-646997179), so the optimization wasn't applied to `${.sh.level}`.