### PR TITLE
Fix a crash when running 'unalias r'

### DIFF
--- a/src/cmd/ksh93/bltins/typeset.c
+++ b/src/cmd/ksh93/bltins/typeset.c
@@ -1162,7 +1162,7 @@ static int unall(int argc, char **argv, register Dt_t *troot, Shell_t* shp)
 	register const char *name;
 	volatile int r;
 	Dt_t	*dp;
-	int nflag=0,all=0,isfun,jmpval;
+	int nflag=0,all=0,isfun,jmpval,nofree_attr;
 	struct checkpt buff;
 	NOT_USED(argc);
 	if(troot==shp->alias_tree)
@@ -1292,6 +1292,16 @@ static int unall(int argc, char **argv, register Dt_t *troot, Shell_t* shp)
 				}
 			}
 
+			/*
+			 * When aliases are removed from the tree, the NV_NOFREE attribute
+			 * must be used for the 'history' and 'r' aliases since those are
+			 * given the NV_NOFREE attribute. _nv_unset discards NV_NOFREE so
+			 * the status of NV_NOFREE is obtained now to prevent an invalid
+			 * free crash.
+			 */
+			if(troot==shp->alias_tree)
+				nofree_attr = nv_isattr(np,NV_NOFREE) ? NV_NOFREE : 0;
+
 			if(!nv_isnull(np) || nv_size(np) || nv_isattr(np,~(NV_MINIMAL|NV_NOFREE)))
 				_nv_unset(np,0);
 			if(troot==shp->var_tree && shp->st.real_fun && (dp=shp->var_tree->walk) && dp==shp->st.real_fun->sdict)
@@ -1311,7 +1321,7 @@ static int unall(int argc, char **argv, register Dt_t *troot, Shell_t* shp)
 			}
 			/* The alias has been unset by call to _nv_unset, remove it from the tree */
 			else if(troot==shp->alias_tree)
-				nv_delete(np,troot,nv_isattr(np,NV_NOFREE));
+				nv_delete(np,troot,nofree_attr);
 #if 0
 			/* causes unsetting local variable to expose global */
 			else if(shp->var_tree==troot && shp->var_tree!=shp->var_base && nv_search((char*)np,shp->var_tree,HASH_BUCKET|HASH_NOSCOPE))

--- a/src/cmd/ksh93/bltins/typeset.c
+++ b/src/cmd/ksh93/bltins/typeset.c
@@ -1293,14 +1293,12 @@ static int unall(int argc, char **argv, register Dt_t *troot, Shell_t* shp)
 			}
 
 			/*
-			 * When aliases are removed from the tree, the NV_NOFREE attribute
-			 * must be used for the 'history' and 'r' aliases since those are
-			 * given the NV_NOFREE attribute. _nv_unset discards NV_NOFREE so
-			 * the status of NV_NOFREE is obtained now to prevent an invalid
-			 * free crash.
+			 * When aliases are removed from the tree, the NV_NOFREE attribute must be used for
+			 * preset aliases since those are given the NV_NOFREE attribute. _nv_unset discards
+			 * NV_NOFREE so the status of NV_NOFREE is obtained now to prevent an invalid free crash.
 			 */
 			if(troot==shp->alias_tree)
-				nofree_attr = nv_isattr(np,NV_NOFREE) ? NV_NOFREE : 0;
+				nofree_attr = nv_isattr(np,NV_NOFREE);	/* note: returns bitmask, not boolean */
 
 			if(!nv_isnull(np) || nv_size(np) || nv_isattr(np,~(NV_MINIMAL|NV_NOFREE)))
 				_nv_unset(np,0);

--- a/src/cmd/ksh93/bltins/typeset.c
+++ b/src/cmd/ksh93/bltins/typeset.c
@@ -1162,7 +1162,7 @@ static int unall(int argc, char **argv, register Dt_t *troot, Shell_t* shp)
 	register const char *name;
 	volatile int r;
 	Dt_t	*dp;
-	int nflag=0,all=0,isfun,jmpval;
+	int nflag=0,all=0,isfun,jmpval,nofree_attr;
 	struct checkpt buff;
 	NOT_USED(argc);
 	if(troot==shp->alias_tree)
