### PR TITLE
Fix backslashctrl behavior in emacs mode reverse search

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,11 @@ For full details, see the git log at: https://github.com/ksh93/ksh
 
 Any uppercase BUG_* names are modernish shell bug IDs.
 
+2021-02-16:
+
+- Fixed buggy behavior in emacs mode reverse search when control characters
+  are escaped with a backslash.
+
 2021-02-15:
 
 - Fixed a regression introduced by ksh93 (was not in ksh88): an empty 'case'

--- a/NEWS
+++ b/NEWS
@@ -5,12 +5,10 @@ Any uppercase BUG_* names are modernish shell bug IDs.
 
 2021-02-17:
 
-- Erasing a backslash while doing a reverse search in emacs mode no longer
-  deletes extra characters.
-- The interrupt character can now be escaped in emacs mode when entered
-  after a backslash.
-- A minor documentation error that called ^? the interrupt character has
-  been fixed (^C is usually the interrupt character).
+- Emacs mode fixes:
+  1. Erasing a backslash while doing a reverse search (^R) no longer deletes
+     extra characters.
+  2. The backslash now escapes a subsequent interrupt (^C) as documented.
 
 2021-02-15:
 

--- a/NEWS
+++ b/NEWS
@@ -3,10 +3,14 @@ For full details, see the git log at: https://github.com/ksh93/ksh
 
 Any uppercase BUG_* names are modernish shell bug IDs.
 
-2021-02-16:
+2021-02-17:
 
-- Fixed buggy behavior in emacs mode reverse search when control characters
-  are escaped with a backslash.
+- Erasing a backslash while doing a reverse search in emacs mode no longer
+  deletes extra characters.
+- The interrupt character can now be escaped in emacs mode when entered
+  after a backslash.
+- A minor documentation error that called ^? the interrupt character has
+  been fixed (^C is usually the interrupt character).
 
 2021-02-15:
 

--- a/src/cmd/ksh93/edit/edit.c
+++ b/src/cmd/ksh93/edit/edit.c
@@ -1068,7 +1068,7 @@ int ed_getchar(register Edit_t *ep,int mode)
 	{
 		ed_flush(ep);
 		ep->e_inmacro = 0;
-		/* The while is necessary for reads of partial multbyte chars */
+		/* The while is necessary for reads of partial multibyte chars */
 		*ep->e_vi_insert = (mode==-2);
 		if((n=ed_read(ep,ep->e_fd,readin,-LOOKAHEAD,0)) > 0)
 			n = putstack(ep,readin,n,1);

--- a/src/cmd/ksh93/edit/emacs.c
+++ b/src/cmd/ksh93/edit/emacs.c
@@ -1315,7 +1315,7 @@ static void search(Emacs_t* ep,genchar *out,int direction)
 				draw(ep,APPEND);
 				i = ed_getchar(ep->ed,1);
 
-				/* Backslashes don't affect the interrupt character or newlines */
+				/* Backslashes don't affect newlines */
 				if (i == '\n' || i == '\r')
 					goto skip;
 				else if (i == usrerase || !print(i))

--- a/src/cmd/ksh93/edit/emacs.c
+++ b/src/cmd/ksh93/edit/emacs.c
@@ -1314,10 +1314,10 @@ static void search(Emacs_t* ep,genchar *out,int direction)
 				draw(ep,APPEND);
 				i = ed_getchar(ep->ed,1);
 
-				/* Backslashes don't affect Ctrl+C or newlines */
+				/* Backslashes don't affect the interrupt character or newlines */
 				if (i == '\n' || i == '\r')
 					goto skip;
-				else if (i == cntl('C'))
+				else if (i == ep->ed->e_intr)
 					goto restore;
 				else if (i == usrerase || !print(i))
 					string[--sl] = '\0';

--- a/src/cmd/ksh93/edit/emacs.c
+++ b/src/cmd/ksh93/edit/emacs.c
@@ -281,11 +281,12 @@ int ed_emacsread(void *context, int fd,char *buff,int scend, int reedit)
 #endif /* ESH_NFIRST */
 	}
 	ep->CntrlO = 0;
