### PR TITLE
Skip comsub tests when testing without a controlling terminal

### DIFF
--- a/src/cmd/ksh93/tests/bracket.sh
+++ b/src/cmd/ksh93/tests/bracket.sh
@@ -388,17 +388,21 @@ actual=$(echo begin; [ -n X -a -t ] || test -n X -a -t && echo -t is true; echo 
 [[ $actual == "$expect" ]] || err_exit 'test -t in comsub fails (compound expression)' \
 	"(expected $(printf %q "$expect"), got $(printf %q "$actual"))"
 
-# This is the more complex case that does redirect stdout within the command substitution to the
-# actual tty. Thus the [ -t 1 ] test should be true.
-actual=$(echo begin; exec >/dev/tty; [ -t 1 ] && test -t 1 && [[ -t 1 ]]) \
-|| err_exit 'test -t 1 in comsub with exec >/dev/tty fails'
-actual=$(echo begin; exec >/dev/tty; [ -n X -a -t 1 ] && test -n X -a -t 1 && [[ -n X && -t 1 ]]) \
-|| err_exit 'test -t 1 in comsub with exec >/dev/tty fails (compound expression)'
-# Same for the ancient compatibility hack for 'test -t' with no arguments.
-actual=$(echo begin; exec >/dev/tty; [ -t ] && test -t) \
-|| err_exit 'test -t in comsub with exec >/dev/tty fails'
-actual=$(echo begin; exec >/dev/tty; [ -n X -a -t ] && test -n X -a -t) \
-|| err_exit 'test -t in comsub with exec >/dev/tty fails (compound expression)'
+if	! >/dev/tty
+then	print -u2 "\t${Command}[$LINENO]: warning: no controlling terminal: skipping comsub tests"
+else	# This is the more complex case that does redirect stdout within the command substitution to
+	# the actual tty. Thus the [ -t 1 ] test should be true.
+	actual=$(echo begin; exec >/dev/tty; [ -t 1 ] && test -t 1 && [[ -t 1 ]]) \
+		|| err_exit 'test -t 1 in comsub with exec >/dev/tty fails'
+	actual=$(echo begin; exec >/dev/tty; [ -n X -a -t 1 ] && \
+		test -n X -a -t 1 && [[ -n X && -t 1 ]]) \
+		|| err_exit 'test -t 1 in comsub with exec >/dev/tty fails (compound expression)'
+	# Same for the ancient compatibility hack for 'test -t' with no arguments.
+	actual=$(echo begin; exec >/dev/tty; [ -t ] && test -t) \
+		|| err_exit 'test -t in comsub with exec >/dev/tty fails'
+	actual=$(echo begin; exec >/dev/tty; [ -n X -a -t ] && test -n X -a -t) \
+		|| err_exit 'test -t in comsub with exec >/dev/tty fails (compound expression)'
+fi
 
 # The POSIX mode should disable the ancient 'test -t' compatibility hack.
 if	[[ -o ?posix ]]


### PR DESCRIPTION
src/cmd/ksh93/tests/bracket.sh:
- Test for the presence of a controlling terminal by writing to
  /dev/tty. In the absence of a controlling terminal, the write will
  fail and the comsub tests can be skipped as they are guaranteed to
  fail otherwise.
- Issue a diagnostic if the comsub tests are skipped.

Hi @McDutchie, the reason for this last patch is that I'm trying to package this edition of the Korn shell for the Void Linux distribution.

See void-linux/void-packages#28685 . Most of the tests run except for those requiring a controlling terminal. Actually, I was going to look into why there is a regression with the i386 build, because that's the only thing holding this package back.