@@ -1291,12 +1291,17 @@ static int unall(int argc, char **argv, register Dt_t *troot, Shell_t* shp)
 						np=sh_assignok(np,0);
 				}
 			}
+
+			/*
+			 * When aliases are removed from the tree, the NV_NOFREE attribute
+			 * must be used for the 'history' and 'r' aliases since those are
+			 * given the NV_NOFREE attribute. _nv_unset discards NV_NOFREE so
+			 * the status of NV_NOFREE is obtained now to prevent an invalid
+			 * free crash.
+			 */
 			if(troot==shp->alias_tree)
-			{
-				/* Since aliases don't have virtual subshell tables, no need to _nv_unset() them first. */
-				nv_delete(np,troot,nv_isattr(np,NV_NOFREE));
-				continue;
-			}
+				nofree_attr = nv_isattr(np,NV_NOFREE) ? NV_NOFREE : 0;
+
 			if(!nv_isnull(np) || nv_size(np) || nv_isattr(np,~(NV_MINIMAL|NV_NOFREE)))
 				_nv_unset(np,0);
 			if(troot==shp->var_tree && shp->st.real_fun && (dp=shp->var_tree->walk) && dp==shp->st.real_fun->sdict)
@@ -1314,6 +1319,9 @@ static int unall(int argc, char **argv, register Dt_t *troot, Shell_t* shp)
 				while((troottmp = troottmp->view) && (np = nv_search(name,troottmp,0)) && is_afunction(np))
 					nv_delete(np,troottmp,0);
 			}
+			/* The alias has been unset by call to _nv_unset, remove it from the tree */
+			else if(troot==shp->alias_tree)
+				nv_delete(np,troot,nofree_attr);
 #if 0
 			/* causes unsetting local variable to expose global */
 			else if(shp->var_tree==troot && shp->var_tree!=shp->var_base && nv_search((char*)np,shp->var_tree,HASH_BUCKET|HASH_NOSCOPE))

--- a/src/cmd/ksh93/tests/alias.sh
+++ b/src/cmd/ksh93/tests/alias.sh
@@ -109,9 +109,9 @@ alias foo=bar
 unalias foo
 unalias foo && err_exit 'unalias should return non-zero when a previously set alias is unaliased twice'
 
-# Removing a preset alias should work without an error from free(3)
-err=$(set +x; { "$SHELL" -i -c 'unalias history'; } 2>&1) && [[ -z $err ]] \
-|| err_exit "removing a preset alias does not work (got $(printf %q "$err"))"
+# Removing the history and r aliases should work without an error from free(3)
+err=$(set +x; { "$SHELL" -i -c 'unalias history; unalias r'; } 2>&1) && [[ -z $err ]] \
+|| err_exit "the 'history' and 'r' aliases can't be removed (got $(printf %q "$err"))"
 
 # ======
 exit $((Errors<125?Errors:125))


### PR DESCRIPTION
After commit ddaa145b, the following set of commands now causes ksh to crash:

```
$ unalias history; unalias r
Memory fault
```

When ksh is compiled with ` -D_std_malloc`, the crash always occurs when the `r` alias is removed with `unalias r`, although with vmalloc `unalias history` must be run first for the crash to occur. The crash message is also different when the native malloc is used instead of vmalloc:

```
$ unalias r
free(): invalid pointer
Abort
```

This crash happens because the `NV_NOFREE` flag disappears after `_nv_unset`, which results in `nv_isattr` becoming a no-op (as it always returns zero). `nv_delete` then attempts an invalid free, which causes the crash:
https://github.com/ksh93/ksh/blob/05683ec75b4c7123143bf60c58f52c75e719cb45/src/cmd/ksh93/bltins/typeset.c#L1295-L1296
https://github.com/ksh93/ksh/blob/05683ec75b4c7123143bf60c58f52c75e719cb45/src/cmd/ksh93/bltins/typeset.c#L1314

The `history` and `r` aliases shouldn't be freed from memory by `nv_delete` because those aliases are given the `NV_NOFREE` flag:
https://github.com/ksh93/ksh/blob/05683ec75b4c7123143bf60c58f52c75e719cb45/src/cmd/ksh93/data/aliases.c#L32-L33

This pull request fixes the crash by saving the `NV_NOFREE` flag for aliases to prevent an invalid free from occurring.