### PR TITLE
Improved fix 'typeset -xu', 'typeset -xl' (rhbz#1188377)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,12 @@ For full details, see the git log at: https://github.com/ksh93/ksh
 
 Any uppercase BUG_* names are modernish shell bug IDs.
 
+2020-10-21:
+
+- Fixed: More concisely correct the exporting of uppercase and lowercase
+  variables when only the export and change case attributes were applied.
+  This fix improves upon the previous 2020-09-30 modifications.
+
 2020-10-06:
 
 - The security of virtual/non-forking subshells that locally change the present

--- a/src/cmd/ksh93/bltins/typeset.c
+++ b/src/cmd/ksh93/bltins/typeset.c
@@ -94,7 +94,6 @@ int    b_readonly(int argc,char *argv[],Shbltin_t *context)
 	memset((void*)&tdata,0,sizeof(tdata));
 	tdata.sh = context->shp;
 	tdata.aflag = '-';
-	tdata.argnum = -1;  /* tell nv_newattr() that we should not change size */
 	while((flag = optget(argv,*command=='e'?sh_optexport:sh_optreadonly))) switch(flag)
 	{
 		case 'p':

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -17,4 +17,4 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                                                                      *
 ***********************************************************************/
-#define SH_RELEASE	"93u+m 2020-10-06"
+#define SH_RELEASE	"93u+m 2020-10-21"

--- a/src/cmd/ksh93/sh/name.c
+++ b/src/cmd/ksh93/sh/name.c
@@ -2938,28 +2938,29 @@ void nv_newattr (register Namval_t *np, unsigned newatts, int size)
 		errormsg(SH_DICT,ERROR_exit(1),e_restricted,nv_name(np));
 	/* handle attributes that do not change data separately */
 	n = np->nvflag;
-	trans = !(n&NV_INTEGER) && (n&(NV_LTOU|NV_UTOL));
+	trans = !(n&NV_INTEGER) && (n&(NV_LTOU|NV_UTOL)); /* transcode to lower or upper case */
 	if(newatts&NV_EXPORT)
 		nv_offattr(np,NV_IMPORT);
-	if(((n^newatts)&NV_EXPORT))
+	if(((n^newatts)&NV_EXPORT)) /* EXPORT attribute has been toggled */
 	{
 		/* record changes to the environment */
-		if(n&NV_EXPORT)
+		if(n&NV_EXPORT) 
 		{
+			/* EXPORT exists on old attributes therefore not on new */
 			nv_offattr(np,NV_EXPORT);
 			env_delete(shp->env,nv_name(np));
 		}
 		else
-		{
+		{ 
+			/* EXPORT is now turned on for new attributes */
 			nv_onattr(np,NV_EXPORT);
 			sh_envput(shp->env,np);
 		}
-		if((n^newatts)==NV_EXPORT && size==-1)
+		if((n^newatts)==NV_EXPORT && !trans)
+			/* Only EXPORT attribute has changed and thus all work has been done. */
 			return;
 	}
 	oldsize = nv_size(np);
-	if(size==-1)
-		size = oldsize;
 	if((size==oldsize|| (n&NV_INTEGER)) && !trans && ((n^newatts)&~NV_NOCHANGE)==0)
 	{
 		if(size)


### PR DESCRIPTION
'typeset -xu' and 'typeset -xl' would export the variable but fail
to change case in the value as the check between old and new
attributes did not provide the necesssary insight for lower or
upper case transcoding due to the lower or upper case attribute
being set within typeset.c prior to calling name.c nv_newattr
function.

Previous rhbz#1188377 patch added a conditional check for size==-1
which in effect caused the nv_newattr export code block return
optimization to never be executed as one cannot set any attributes
using the readonly builtin. By altering the size==-1 check to !trans
the export only optimization can run.

Also, the rhbz#1188377 patch altered new_attr function by setting
the new size to oldsize if run by the readonly builtin. The result
of setting size==oldsize allowed the succeeding if statement to
run more frequently and if size was a non-zero value resulted in
nv_setsize resetting the value to what it already was. Investigation
yielded that size was always 0 coming from the readonly builtin.

src/cmd/ksh93/bltins/typeset.c:
- Remove the setting of tdata.argnum to -1 as it is not needed due to
  existing name.c nv_newattr() logic.

src/cmd/ksh93/sh/name.c: nv_newattr():
- Corrected the export only check optimization by using !trans instead
  of using size==-1.
- Removed previous condition check to set size=oldsize if coming from
  the readonly builtin. nv_newattr already had existing logic to
  prevent changing the size via nv_setsize as size is always 0 when
  coming from readonly builtin.