-	while ((c = ed_getchar(ep->ed,0)) != (-1))
+	while ((c = ed_getchar(ep->ed,backslash)) != (-1))
 	{
 		if (backslash)
 		{
-			backslash = 0;
+			if(c!='\\')
+				backslash = 0;
 			if (c==usrerase||c==usrkill||(!print(c) &&
 				(c!='\r'&&c!='\n')))
 			{
@@ -1317,8 +1318,6 @@ static void search(Emacs_t* ep,genchar *out,int direction)
 				/* Backslashes don't affect the interrupt character or newlines */
 				if (i == '\n' || i == '\r')
 					goto skip;
-				else if (i == ep->ed->e_intr)
-					goto restore;
 				else if (i == usrerase || !print(i))
 					string[--sl] = '\0';
 			}

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -20,7 +20,7 @@
 
 #define SH_RELEASE_FORK	"93u+m"		/* only change if you develop a new ksh93 fork */
 #define SH_RELEASE_SVER	"1.0.0-alpha"	/* semantic version number: https://semver.org */
-#define SH_RELEASE_DATE	"2021-02-15"	/* must be in this format for $((.sh.version)) */
+#define SH_RELEASE_DATE	"2021-02-16"	/* must be in this format for $((.sh.version)) */
 #define SH_RELEASE_CPYR	"(c) 2020-2021 Contributors to ksh " SH_RELEASE_FORK
 
 /* Scripts sometimes field-split ${.sh.version}, so don't change amount of whitespace. */

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -20,7 +20,7 @@
 
 #define SH_RELEASE_FORK	"93u+m"		/* only change if you develop a new ksh93 fork */
 #define SH_RELEASE_SVER	"1.0.0-alpha"	/* semantic version number: https://semver.org */
-#define SH_RELEASE_DATE	"2021-02-16"	/* must be in this format for $((.sh.version)) */
+#define SH_RELEASE_DATE	"2021-02-17"	/* must be in this format for $((.sh.version)) */
 #define SH_RELEASE_CPYR	"(c) 2020-2021 Contributors to ksh " SH_RELEASE_FORK
 
 /* Scripts sometimes field-split ${.sh.version}, so don't change amount of whitespace. */

--- a/src/cmd/ksh93/sh.1
+++ b/src/cmd/ksh93/sh.1
@@ -4969,7 +4969,7 @@ If the
 shell option is on (which is the default setting), this escapes the next character.
 Editing characters, the user's erase, kill and
 interrupt (normally
-.BR ^? )
+.BR ^C )
 characters
 may be entered
 in a command line or in a search string if preceded by a

--- a/src/cmd/ksh93/tests/pty.sh
+++ b/src/cmd/ksh93/tests/pty.sh
@@ -660,9 +660,9 @@ p :test-4:
 w \cRs\\\\\cH\cH\cH
 u set
 
-# \ shouldn't escape the interrupt character (usually Ctrl+C)
-w echo stringgg \cRset\\\cC\cH\cH
-u string
+# \ should escape the interrupt character (usually Ctrl+C)
+w string\\\cC\cH
+r ^string\r\n$
 !
 
 # ======

--- a/src/cmd/ksh93/tests/pty.sh
+++ b/src/cmd/ksh93/tests/pty.sh
@@ -641,8 +641,7 @@ r ^:test-2:
 !
 
 # err_exit #
-((SHOPT_ESH)) &&
-tst $LINENO <<"!"
+((SHOPT_ESH)) && tst $LINENO <<"!"
 L backslashctrl functionality in emacs mode reverse search
 
 d 10

--- a/src/cmd/ksh93/tests/pty.sh
+++ b/src/cmd/ksh93/tests/pty.sh
@@ -640,5 +640,30 @@ r ^/dev/null\r\n$
 r ^:test-2:
 !
 
+# err_exit #
+tst $LINENO <<"!"
+L backslashctrl functionality in emacs mode reverse search
+
+d 10
+p :test-1:
+w set -o emacs --nobackslashctrl
+
+# --nobackslashctrl shouldn't be ignored by reverse search
+p :test-2:
+w \cR\\\cH\cH
+r ^:test-2: \r\n$
+p :test-3:
+w set -o backslashctrl
+
+# Test for too many backslash deletions
+p :test-4:
+w \cRs\\\\\cH\cH\cH
+u set
+
+# \ shouldn't escape Ctrl+C
+w echo stringgg \cRset\\\cC\cH\cH
+u string
+!
+
 # ======
 exit $((Errors<125?Errors:125))

--- a/src/cmd/ksh93/tests/pty.sh
+++ b/src/cmd/ksh93/tests/pty.sh
@@ -641,28 +641,33 @@ r ^:test-2:
 !
 
 # err_exit #
-((SHOPT_ESH)) && tst $LINENO <<"!"
-L backslashctrl functionality in emacs mode reverse search
+((SHOPT_ESH)) && [[ -o ?backslashctrl ]] && tst $LINENO <<"!"
+L nobackslashctrl in emacs
 
 d 10
-p :test-1:
 w set -o emacs --nobackslashctrl
 
 # --nobackslashctrl shouldn't be ignored by reverse search
 p :test-2:
 w \cR\\\cH\cH
 r ^:test-2: \r\n$
-p :test-3:
-w set -o backslashctrl
+!
 
-# Test for too many backslash deletions
-p :test-4:
-w \cRs\\\\\cH\cH\cH
-u set
+# err_exit #
+((SHOPT_ESH)) && tst $LINENO <<"!"
+L emacs backslash escaping
+
+d 10
+w set -o emacs
+
+# Test for too many backslash deletions in reverse-search mode
+p :test-2:
+w \cRset\\\\\\\\\cH\cH\cH\cH\cH
+r ^:test-2: set -o emacs$
 
 # \ should escape the interrupt character (usually Ctrl+C)
-w string\\\cC\cH
-r ^string\r\n$
+w true \\\cC
+r true \^C
 !
 
 # ======

--- a/src/cmd/ksh93/tests/pty.sh
+++ b/src/cmd/ksh93/tests/pty.sh
@@ -641,6 +641,7 @@ r ^:test-2:
 !
 
 # err_exit #
+((SHOPT_ESH)) &&
 tst $LINENO <<"!"
 L backslashctrl functionality in emacs mode reverse search
 

--- a/src/cmd/ksh93/tests/pty.sh
+++ b/src/cmd/ksh93/tests/pty.sh
@@ -660,7 +660,7 @@ p :test-4:
 w \cRs\\\\\cH\cH\cH
 u set
 
-# \ shouldn't escape Ctrl+C
+# \ shouldn't escape the interrupt character (usually Ctrl+C)
 w echo stringgg \cRset\\\cC\cH\cH
 u string
 !


### PR DESCRIPTION
This pull request fixes three `backslashctrl` bugs that occur when doing a reverse search in emacs mode:

- Emacs mode ignores `--nobackslashctrl` when in reverse search (fixed by changing an if statement). Additionally, when entering any more than one backslash, emacs mode deletes multiple backslashes after pressing backspace once (fixed by processing backslashes in a while loop). Reproducer:
```sh
$ set -o emacs --nobackslashctrl  # This fails to disable backslashctrl
$ <Ctrl+R> \\\\ <Backspace>      # Too many backslashes are erased
```

- After entering one backslash, pressing Ctrl+C escapes the input as ^C when in reverse search (Ctrl+C should ignore the effects of backslashes). Reproducer:
```sh
$ set -o emacs -o backslashctrl
$ teststring <Ctrl+R> \ <Ctrl+C>
```