### PR TITLE
'whence -f' should ignore functions

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,10 @@ For full details, see the git log at: https://github.com/ksh93/ksh
 
 Any uppercase BUG_* names are modernish shell bug IDs.
 
+2020-09-26:
+
+- 'whence -f' now completely ignores the existence of functions, as documented.
+
 2020-09-25:
 
 - whence -v/-a now reports the path to the file that an "undefined" (i.e.

--- a/src/cmd/ksh93/bltins/whence.c
+++ b/src/cmd/ksh93/bltins/whence.c
@@ -243,9 +243,11 @@ static int whence(Shell_t *shp,char **argv, register int flags)
 					cp = 0;
 			}
 			if(flags&Q_FLAG)
-			{
-				pp = 0;
-				ret = !cp;
+			{ /* There isn't any reason to continue the loop when -q
+			     is passed since -a is ignored. If the exit status will
+				 be one, return. */
+				if(!cp)
+					return(1);
 			}
 			else if(maybe_undef_fn)
 			{

--- a/src/cmd/ksh93/bltins/whence.c
+++ b/src/cmd/ksh93/bltins/whence.c
@@ -243,9 +243,8 @@ static int whence(Shell_t *shp,char **argv, register int flags)
 					cp = 0;
 			}
 			if(flags&Q_FLAG)
-			{ /* There is no reason to continue the loop when -q
-			     is passed since -a is ignored. If the exit status
-		 	     will be one, return. */
+			{
+				/* Since -q ignores -a, return on the first non-match */
 				if(!cp)
 					return(1);
 			}

--- a/src/cmd/ksh93/bltins/whence.c
+++ b/src/cmd/ksh93/bltins/whence.c
@@ -243,9 +243,9 @@ static int whence(Shell_t *shp,char **argv, register int flags)
 					cp = 0;
 			}
 			if(flags&Q_FLAG)
-			{ /* There isn't any reason to continue the loop when -q
-			     is passed since -a is ignored. If the exit status will
-				 be one, return. */
+			{ /* There is no reason to continue the loop when -q
+			     is passed since -a is ignored. If the exit status
+		 	     will be one, return. */
 				if(!cp)
 					return(1);
 			}

--- a/src/cmd/ksh93/bltins/whence.c
+++ b/src/cmd/ksh93/bltins/whence.c
@@ -135,7 +135,7 @@ static int whence(Shell_t *shp,char **argv, register int flags)
 	register const char *name;
 	register Namval_t *np;
 	register const char *cp;
-	register int aflag,r=0;
+	register int aflag, ret = 0;
 	register const char *msg;
 	Namval_t *nq;
 	char *notused;
@@ -230,7 +230,7 @@ static int whence(Shell_t *shp,char **argv, register int flags)
 				cp = name;
 				if(*cp!='/')
 				{
-					if(flags&P_FLAG)
+					if(flags&(P_FLAG|F_FLAG)) /* Ignore functions when passed -f or -p */
 						cp = 0;
 					else
 						maybe_undef_fn = 1;
@@ -245,7 +245,7 @@ static int whence(Shell_t *shp,char **argv, register int flags)
 			if(flags&Q_FLAG)
 			{
 				pp = 0;
-				r |= !cp;
+				ret = !cp;
 			}
 			else if(maybe_undef_fn)
 			{
@@ -286,7 +286,7 @@ static int whence(Shell_t *shp,char **argv, register int flags)
 			}
 			else if(aflag<=1) 
 			{
-				r |= 1;
+				ret = 1;
 				if(flags&V_FLAG)
 					 errormsg(SH_DICT,ERROR_exit(0),e_found,sh_fmtq(name));
 			}
@@ -302,6 +302,6 @@ static int whence(Shell_t *shp,char **argv, register int flags)
 				pp = 0;
 		} while(pp);
 	}
-	return(r);
+	return(ret);
 }
 

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -17,4 +17,4 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                                                                      *
 ***********************************************************************/
-#define SH_RELEASE	"93u+m 2020-09-25"
+#define SH_RELEASE	"93u+m 2020-09-26"

--- a/src/cmd/ksh93/tests/builtins.sh
+++ b/src/cmd/ksh93/tests/builtins.sh
@@ -851,6 +851,17 @@ actual="$(type -f foo_bar 2>&1)"
 type -f foo_bar >/dev/null 2>&1 && err_exit "'type -f' doesn't ignore functions (got '$(printf %q "$actual")')"
 type -qf foo_bar && err_exit "'type -qf' doesn't ignore functions"
 
+# Test the exit status of 'whence -q'
+(
+	mkdir "$tmp/fakepath"
+	ln -s "${ whence -p cat ;}" "$tmp/fakepath"
+	ln -s "${ whence -p ls ;}" "$tmp/fakepath"
+	PATH="$tmp/fakepath"
+	whence -q cat nonexist ls && err_exit "'whence -q' has the wrong exit status"
+	whence -q cat nonexist && err_exit "'whence -q' has the wrong exit status"
+	whence -q nonexist && err_exit "'whence -q' has the wrong exit status"
+)
+
 # ======
 # 'cd ../.foo' should not exclude the '.' in '.foo'
 # https://bugzilla.redhat.com/889748

--- a/src/cmd/ksh93/tests/builtins.sh
+++ b/src/cmd/ksh93/tests/builtins.sh
@@ -841,6 +841,16 @@ actual=$(hash -r; alias ls='echo ALL UR F1LEZ R G0N3'; hash ls; whence -a ls)
 [[ $actual == "$expect" ]] || err_exit "'whence -a' does not report tracked alias if alias exists" \
 	"(expected $(printf %q "$expect"), got $(printf %q "$actual"))"
 
+# 'whence -f' should ignore functions
+foo_bar() { true; }
+actual="$(whence -f foo_bar)"
+whence -f foo_bar >/dev/null && err_exit "'whence -f' doesn't ignore functions (got '$(printf %q "$actual")')"
+
+# whence -vq/type -q must be tested as well
+actual="$(type -f foo_bar 2>&1)"
+type -f foo_bar >/dev/null 2>&1 && err_exit "'type -f' doesn't ignore functions (got '$(printf %q "$actual")')"
+type -qf foo_bar && err_exit "'type -qf' doesn't ignore functions"
+
 # ======
 # 'cd ../.foo' should not exclude the '.' in '.foo'
 # https://bugzilla.redhat.com/889748


### PR DESCRIPTION
According to the man page for `whence`, `whence -f` should ignore functions:
```
  -f              Do not check for functions.
```

Right now this is only accomplished partially. As of commit a329c22d `whence -f` avoids any output when encountering a function (in ksh93u+ `whence -f` has incorrect output). The return value is still wrong though:

```sh
$ foo() { true; }
$ whence -f foo; echo $?
0
```

`whence -p` correctly ignores functions by setting `cp` to a null value:
https://github.com/ksh93/ksh/blob/7e6bbf85b635a884dc48a7c7cca8123e2a2f2257/src/cmd/ksh93/bltins/whence.c#L233-L234
To fix `whence -f` an additional check for `F_FLAG` was added to that if statement. The code for saving the return value has also been simplified to remove unnecessary usage of the `|=` operator (see att/ast#1324).