### PR TITLE
Fix garbled output from Ctrl+Alt+V

### DIFF
--- a/src/cmd/ksh93/sh/string.c
+++ b/src/cmd/ksh93/sh/string.c
@@ -741,8 +741,3 @@ char *sh_checkid(char *str, char *last)
 	}
 	return(last);
 }
-
-char *fmtident(const char *string)
-{
-	return((char*)string);
-}


### PR DESCRIPTION
This pull request fixes a regression introduced in commit f9c127e3. When the legacy code for older versions of libast was removed, the `fmtident` wrapper wasn't removed. As a result, the version string output by Ctrl+Alt+V is garbled because the `fmtident` wrapper doesn't do any formatting:

```
$ <Ctrl+Alt+V>
^J@(#)$Id: Version AJM 93u+m 2020-09-14
```

The `fmtident` wrapper in string.c was removed to fix this bug (the correct version of `fmtident` is in `src/lib/libast/string/fmtident.c`).