### PR TITLE
Use poll instead of select when advantageous and harden tvsleep

### DIFF
--- a/src/lib/libast/features/tvlib
+++ b/src/lib/libast/features/tvlib
@@ -43,6 +43,38 @@ lib	utimets link{
 	}
 }end
 
+tst	prefer_poll note{ is select less precise than 1 ms }end execute{
+	#include <sys/types.h>
+	#include <sys/time.h>
+	#if _sys_select
+	# include <sys/select.h>
+	#else
+	# include <sys/socket.h>
+	#endif
+	int
+	main()
+	{
+		struct timeval tvSleep = { 0, 1 }, tvBefore, tvAfter;
+		int i;
+		/* Take a few measurements to prevent a fluke. */
+		for (i = 0; i < 5; ++i)
+		{
+			gettimeofday(&tvBefore, NULL);
+			select(0, NULL, NULL, NULL, &tvSleep);
+			gettimeofday(&tvAfter, NULL);
+			if (tvAfter.tv_sec == tvBefore.tv_sec + 1)
+			{
+				--tvAfter.tv_sec;
+				tvAfter.tv_usec += 1000000;
+			}
+			if ((tvAfter.tv_sec == tvBefore.tv_sec) &&
+				tvAfter.tv_usec - tvBefore.tv_usec < 1000)
+				return -1;
+		}
+		return 0;
+	}
+}end
+
 tst	- -DN=1 - -DN=2 - -DN=3 - -DN=4 output{
 	#include <sys/types.h>
 	#include <sys/time.h>


### PR DESCRIPTION
On SVR4 platforms, select is a sometimes erroneous wrapper around
the poll system call, so call poll directly for efficiency purposes if
it implies no loss in precision.

See, e.g., http://bugs.motifzone.net/long_list.cgi?buglist=129 .

src/lib/libast/features/tvlib:
- For systems lacking nanosleep, test whether select is truly more
  precise than poll.
src/lib/libast/tm/tvsleep.c:
- Verify that tv argument is not null.
- Immediately return if asked to sleep for a duration of zero.
- Immediately initialize timespec in the nanosleep case.
- Revise variable names to use Apps Hungarian.
- Use poll instead of select when there is no loss in precision.
- Check for overflow in the poll case.
- Improve comments.
- Revise arithmetic to work with unsigned types, rather than
  casting to long.
- Do not return non-zero if we have slept for a sufficient
  time.