### PR TITLE
Produce IEEE compliant output from pow() despite platform deviations

### DIFF
--- a/src/cmd/ksh93/features/math.sh
+++ b/src/cmd/ksh93/features/math.sh
@@ -29,7 +29,7 @@ esac
 
 command=$0
 iffeflags="-n -v"
-iffehdrs="math.h"
+iffehdrs="ast_float.h"
 iffelibs="-lm"
 table=/dev/null
 
@@ -136,11 +136,11 @@ case $_hdr_ieeefp in
 1)	echo "#include <ieeefp.h>" ;;
 esac
 cat <<!
+#include <ast_float.h>
 #if defined(__ia64__) && defined(signbit)
 # if defined __GNUC__ && __GNUC__ >= 4
 #  define __signbitl(f)		__builtin_signbitl(f)
 # else
-#  include <ast_float.h>
 #  if _lib_copysignl
 #   define __signbitl(f)	(int)(copysignl(1.0,(f))<0.0)
 #  endif

--- a/src/cmd/ksh93/tests/arith.sh
+++ b/src/cmd/ksh93/tests/arith.sh
@@ -297,6 +297,12 @@ fi
 if	(( (4**3)**2 != pow(pow(4,3),2) ))
 then	err_exit '(4**3)**2 not working'
 fi
+if	(( 1**Inf != pow(1,Inf) ))
+then	err_exit '1**Inf not working'
+fi
+if	(( 1**NaN != pow(1,NaN) ))
+then	err_exit '1**NaN not working'
+fi
 typeset -Z3 x=11
 typeset -i x
 if	(( x != 11 ))
@@ -465,8 +471,12 @@ then	set \
 	(( NaN != NaN )) || err_exit 'NaN == NaN'
 	(( -5*Inf == -Inf )) || err_exit '-5*Inf != -Inf'
 	[[ $(print -- $((sqrt(-1.0)))) == ?(-)nan ]]|| err_exit 'sqrt(-1.0) != NaN'
+	(( pow(1.0,-Inf) == 1.0 )) || err_exit 'pow(1.0,-Inf) != 1.0'
+	(( pow(-Inf,0.0) == 1.0 )) || err_exit 'pow(-Inf,0.0) != 1.0'
 	(( pow(1.0,Inf) == 1.0 )) || err_exit 'pow(1.0,Inf) != 1.0'
 	(( pow(Inf,0.0) == 1.0 )) || err_exit 'pow(Inf,0.0) != 1.0'
+	(( pow(1.0,NaN) == 1.0 )) || err_exit 'pow(1.0,NaN) != 1.0'
+	(( pow(Nan,0.0) == 1.0 )) || err_exit 'pow(Nan,0.0) != 1.0'
 	[[ $(print -- $((NaN/Inf))) == ?(-)nan ]] || err_exit 'NaN/Inf != NaN'
 	(( 4.0/Inf == 0.0 )) || err_exit '4.0/Inf != 0.0'
 else	err_exit 'Inf and NaN not working'

--- a/src/cmd/ksh93/tests/bracket.sh
+++ b/src/cmd/ksh93/tests/bracket.sh
@@ -264,9 +264,14 @@ test '(' = ')' && err_exit '"test ( = )" should not be true'
 [[ $($SHELL -c 'case  F in ~(Eilr)[a-z0-9#]) print ok;;esac' 2> /dev/null) == ok ]] || err_exit '~(Eilr) not working in case command'
 [[ $($SHELL -c "case  Q in ~(Fi)q |  \$'\E') print ok;;esac" 2> /dev/null) == ok ]] || err_exit '~(Fi)q | \E  not working in case command'
 
-for l in C en_US.ISO8859-15
-do	[[ $($SHELL -c "LC_COLLATE=$l" 2>&1) ]] && continue
-	export LC_COLLATE=$l
+for l in C en_US.ISO8859-1 en_US.ISO8859-15 en_US.UTF-8
+do	if [[ ! $(locale -a) =~ "${l}" ]] ||
+	   [[ $($SHELL -c "LC_COLLATE=${l}" 2>&1) ]]
+	then
+		print -u2 "\t${Command}[$LINENO]: warning: cannot test unavailable locale: ${l}"
+                continue
+	fi
+	export LC_COLLATE="${l}"
 	set -- \
 		'A'   0 1 1   0 1 1      1 0 0   1 0 0   \
 		'Z'   0 1 1   0 1 1      1 0 0   1 0 0   \
@@ -300,7 +305,7 @@ do	[[ $($SHELL -c "LC_COLLATE=$l" 2>&1) ]] && continue
 			shift
 			[[ $c == $p ]]
 			g=$?
