### PR TITLE
Fix compile with -D_std_malloc

### DIFF
--- a/src/cmd/ksh93/include/jobs.h
+++ b/src/cmd/ksh93/include/jobs.h
@@ -120,6 +120,8 @@ extern struct jobs job;
 #else
 #define vmbusy()	(vmstat(0,0)!=0)
 #endif
+#else
+#define vmbusy()	0
 #endif
 
 #define job_lock()	(job.in_critical++)


### PR DESCRIPTION
Commit f9c127e caused building ksh with `-D_std_malloc` to fail with the following errors:
```
/usr/bin/ld: libshell.a(jobs.o): in function `job_clear':
jobs.c:(.text+0xc0c): undefined reference to `vmbusy'
/usr/bin/ld: libshell.a(jobs.o): in function `job_reap':
jobs.c:(.text+0xc8d): undefined reference to `vmbusy'
/usr/bin/ld: libshell.a(jobs.o): in function `job_chldtrap':
jobs.c:(.text+0x15eb): undefined reference to `vmbusy'
/usr/bin/ld: libshell.a(jobs.o): in function `job_waitsafe':
jobs.c:(.text+0x1643): undefined reference to `vmbusy'
/usr/bin/ld: libshell.a(jobs.o): in function `job_close':
jobs.c:(.text+0x186b): undefined reference to `vmbusy'
/usr/bin/ld: libshell.a(jobs.o):jobs.c:(.text+0x1be9): more undefined references to `vmbusy' follow
collect2: error: ld returned 1 exit status
```
The errors occur because the `_std_malloc` definition of `vmbusy` was removed. Ksh assumes `vmbusy` is always a macro (when `_std_malloc` is defined `vmbusy` is zero, similar to `mbwide`). This commit reintroduces the `_std_malloc` definition of `vmbusy` to fix the undefined reference errors.