### PR TITLE
Fix the Alt+D and Alt+H keyboard shortcuts in emacs mode

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,11 @@ For full details, see the git log at: https://github.com/ksh93/ksh
 
 Any uppercase BUG_* names are modernish shell bug IDs.
 
+2021-02-15:
+
+- Fixed a bug in the emacs built-in editor, introduced on 2020-09-17, that
+  made the Meta-D and Meta-H keys delete single characters instead of words.
+
 2021-02-14:
 
 - Due to a deficiency in some UNIX veriants, the 'sleep' built-in command could

--- a/src/cmd/ksh93/edit/emacs.c
+++ b/src/cmd/ksh93/edit/emacs.c
@@ -318,13 +318,13 @@ int ed_emacsread(void *context, int fd,char *buff,int scend, int reedit)
 			killing = 0;
 #endif
 		oadjust = count = adjust;
-		if(vt220_save_repeat)
-		{
-			count = vt220_save_repeat;
-			vt220_save_repeat = 0;
-		}
 		if(count<0)
 			count = 1;
+		if(vt220_save_repeat>0)
+		{
+			count += vt220_save_repeat;
+			vt220_save_repeat = 0;
+		}
 		adjust = -1;
 		i = cur;
 		if(c!='\t' && c!=ESC && !digit(c))

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -20,7 +20,7 @@
 
 #define SH_RELEASE_FORK	"93u+m"		/* only change if you develop a new ksh93 fork */
 #define SH_RELEASE_SVER	"1.0.0-alpha"	/* semantic version number: https://semver.org */
-#define SH_RELEASE_DATE	"2021-02-14"	/* must be in this format for $((.sh.version)) */
+#define SH_RELEASE_DATE	"2021-02-15"	/* must be in this format for $((.sh.version)) */
 #define SH_RELEASE_CPYR	"(c) 2020-2021 Contributors to ksh " SH_RELEASE_FORK
 
 /* Scripts sometimes field-split ${.sh.version}, so don't change amount of whitespace. */


### PR DESCRIPTION
This commit fixes the functionality of Alt+D and Alt+H in emacs mode. These keyboard shortcuts are intended to work on whole words, but after commit 13c3fb21 their functionality was reduced to deleting only singular letters:

```
$ Test word <Alt+H>    # This should delete 'word', not just 'd'.
$ Foo <Alt+B> <Alt+D>  # This should delete 'Foo', not just 'F'.
```

Man page entries for reference:
```
  M-d       Delete current word.
  M-^H      (Meta-backspace) Delete previous word.
  M-h       Delete previous word.
```
Changes in emacs.c:
 - `count` cannot be overridden when handling Alt+D or Alt+H, so add the total number of repetitions to count instead (the number of repetitions can't be negative).
- If `count` is a negative number, set it to one before adding the number of repetitions.