### PR TITLE
Reenable the clobber method on UnixWare.

### DIFF
--- a/src/cmd/ksh93/sh/main.c
+++ b/src/cmd/ksh93/sh/main.c
@@ -53,7 +53,7 @@
 /* These routines are referenced by this module */
 static void	exfile(Shell_t*, Sfio_t*,int);
 static void	chkmail(Shell_t *shp, char*);
-#if defined(_lib_fork) && !defined(_NEXT_SOURCE) && !defined(__USLC__) && !defined(__sun)
+#if defined(_lib_fork) && !defined(_NEXT_SOURCE) && !defined(__sun)
     static void	fixargs(char**,int);
 #else
 #   define fixargs(a,b)


### PR DESCRIPTION
UnixWare's ps prefers to read psinfo (from the proc structure in
kernel memory) within /proc as an anti-Trojan horse measure.
Updates to argv[0] are still reflected within /proc/$pid/cmdline,
which is useful for diagnostic purposes.

src/cmd/ksh93/sh/main.c:
- Remove __USLC__ from the list of platforms excluded from the
  fixargs method.

src/cmd/ksh93/tests/basic.sh:
- Read /proc/$pid/cmdline instead of ps on UnixWare.