### PR TITLE
Fix incompatibilities between the Korn shell and the musl C library

### DIFF
--- a/src/lib/libast/features/lib
+++ b/src/lib/libast/features/lib
@@ -723,3 +723,13 @@ tst	no64 -D_LARGEFILE64_SOURCE note{ largefile 64 broken }end execute{
 	echo "#undef	_lib_statvfs64"
 	echo "#undef	_lib_truncate64"
 }end
+
+tst	need64 -D_LARGEFILE64_SOURCE note{ off64_t necessary }end nocompile{
+	#include <sys/types.h>
+	typedef off64_t __ast_off64_t__;
+	typedef off_t __ast_off_t__;
+	extern __ast_off64_t__ x;
+	__ast_off_t__ x;
+}end fail{
+	echo "#undef	_typ_off64_t"
+}end

--- a/src/lib/libast/features/wchar
+++ b/src/lib/libast/features/wchar
@@ -16,11 +16,17 @@ lib	towlower,towupper stdlib.h stdio.h wchar.h
 typ	mbstate_t stdlib.h stdio.h wchar.h
 nxt	wchar
 
-cat{
+run{
+cat <<!
 	#ifndef _SFSTDIO_H
 	#include <ast_common.h>
 	#include <stdio.h>
 	#endif
+
+	#if _hdr_wchar && defined(_nxt_wchar)
+	#include ${_nxt_wchar-_nxt_wchar}	/* the native wchar.h */
+	#endif
+!
 }end
 
 if	tst note{ <wchar.h> requires native <stdio.h> }end nocompile{
@@ -53,10 +59,6 @@ endif
 
 run{
 cat <<!
-	#if _hdr_wchar && defined(_nxt_wchar)
-	#include ${_nxt_wchar-_nxt_wchar}	/* the native wchar.h */
-	#endif
-
 	#ifndef WEOF
 	#define WEOF		(-1)
 	#endif

--- a/src/lib/libast/include/ast_std.h
+++ b/src/lib/libast/include/ast_std.h
@@ -93,6 +93,9 @@ struct _sfio_s;
 #ifndef __FILE_defined
 #define __FILE_defined 1
 #endif
+#ifndef __DEFINED_FILE
+#define __DEFINED_FILE 1
+#endif
 #endif
 
 /* locale stuff */


### PR DESCRIPTION
Define __DEFINED_FILE to hide FILE internals from the Korn shell's SFIO;
Include wchar.h before redefining iswalpha() to avoid mangling the C library's declaration; and
Test whether off64_t and off_t are actually distinct types before using the former.