### PR TITLE
Unixware fixes

### DIFF
--- a/src/cmd/ksh93/bltins/sleep.c
+++ b/src/cmd/ksh93/bltins/sleep.c
@@ -139,7 +139,7 @@ void sh_delay(double t, int sflag)
 
 	ts.tv_sec = n;
 	ts.tv_nsec = 1000000000 * (t - (double)n);
-	while(tvsleep(&ts, &tx) < 0 && errno == EINTR)
+	while(tvsleep(&ts, &tx) < 0)
 	{
 		if ((shp->trapnote & (SH_SIGSET | SH_SIGTRAP)) || sflag)
 			return;

--- a/src/cmd/ksh93/tests/functions.sh
+++ b/src/cmd/ksh93/tests/functions.sh
@@ -1126,7 +1126,7 @@ function gosleep
 	"$bin_sleep" 1
 }
 x=$(
-	(sleep .25; pid=; ps | grep sleep | read pid extra; [[ $pid ]] && kill -- "$pid") &
+	(sleep .25; pid=; ps 2>/dev/null | grep sleep | read pid extra; [[ $pid ]] && kill -- "$pid") &
 	gosleep 2> /dev/null
 	print ok
 )

--- a/src/cmd/ksh93/tests/variables.sh
+++ b/src/cmd/ksh93/tests/variables.sh
@@ -40,11 +40,15 @@ if	(( RANDOM==RANDOM || $RANDOM==$RANDOM ))
 then	err_exit RANDOM variable not working
 fi
 # SECONDS
-let SECONDS=0.0
-sleep .001
-if	(( SECONDS < .001 ))
-then	err_exit "either 'sleep' or \$SECONDS not working"
+float secElapsed=0.0 secSleep=0.001
+let SECONDS=$secElapsed
+sleep $secSleep
+secElapsed=SECONDS
+if	(( secElapsed < secSleep ))
+then	err_exit "slept ${secElapsed} seconds instead of ${secSleep}: " \
+                 "either 'sleep' or \$SECONDS not working"
 fi
+unset -v secElapsed secSleep
 # _
 set abc def
 if	[[ $_ != def ]]
@@ -508,12 +512,11 @@ fi
 function foo
 {
 	typeset SECONDS=0
-	sleep .002
+	sleep 0.002
 	print $SECONDS
-
 }
 x=$(foo)
-(( x >.001 && x < 1 ))
+(( x >= 0.002 && x < 1 ))
 '
 } 2> /dev/null   || err_exit 'SECONDS not working in function'
 cat > $tmp/script <<-\!


### PR DESCRIPTION
Hi, the clock has been a recurring issue in my effort to get ksh working without regressions on UnixWare. With a small testing program, I determined that no matter the method (select, poll, usleep, etc.), UnixWare only sleeps for approximate times, and sometimes that can actually be for less than the time we asked for. The Korn shell picks up on these small oscillations, causing sporadic test failures.

Being able to promise to users that 'sleep 2' actually sleeps for a minimum two seconds seems like a very desirable quality (e.g., for synchronization of tasks), so I decided to try to get to the root of the issue and fortify the libast-OS sleep interface. With this patch, ksh won't trust the OS but will instead always verify that the system clock has advanced by the appropriate amount.

Running the variables.sh shtest module in a loop, I can no longer provoke test failures, even when I tightened up the timing parameters for the SECONDS function test.