### PR TITLE
Enforce integer base limits of 2 to 64

### DIFF
--- a/src/cmd/ksh93/bltins/typeset.c
+++ b/src/cmd/ksh93/bltins/typeset.c
@@ -320,7 +320,7 @@ int    b_typeset(int argc,register char *argv[],Shbltin_t *context)
 				troot = tdata.sh->fun_tree;
 				break;
 			case 'i':
-				if(!opt_info.arg || (tdata.argnum = opt_info.num) <0)
+				if(!opt_info.arg || (tdata.argnum = opt_info.num) <2 || tdata.argnum >64)
 					tdata.argnum = 10;
 				flag |= NV_INTEGER;
 				break;
@@ -806,15 +806,9 @@ static int     setall(char **argv,register int flag,Dt_t *troot,struct tdata *tp
 					nv_setattr(np,newflag&~NV_ASSIGN);
 				else
 				{
-					char *oldname=0;
-					int len=strlen(name);
-					if(tp->argnum==1 && newflag==NV_INTEGER && nv_isattr(np,NV_INTEGER))
-						tp->argnum = 10;
-					if(np->nvfun && !nv_isarray(np) && name[len-1]=='.')
+					if(np->nvfun && !nv_isarray(np) && name[strlen(name)-1]=='.')
 						newflag |= NV_NODISC;
 					nv_newattr (np, newflag&~NV_ASSIGN,tp->argnum);
-					if(oldname)
-						np->nvname = oldname;
 				}
 			}
 			if(tp->help && !nv_isattr(np,NV_MINIMAL|NV_EXPORT))

--- a/src/cmd/ksh93/tests/attributes.sh
+++ b/src/cmd/ksh93/tests/attributes.sh
@@ -552,5 +552,13 @@ do	unset foo
 done
 unset expect
 
+unset base
+for base in 0 1 65
+do	unset x
+	typeset -i $base x
+	[[ $(typeset -p x) == 'typeset -i x' ]] || err_exit "typeset -i base limits failed to default to 10 with base: $base."
+done
+unset x base
+
 # ======
 exit $((Errors<125?Errors:125))


### PR DESCRIPTION
src/cmd/ksh93/bltins/typeset.c: b_typeset():
- For integer bases change argnum check to default values that
  are < 2 or > 64 to 10 instead of allowing invalid bases that
  ksh cannot process.

src/cmd/ksh93/bltins/typeset.c: setall():
- Remove argnum check for integer base of 1 as base cannot be 1.
- Relocate strlen(name) to inside of conditional check for
  np->nvfun as this code does not need to run for all.
- Remove no-op oldname code.

src/cmd/ksh93/tests/attributes.sh:
- Add typeset -i base bounds checks to default base 10