### PR TITLE
UnixWare and typeset fixes

### DIFF
--- a/src/cmd/INIT/Makefile
+++ b/src/cmd/INIT/Makefile
@@ -60,7 +60,7 @@ cc ld ldd :PACKAGE_INIT: mamake.c proto.c ratz.c release.c
 	cc.sco.i386 \
 	cc.sgi.mips2 cc.sgi.mips3 cc.sgi.mips3-o32 cc.sgi.mips4 \
 	cc.sgi.mips4-n32 ldd.sgi \
-	cc.unix.mc68k
+	cc.unix.mc68k cc.unixware.i386
 
 LICENSE : .DONTCARE
 

--- a/src/cmd/INIT/cc.unixware.i386
+++ b/src/cmd/INIT/cc.unixware.i386
@@ -1,0 +1,9 @@
+: unixware.i386 cc wrapper
+
+HOSTTYPE=unixware.i386
+
+case " $* " in
+*" -dumpmachine "*) echo $HOSTTYPE; exit ;;
+esac
+
+/bin/cc -D_XOPEN_UNIX -D_XOPEN_SOURCE_EXTENDED "$@"

--- a/src/cmd/ksh93/bltins/typeset.c
+++ b/src/cmd/ksh93/bltins/typeset.c
@@ -196,8 +196,9 @@ int    b_typeset(int argc,register char *argv[],Shbltin_t *context)
 	Namdecl_t 	*ntp = (Namdecl_t*)context->ptr;
 	Dt_t		*troot;
 	int		isfloat=0, shortint=0, sflag=0;
-	char		*new_argv[argc + 1];
+	char		**new_argv;
 
+	new_argv = (char **)stakalloc((argc + 2) * sizeof(char*));
 	memset((void*)&tdata,0,sizeof(tdata));
 	tdata.sh = context->shp;
 	troot = tdata.sh->var_tree;

--- a/src/lib/libast/features/standards
+++ b/src/lib/libast/features/standards
@@ -6,9 +6,9 @@ set stdio
 # careful that we don't get fooled by presence of FreeBSD that underpins some
 # subsystems in Mac OS X; there are other Apple-specific portability hacks
 # elsewhere we should not interfere with.
-if tst note{ FreeBSD or DragonFly BSD }end compile{
+if tst note{ FreeBSD, DragonFly BSD, or UnixWare }end compile{
 		#include <sys/param.h>
-		#if (!defined(__FreeBSD__) && !defined(__DragonFly__)) || defined(APPLE)
+		#if (!defined(__FreeBSD__) && !defined(__DragonFly__) && !defined(__USLC__)) || defined(APPLE)
 		#error not a FreeBSD or DragonFly BSD system
 		#endif
 	}end {


### PR DESCRIPTION
Hi,

This patch fixes an ISO C90 incompatibility and adds support for UnixWare. While porting, I found a fencepost error within typeset, which writes new_argv[argc+1] while new_argv only has argc+1 [0..argc] elements:
                for (n = 1; n <= argc; n++)
                        new_argv[n + 1] = argv[n];

Thanks,
Lev