-			[[ $g == $e ]] || err_exit "[[ '$c' == $p ]] for LC_COLLATE=$l failed -- expected $e, got $g"
+			[[ $g == $e ]] || err_exit "[[ '$c' == $p ]] for LC_COLLATE=${l} failed -- expected $e, got $g"
 		done
 	done
 done

--- a/src/cmd/ksh93/tests/bracket.sh
+++ b/src/cmd/ksh93/tests/bracket.sh
@@ -388,6 +388,17 @@ actual=$(echo begin; [ -n X -a -t ] || test -n X -a -t && echo -t is true; echo 
 [[ $actual == "$expect" ]] || err_exit 'test -t in comsub fails (compound expression)' \
 	"(expected $(printf %q "$expect"), got $(printf %q "$actual"))"
 
+function has_controlling_terminal
+{
+    if [[ -c /dev/tty ]] && [[ -w /dev/tty ]]; then
+        >/dev/tty || return
+        print -- TRUE
+    fi
+}
+if [[ $(has_controlling_terminal) != "TRUE" ]]
+then
+    print -u2 "\t${Command}[$LINENO]: warning: no controlling terminal: skipping comsub tests"
+else
 # This is the more complex case that does redirect stdout within the command substitution to the
 # actual tty. Thus the [ -t 1 ] test should be true.
 actual=$(echo begin; exec >/dev/tty; [ -t 1 ] && test -t 1 && [[ -t 1 ]]) \
@@ -399,6 +410,8 @@ actual=$(echo begin; exec >/dev/tty; [ -t ] && test -t) \
 || err_exit 'test -t in comsub with exec >/dev/tty fails'
 actual=$(echo begin; exec >/dev/tty; [ -n X -a -t ] && test -n X -a -t) \
 || err_exit 'test -t in comsub with exec >/dev/tty fails (compound expression)'
+fi
+unset -f has_controlling_terminal
 
 # The POSIX mode should disable the ancient 'test -t' compatibility hack.
 if	[[ -o ?posix ]]

--- a/src/lib/libast/features/float
+++ b/src/lib/libast/features/float
@@ -1230,3 +1230,16 @@ tst	- -DSCAN=1 - -lm -DSTRTO=1 - -DMAC=1 - -DDIV=1 - -DEXP=1 - -DADD=1 - -DMPY=1
 		return 0;
 	}
 }end
+
+tst	ast_pow_ieee -lm note{ pow(1,inf) is IEEE compliant }end execute{
+	#include <sys/types.h>
+	#include <sys/stat.h>
+	#include <stdlib.h>
+	#include <unistd.h>
+	#include <math.h>
+	int main() { return pow(1.0, 1.0 / 0.0) != 1.0; }
+}end fail{
+	echo '#define powf(x,y)	(((x)==1.0)?1.0:powf((x),(y)))'
+	echo '#define pow(x,y)	(((x)==1.0)?1.0:pow((x),(y)))'
+	echo '#define powl(x,y)	(((x)==1.0)?1.0:powl((x),(y)))'
+}end

--- a/src/lib/libast/misc/magic.c
+++ b/src/lib/libast/misc/magic.c
@@ -687,8 +687,8 @@ ckmagic(register Magic_t* mp, const char* file, char* buf, char* end, struct sta
 				c = mp->fbsz;
 				if (c >= sizeof(mp->nbuf))
 					c = sizeof(mp->nbuf) - 1;
-				p = (char*)memcpy(mp->nbuf, p, c);
-				p[c] = 0;
+				p = strncpy(mp->nbuf, p, c);
+				p[c] = '\0';
 				ccmapstr(mp->x2n, p, c);
 				if ((c = regexec(ep->value.sub, p, elementsof(matches), matches, 0)) || (c = regsubexec(ep->value.sub, p, elementsof(matches), matches)))
 				{


### PR DESCRIPTION
src/cmd/ksh93/features/math.sh:
- Specify ast_float.h within iffehdrs instead of math.h, so that iffe
  will pick up on macro substitutions within libast. This should make
  any future efforts to remedy floating point behavior easier as well.
- Always include ast_float.h within the generated math header file,
  not just on IA64 platforms.

src/cmd/ksh93/tests/arith.sh:
- Test pow(1.0,-Inf) and pow(1.0,NaN) for IEEE compliance as well.
- Test the exponentiation operator (**) in addition, as streval.c,
  which processes the same, calls pow() separately.

src/lib/libast/features/float:
- Test the IEEE compliance of the underlying math library's pow()
  function and substitute macros producing compliant behavior if
  necessary.