### PR TITLE
b_typeset(): Correct wrong numeric attribute change for floating points

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,6 +9,9 @@ Any uppercase BUG_* names are modernish shell bug IDs.
   IFS field splitting to be deactivated in code executed after the trap action.
   This bug was introduced in ksh 93t+ 2009-11-30.
 
+- Fixed: a bit flag collision in typeset when providing -u with -F or -E that
+  caused incorrect variable attributes to be assigned or altered to -X.
+
 2021-01-23:
 
 - Fixed: when the DEBUG trap was redefined in a subshell, the DEBUG trap in

--- a/NEWS
+++ b/NEWS
@@ -5,12 +5,12 @@ Any uppercase BUG_* names are modernish shell bug IDs.
 
 2021-01-24:
 
+- Fixed a bug in 'typeset': combining the -u option with -F or -E caused the
+  variable to become a hexadecimal floating point in error.
+
 - Fixed: an unquoted variable expansion evaluated in a DEBUG trap action caused
   IFS field splitting to be deactivated in code executed after the trap action.
   This bug was introduced in ksh 93t+ 2009-11-30.
-
-- Fixed: a bit flag collision in typeset when providing -u with -F or -E that
-  caused incorrect variable attributes to be assigned or altered to -X.
 
 2021-01-23:
 

--- a/src/cmd/ksh93/bltins/typeset.c
+++ b/src/cmd/ksh93/bltins/typeset.c
@@ -274,6 +274,9 @@ int    b_typeset(int argc,register char *argv[],Shbltin_t *context)
 					flag &= ~NV_EXPNOTE;
 					flag |= NV_HEXFLOAT;
 				}
+				else
+				        /* n=='F' Remove possible collision with NV_UNSIGN/NV_HEXFLOAT */
+				        flag &= ~NV_HEXFLOAT;
 				break;
 			case 'b':
 				flag |= NV_BINARY;
@@ -352,8 +355,11 @@ int    b_typeset(int argc,register char *argv[],Shbltin_t *context)
 				flag |= NV_TAGGED;
 				break;
 			case 'u':
-				tdata.wctname = e_toupper;
-				flag |= NV_LTOU;
+			        if(!isfloat)
+			        {
+				        tdata.wctname = e_toupper;
+				        flag |= NV_LTOU;
+				}
 				break;
 			case 'x':
 				flag &= ~NV_VARNAME;


### PR DESCRIPTION
src/cmd/ksh93/bltins/typeset.c
- If the unsigned option (-u) was provided in conjunction with a floating
  point (-F) then due to a flag collision with NV_UNSIGN and NV_HEXFLOAT
  both having the value of NV_LTOU caused the floating point to become a
  hexadecimal floating point (-X) in error. Also, if a -E option flag
  was followed with a -u option then the resulting variable would be
  both a scientific notation and a hexadecimal floating point at the same
  time.

  This commit resolves the following incorrect variable assignments:
  $ unset a; typeset -uF a=2; typeset -p a
  typeset -X a=0x1.0000000000p+1
  $ unset a; typeset -Fu a=2; typeset -p a
  typeset -X a=0x1.0000000000p+1
  $ unset a; typeset -ulF a=2; typeset -p a
  typeset -l -X a=0x1.0000000000p+1
  $ unset a; typeset -Ful a=2; typeset -p a
  typeset -l -X a=0x1.0000000000p+1
  $ unset a; typeset -Eu a=2; typeset -p a
  typeset -E -X a=2
  $ unset a; typeset -Eul a=2; typeset -p a
  typeset -l -E -X a=2