### PR TITLE
Add more out of memory checks after allocating memory

### DIFF
--- a/src/cmd/builtin/pty.c
+++ b/src/cmd/builtin/pty.c
@@ -646,7 +646,7 @@ masterline(Sfio_t* mp, Sfio_t* lp, char* prompt, int must, int timeout, Master_t
 		r = bp->buf;
 		if (!(bp->buf = vmnewof(bp->vm, bp->buf, char, a, 0)))
 		{
-			error(ERROR_SYSTEM|2, "out of space");
+			error(ERROR_PANIC, "out of memory");
 			return 0;
 		}
 		bp->max = bp->buf + a;
@@ -785,7 +785,7 @@ dialogue(Sfio_t* mp, Sfio_t* lp, int delay, int timeout)
 	    !(master = vmnewof(vm, 0, Master_t, 1, 0)) ||
 	    !(master->buf = vmnewof(vm, 0, char, 2 * SF_BUFSIZE, 0)))
 	{
-		error(ERROR_SYSTEM|2, "out of space");
+		error(ERROR_PANIC, "out of memory");
 		id = 0;
 		line = 0;
 		goto done;
@@ -841,7 +841,7 @@ dialogue(Sfio_t* mp, Sfio_t* lp, int delay, int timeout)
 		case 'i':
 			if (!cond->next && !(cond->next = vmnewof(vm, 0, Cond_t, 1, 0)))
 			{
-				error(ERROR_SYSTEM|2, "out of space");
+				error(ERROR_PANIC, "out of memory");
 				goto done;
 			}
 			cond = cond->next;
@@ -1080,7 +1080,7 @@ b_pty(int argc, char** argv, Shbltin_t* context)
 			if (isspace(*s))
 				n++;
 		if (!(ap = newof(0, Argv_t, 1, (n + 2) * sizeof(char*) + (s - stty + 1))))
-			error(ERROR_system(1), "out of space");
+			error(ERROR_PANIC, "out of memory");
 		ap->argc = n + 1;
 		ap->argv = (char**)(ap + 1);
 		ap->args = (char*)(ap->argv + n + 2);

--- a/src/cmd/builtin/pty.c
+++ b/src/cmd/builtin/pty.c
@@ -125,6 +125,11 @@ static const char usage[] =
 #define CMIN		1
 #endif
 
+static void outofmemory(void)
+{
+	error(ERROR_SYSTEM|ERROR_PANIC, "out of memory");
+}
+
 #if !_lib_openpty && !_lib__getpty && !defined(_pty_clone)
 # if !_lib_grantpt || !_lib_unlock
 #   if !_lib_ptsname
@@ -645,10 +650,7 @@ masterline(Sfio_t* mp, Sfio_t* lp, char* prompt, int must, int timeout, Master_t
 		a = roundof(bp->max - bp->buf + n, SF_BUFSIZE);
 		r = bp->buf;
 		if (!(bp->buf = vmnewof(bp->vm, bp->buf, char, a, 0)))
-		{
-			error(ERROR_PANIC, "out of memory");
-			return 0;
-		}
+			outofmemory();
 		bp->max = bp->buf + a;
 		if (bp->buf != r)
 		{
@@ -784,12 +786,7 @@ dialogue(Sfio_t* mp, Sfio_t* lp, int delay, int timeout)
 	    !(cond = vmnewof(vm, 0, Cond_t, 1, 0)) ||
 	    !(master = vmnewof(vm, 0, Master_t, 1, 0)) ||
 	    !(master->buf = vmnewof(vm, 0, char, 2 * SF_BUFSIZE, 0)))
-	{
-		error(ERROR_PANIC, "out of memory");
-		id = 0;
-		line = 0;
-		goto done;
-	}
+		outofmemory();
 	master->vm = vm;
 	master->cur = master->end = master->buf;
 	master->max = master->buf + 2 * SF_BUFSIZE - 1;
@@ -840,10 +837,7 @@ dialogue(Sfio_t* mp, Sfio_t* lp, int delay, int timeout)
 			break;
 		case 'i':
 			if (!cond->next && !(cond->next = vmnewof(vm, 0, Cond_t, 1, 0)))
-			{
-				error(ERROR_PANIC, "out of memory");
-				goto done;
-			}
+				outofmemory();
 			cond = cond->next;
 			cond->flags = IF;
 			if ((cond->prev->flags & SKIP) && !(cond->text = 0) || !(cond->text = masterline(mp, lp, 0, 0, timeout, master)))
@@ -1080,7 +1074,7 @@ b_pty(int argc, char** argv, Shbltin_t* context)
 			if (isspace(*s))
 				n++;
 		if (!(ap = newof(0, Argv_t, 1, (n + 2) * sizeof(char*) + (s - stty + 1))))
-			error(ERROR_PANIC, "out of memory");
+			outofmemory();
 		ap->argc = n + 1;
 		ap->argv = (char**)(ap + 1);
 		ap->args = (char*)(ap->argv + n + 2);

--- a/src/cmd/ksh93/Mamfile
+++ b/src/cmd/ksh93/Mamfile
@@ -345,11 +345,11 @@ make install
 			done deparse.o generated
 			make enum.o
 				make bltins/enum.c
-					prev include/shell.h implicit
+					prev include/defs.h implicit
 				done bltins/enum.c
 				meta enum.o %.c>%.o bltins/enum.c enum
 				prev bltins/enum.c
-				exec - ${CC} ${mam_cc_FLAGS} ${KSH_RELFLAGS} ${KSH_SHOPTFLAGS} ${CCFLAGS} -Iinclude -I${PACKAGE_ast_INCLUDE} -DERROR_CATALOG=${SH_DICT} -D_BLD_shell -D_API_ast=20100309 -D_PACKAGE_ast -DERROR_CONTEXT_T=Error_context_t -c bltins/enum.c
+				exec - ${CC} ${mam_cc_FLAGS} ${KSH_RELFLAGS} ${KSH_SHOPTFLAGS} ${CCFLAGS} -I. -Iinclude -I${PACKAGE_ast_INCLUDE} -DERROR_CATALOG=${SH_DICT} -D_BLD_shell -D_API_ast=20100309 -D_PACKAGE_ast -DERROR_CONTEXT_T=Error_context_t -c bltins/enum.c
 				prev SHOPT.sh
 			done enum.o generated
 			make getopts.o

--- a/src/cmd/ksh93/bltins/alarm.c
+++ b/src/cmd/ksh93/bltins/alarm.c
@@ -273,8 +273,7 @@ int	b_alarm(int argc,char *argv[],Shbltin_t *context)
 	if(!nv_isnull(np))
 		nv_unset(np);
 	nv_setattr(np, NV_DOUBLE);
-	if(!(tp = newof(NIL(struct tevent*),struct tevent,1,0)))
-		sh_outofmemory();
+	tp = sh_newof(NIL(struct tevent*),struct tevent,1,0);
 	tp->fun.disc = &alarmdisc;
 	tp->flags = rflag;
 	tp->node = np;

--- a/src/cmd/ksh93/bltins/enum.c
+++ b/src/cmd/ksh93/bltins/enum.c
@@ -18,7 +18,7 @@
 *                                                                      *
 ***********************************************************************/
 #pragma prototyped
-#include	<shell.h>
+#include	"defs.h"
 
 static const char enum_usage[] =
 "[-?@(#)$Id: enum (AT&T Research) 2008-01-08 $\n]"
@@ -112,9 +112,7 @@ static int enuminfo(Opt_t* op, Sfio_t *out, const char *str, Optdisc_t *fp)
 static Namfun_t *clone_enum(Namval_t* np, Namval_t *mp, int flags, Namfun_t *fp)
 {
 	struct Enum	*ep, *pp=(struct Enum*)fp;
-	ep = newof(0,struct Enum,1,pp->nelem*sizeof(char*));
-	if(!ep)
-		error(ERROR_PANIC, "out of memory");
+	ep = sh_newof(0,struct Enum,1,pp->nelem*sizeof(char*));
 	memcpy((void*)ep,(void*)pp,sizeof(struct Enum)+pp->nelem*sizeof(char*));
 	return(&ep->hdr);
 }
@@ -230,8 +228,7 @@ int b_enum(int argc, char** argv, Shbltin_t *context)
 		}
 		while(nv_nextsub(np));
 		sz += n*sizeof(char*);
-		if(!(ep = newof(0,struct Enum,1,sz)))
-			error(ERROR_PANIC, "out of memory");
+		ep = sh_newof(0,struct Enum,1,sz);
 		ep->iflag = iflag;
 		ep->nelem = n;
 		cp = (char*)&ep->values[n+1];

--- a/src/cmd/ksh93/bltins/enum.c
+++ b/src/cmd/ksh93/bltins/enum.c
@@ -113,6 +113,8 @@ static Namfun_t *clone_enum(Namval_t* np, Namval_t *mp, int flags, Namfun_t *fp)
 {
 	struct Enum	*ep, *pp=(struct Enum*)fp;
 	ep = newof(0,struct Enum,1,pp->nelem*sizeof(char*));
+	if(!ep)
+		error(ERROR_PANIC, "out of space");
 	memcpy((void*)ep,(void*)pp,sizeof(struct Enum)+pp->nelem*sizeof(char*));
 	return(&ep->hdr);
 }
@@ -229,7 +231,7 @@ int b_enum(int argc, char** argv, Shbltin_t *context)
 		while(nv_nextsub(np));
 		sz += n*sizeof(char*);
 		if(!(ep = newof(0,struct Enum,1,sz)))
-			error(ERROR_system(1), "out of space");
+			error(ERROR_PANIC, "out of space");
 		ep->iflag = iflag;
 		ep->nelem = n;
 		cp = (char*)&ep->values[n+1];

--- a/src/cmd/ksh93/bltins/enum.c
+++ b/src/cmd/ksh93/bltins/enum.c
@@ -114,7 +114,7 @@ static Namfun_t *clone_enum(Namval_t* np, Namval_t *mp, int flags, Namfun_t *fp)
 	struct Enum	*ep, *pp=(struct Enum*)fp;
 	ep = newof(0,struct Enum,1,pp->nelem*sizeof(char*));
 	if(!ep)
-		error(ERROR_PANIC, "out of space");
+		error(ERROR_PANIC, "out of memory");
 	memcpy((void*)ep,(void*)pp,sizeof(struct Enum)+pp->nelem*sizeof(char*));
 	return(&ep->hdr);
 }
@@ -231,7 +231,7 @@ int b_enum(int argc, char** argv, Shbltin_t *context)
 		while(nv_nextsub(np));
 		sz += n*sizeof(char*);
 		if(!(ep = newof(0,struct Enum,1,sz)))
-			error(ERROR_PANIC, "out of space");
+			error(ERROR_PANIC, "out of memory");
 		ep->iflag = iflag;
 		ep->nelem = n;
 		cp = (char*)&ep->values[n+1];

--- a/src/cmd/ksh93/bltins/misc.c
+++ b/src/cmd/ksh93/bltins/misc.c
@@ -291,9 +291,7 @@ int    b_dot_cmd(register int n,char *argv[],Shbltin_t *context)
 			sh_exec((Shnode_t*)(nv_funtree(np)),sh_isstate(SH_ERREXIT));
 		else
 		{
-			buffer = malloc(IOBSIZE+1);
-			if(!buffer)
-				sh_outofmemory();
+			buffer = sh_malloc(IOBSIZE+1);
 			iop = sfnew(NIL(Sfio_t*),buffer,IOBSIZE,fd,SF_READ);
 			sh_offstate(SH_NOFORK);
 			sh_eval(iop,sh_isstate(SH_PROFILE)?SH_FUNEVAL:0);

--- a/src/cmd/ksh93/bltins/mkservice.c
+++ b/src/cmd/ksh93/bltins/mkservice.c
@@ -261,6 +261,8 @@ static int service_init(void)
 	file_list =  newof(NULL,short,n,0);
 	poll_list =  newof(NULL,Sfio_t*,n,0);
 	service_list =  newof(NULL,Service_t*,n,0);
+	if(!file_list || !poll_list || !service_list)
+		sh_outofmemory();
 	covered_fdnotify = sh_fdnotify(fdnotify);
 	sh_waitnotify(waitnotify);
 	return(1);
@@ -429,7 +431,7 @@ int	b_mkservice(int argc, char** argv, Shbltin_t *context)
 	if (error_info.errors || !(var = *argv++) || !(path = *argv++) || *argv)
 		error(ERROR_usage(2), optusage(NiL));
 	if (!(sp = newof(0, Service_t, 1, 0)))
-		error(ERROR_exit(1), "out of space");
+		sh_outofmemory();
 	sp->acceptf = Accept;
 	sp->actionf = Action;
 	sp->errorf = Error;

--- a/src/cmd/ksh93/bltins/mkservice.c
+++ b/src/cmd/ksh93/bltins/mkservice.c
@@ -258,11 +258,9 @@ static int waitnotify(int fd, long timeout, int rw)
 
 static int service_init(void)
 {
-	file_list =  newof(NULL,short,n,0);
-	poll_list =  newof(NULL,Sfio_t*,n,0);
-	service_list =  newof(NULL,Service_t*,n,0);
-	if(!file_list || !poll_list || !service_list)
-		sh_outofmemory();
+	file_list = sh_newof(NULL,short,n,0);
+	poll_list = sh_newof(NULL,Sfio_t*,n,0);
+	service_list = sh_newof(NULL,Service_t*,n,0);
 	covered_fdnotify = sh_fdnotify(fdnotify);
 	sh_waitnotify(waitnotify);
 	return(1);
@@ -430,8 +428,7 @@ int	b_mkservice(int argc, char** argv, Shbltin_t *context)
 	argv += opt_info.index;
 	if (error_info.errors || !(var = *argv++) || !(path = *argv++) || *argv)
 		error(ERROR_usage(2), optusage(NiL));
-	if (!(sp = newof(0, Service_t, 1, 0)))
-		sh_outofmemory();
+	sp = sh_newof(0, Service_t, 1, 0);
 	sp->acceptf = Accept;
 	sp->actionf = Action;
 	sp->errorf = Error;

--- a/src/cmd/ksh93/bltins/print.c
+++ b/src/cmd/ksh93/bltins/print.c
@@ -776,6 +776,8 @@ static int extend(Sfio_t* sp, void* v, Sffmt_t* fe)
 			nv_onattr(np,NV_INTEGER);
 			if (np->nvalue.lp = new_of(int32_t,0))
 				*np->nvalue.lp = 0;
+			else
+				sh_outofmemory();
 			nv_setsize(np,10);
 			if(sizeof(int)==sizeof(int32_t))
 				value->ip = (int*)np->nvalue.lp;

--- a/src/cmd/ksh93/bltins/print.c
+++ b/src/cmd/ksh93/bltins/print.c
@@ -776,8 +776,6 @@ static int extend(Sfio_t* sp, void* v, Sffmt_t* fe)
 			nv_onattr(np,NV_INTEGER);
 			if (np->nvalue.lp = new_of(int32_t,0))
 				*np->nvalue.lp = 0;
-			else
-				sh_outofmemory();
 			nv_setsize(np,10);
 			if(sizeof(int)==sizeof(int32_t))
 				value->ip = (int*)np->nvalue.lp;

--- a/src/cmd/ksh93/bltins/read.c
+++ b/src/cmd/ksh93/bltins/read.c
@@ -155,8 +155,11 @@ int	b_read(int argc,char *argv[], Shbltin_t *context)
 		r = strlen(name++);
 	else
 		r = 0;
-	if(argc==fixargs && (rp=newof(NIL(struct read_save*),struct read_save,1,0)))
+	if(argc==fixargs)
 	{
+		rp = newof(NIL(struct read_save*),struct read_save,1,0);
+		if(!rp)
+			sh_outofmemory();
 		context->data = (void*)rp;
 		rp->fd = fd;
 		rp->flags = flags;
@@ -417,7 +420,11 @@ int sh_readline(register Shell_t *shp,char **names, volatile int fd, int flags,s
 							var = memcpy(v, var, cur - var);
 						}
 						else
+						{
 							var = newof(var, char, m, 1);
+							if(!var)
+								sh_outofmemory();
+						}
 						end = var + m;
 						cur = var + cx;
 						up = var + ux;

--- a/src/cmd/ksh93/bltins/read.c
+++ b/src/cmd/ksh93/bltins/read.c
@@ -157,9 +157,7 @@ int	b_read(int argc,char *argv[], Shbltin_t *context)
 		r = 0;
 	if(argc==fixargs)
 	{
-		rp = newof(NIL(struct read_save*),struct read_save,1,0);
-		if(!rp)
-			sh_outofmemory();
+		rp = sh_newof(NIL(struct read_save*),struct read_save,1,0);
 		context->data = (void*)rp;
 		rp->fd = fd;
 		rp->flags = flags;
@@ -351,8 +349,7 @@ int sh_readline(register Shell_t *shp,char **names, volatile int fd, int flags,s
 		/* reserved buffer */
 		if((c=size)>=sizeof(buf))
 		{
-			if(!(var = (char*)malloc(c+1)))
-				sh_outofmemory();
+			var = (char*)sh_malloc(c+1);
 			end = var + c;
 		}
 		else
@@ -414,17 +411,11 @@ int sh_readline(register Shell_t *shp,char **names, volatile int fd, int flags,s
 						m = (end - var) + (c - (end - cur));
 						if (var == buf)
 						{
-							v = (char*)malloc(m+1);
-							if(!v)
-								sh_outofmemory();
+							v = (char*)sh_malloc(m+1);
 							var = memcpy(v, var, cur - var);
 						}
 						else
-						{
-							var = newof(var, char, m, 1);
-							if(!var)
-								sh_outofmemory();
-						}
+							var = sh_newof(var, char, m, 1);
 						end = var + m;
 						cur = var + cx;
 						up = var + ux;
@@ -473,7 +464,7 @@ int sh_readline(register Shell_t *shp,char **names, volatile int fd, int flags,s
 			{
 				Namval_t *mp;
 				if(var==buf)
-					var = memdup(var,c+1);
+					var = sh_memdup(var,c+1);
 				nv_putval(np,var,NV_RAW);
 				nv_setsize(np,c);
 				if(!nv_isattr(np,NV_IMPORT|NV_EXPORT)  && (mp=(Namval_t*)np->nvenv))

--- a/src/cmd/ksh93/bltins/trap.c
+++ b/src/cmd/ksh93/bltins/trap.c
@@ -120,7 +120,7 @@ int	b_trap(int argc,char *argv[],Shbltin_t *context)
 					free(shp->st.trap[sig]);
 				shp->st.trap[sig] = 0;
 				if(!clear && *action)
-					shp->st.trap[sig] = strdup(action);
+					shp->st.trap[sig] = sh_strdup(action);
 				if(sig == SH_DEBUGTRAP)
 				{
 					if(shp->st.trap[sig])
@@ -163,7 +163,7 @@ int	b_trap(int argc,char *argv[],Shbltin_t *context)
 					shp->st.trapmax = sig+1;
 				arg = shp->st.trapcom[sig];
 				sh_sigtrap(sig);
-				shp->st.trapcom[sig] = (shp->sigflag[sig]&SH_SIGOFF) ? Empty : strdup(action);
+				shp->st.trapcom[sig] = (shp->sigflag[sig]&SH_SIGOFF) ? Empty : sh_strdup(action);
 				if(arg && arg != Empty)
 					free(arg);
 				if(sig == 0 && (!shp->fn_depth || shp->end_fn))

--- a/src/cmd/ksh93/bltins/typeset.c
+++ b/src/cmd/ksh93/bltins/typeset.c
@@ -949,6 +949,8 @@ int sh_addlib(Shell_t* shp, void* dll, char* name, Pathcomp_t* pp)
 	{
 		maxlib += GROWLIB;
 		liblist = newof(liblist, Libcomp_t, maxlib+1, 0);
+		if(!liblist)
+			sh_outofmemory();
 	}
 	liblist[nlib].dll = dll;
 	liblist[nlib].attr = (sp->nosfio?BLT_NOSFIO:0);

--- a/src/cmd/ksh93/bltins/typeset.c
+++ b/src/cmd/ksh93/bltins/typeset.c
@@ -440,7 +440,7 @@ endargs:
 	if(tdata.sh->fn_depth && !tdata.pflag)
 		flag |= NV_NOSCOPE;
 	if(tdata.help)
-		tdata.help = strdup(tdata.help);
+		tdata.help = sh_strdup(tdata.help);
 	if(flag&NV_TYPE)
 	{
 		Stk_t *stkp = tdata.sh->stk;
@@ -948,14 +948,12 @@ int sh_addlib(Shell_t* shp, void* dll, char* name, Pathcomp_t* pp)
 	if (nlib >= maxlib)
 	{
 		maxlib += GROWLIB;
-		liblist = newof(liblist, Libcomp_t, maxlib+1, 0);
-		if(!liblist)
-			sh_outofmemory();
+		liblist = sh_newof(liblist, Libcomp_t, maxlib+1, 0);
 	}
 	liblist[nlib].dll = dll;
 	liblist[nlib].attr = (sp->nosfio?BLT_NOSFIO:0);
 	if (name)
-		liblist[nlib].lib = strdup(name);
+		liblist[nlib].lib = sh_strdup(name);
 	if (pp)
 	{
 		liblist[nlib].dev = pp->dev;

--- a/src/cmd/ksh93/edit/edit.c
+++ b/src/cmd/ksh93/edit/edit.c
@@ -759,9 +759,7 @@ void	ed_setup(register Edit_t *ep, int fd, int reedit)
 	{
 		/* can't use output buffer when reading from stderr */
 		static char *buff;
-		buff = (char*)malloc(MAXLINE);
-		if(!buff)
-			sh_outofmemory();
+		buff = (char*)sh_malloc(MAXLINE);
 		ep->e_outbase = ep->e_outptr = buff;
 		ep->e_outlast = ep->e_outptr + MAXLINE;
 		return;
@@ -1873,9 +1871,7 @@ void	ed_histlist(Edit_t *ep,int n)
 
 void	*ed_open(Shell_t *shp)
 {
-	Edit_t *ed = newof(0,Edit_t,1,0);
-	if(!ed)
-		sh_outofmemory();
+	Edit_t *ed = sh_newof(0,Edit_t,1,0);
 	ed->sh = shp;
 	strcpy(ed->e_macro,"_??");
 	return((void*)ed);

--- a/src/cmd/ksh93/edit/edit.c
+++ b/src/cmd/ksh93/edit/edit.c
@@ -759,12 +759,9 @@ void	ed_setup(register Edit_t *ep, int fd, int reedit)
 	{
 		/* can't use output buffer when reading from stderr */
 		static char *buff;
+		buff = (char*)malloc(MAXLINE);
 		if(!buff)
-		{
-			buff = (char*)malloc(MAXLINE);
-			if(!buff)
-				sh_outofmemory();
-		}
+			sh_outofmemory();
 		ep->e_outbase = ep->e_outptr = buff;
 		ep->e_outlast = ep->e_outptr + MAXLINE;
 		return;
@@ -1877,6 +1874,8 @@ void	ed_histlist(Edit_t *ep,int n)
 void	*ed_open(Shell_t *shp)
 {
 	Edit_t *ed = newof(0,Edit_t,1,0);
+	if(!ed)
+		sh_outofmemory();
 	ed->sh = shp;
 	strcpy(ed->e_macro,"_??");
 	return((void*)ed);

--- a/src/cmd/ksh93/edit/edit.c
+++ b/src/cmd/ksh93/edit/edit.c
@@ -759,7 +759,8 @@ void	ed_setup(register Edit_t *ep, int fd, int reedit)
 	{
 		/* can't use output buffer when reading from stderr */
 		static char *buff;
-		buff = (char*)sh_malloc(MAXLINE);
+		if(!buff)
+			buff = (char*)sh_malloc(MAXLINE);
 		ep->e_outbase = ep->e_outptr = buff;
 		ep->e_outlast = ep->e_outptr + MAXLINE;
 		return;

--- a/src/cmd/ksh93/edit/emacs.c
+++ b/src/cmd/ksh93/edit/emacs.c
@@ -197,6 +197,8 @@ int ed_emacsread(void *context, int fd,char *buff,int scend, int reedit)
 	if(!ep)
 	{
 		ep = ed->e_emacs = newof(0,Emacs_t,1,0);
+		if(!ep)
+			sh_outofmemory();
 		ep->ed = ed;
 		ep->prevdirection =  1;
 		location.hist_command =  -5;

--- a/src/cmd/ksh93/edit/emacs.c
+++ b/src/cmd/ksh93/edit/emacs.c
@@ -196,9 +196,7 @@ int ed_emacsread(void *context, int fd,char *buff,int scend, int reedit)
 	memset(Screen,0,sizeof(Screen));
 	if(!ep)
 	{
-		ep = ed->e_emacs = newof(0,Emacs_t,1,0);
-		if(!ep)
-			sh_outofmemory();
+		ep = ed->e_emacs = sh_newof(0,Emacs_t,1,0);
 		ep->ed = ed;
 		ep->prevdirection =  1;
 		location.hist_command =  -5;
@@ -222,9 +220,7 @@ int ed_emacsread(void *context, int fd,char *buff,int scend, int reedit)
 #endif /* SHOPT_MULTIBYTE */
 	if(!kstack)
 	{
-		kstack = (genchar*)malloc(CHARSIZE*MAXLINE);
-		if(!kstack)
-			sh_outofmemory();
+		kstack = (genchar*)sh_malloc(CHARSIZE*MAXLINE);
 		kstack[0] = '\0';
 	}
 	drawbuff = out;

--- a/src/cmd/ksh93/edit/hexpand.c
+++ b/src/cmd/ksh93/edit/hexpand.c
@@ -73,7 +73,7 @@ static char *parse_subst(const char *s, struct subst *sb)
 	/* init "new" with empty string */
 	if(sb->str[1])
 		free(sb->str[1]);
-	sb->str[1] = strdup("");
+	sb->str[1] = sh_strdup("");
 
 	/* get delimiter */
 	del = *s;
@@ -91,7 +91,7 @@ static char *parse_subst(const char *s, struct subst *sb)
 				stakputc('\0');
 				if(sb->str[n])
 					free(sb->str[n]);
-				sb->str[n] = strdup(stakptr(off));
+				sb->str[n] = sh_strdup(stakptr(off));
 				stakseek(off);
 			}
 			n++;
@@ -241,7 +241,7 @@ int hist_expand(const char *ln, char **xp)
 			cp++;
 			n = staktell(); /* terminate string and dup */
 			stakputc('\0');
-			cc = strdup(stakptr(0));
+			cc = sh_strdup(stakptr(0));
 			stakseek(n); /* remove null byte again */
 			ref = sfopen(ref, cc, "s"); /* open as file */
 			n = 0; /* skip history file referencing */
@@ -587,7 +587,7 @@ getsel:
 				{
 					/* preset old with match from !?string? */
 					if(!sb.str[0] && wm)
-						sb.str[0] = strdup(sfsetbuf(wm, (Void_t*)1, 0));
+						sb.str[0] = sh_strdup(sfsetbuf(wm, (Void_t*)1, 0));
 					cp = parse_subst(cp, &sb);
 				}
 
@@ -713,7 +713,7 @@ done:
 
 	/* error? */
 	if(staktell() && !(flag & HIST_ERROR))
-		*xp = strdup(stakfreeze(1));
+		*xp = sh_strdup(stakfreeze(1));
 
 	/* restore shell stack */
 	if(off)

--- a/src/cmd/ksh93/edit/history.c
+++ b/src/cmd/ksh93/edit/history.c
@@ -75,8 +75,8 @@
 #include	"FEATURE/time"
 #include	<error.h>
 #include	<ls.h>
+#include	"defs.h"
 #if KSHELL
-#   include	"defs.h"
 #   include	"variables.h"
 #   include	"path.h"
 #   include	"builtins.h"
@@ -87,27 +87,6 @@
 #include	"history.h"
 
 #if !KSHELL
-
-/*
- * These malloc and strdup wrappers error out when allocation fails
- */
-static void *sh_malloc(size_t size)
-{
-	char *cp = malloc(size);
-	if(!cp)
-		errormsg(SH_DICT, ERROR_PANIC, "out of memory");
-	return(cp);
-}
-
-static void *sh_strdup(const char *s)
-{
-	char *str = strdup(s);
-	if(!str)
-		errormsg(SH_DICT, ERROR_PANIC, "out of memory");
-	return(str);
-}
-
-#   define new_of(type,x)	((type*)sh_malloc((unsigned)sizeof(type)+(x)))
 #   define NIL(type)		((type)0)
 #   define path_relative(s,x)	(s,x)
 #   ifdef __STDC__
@@ -118,7 +97,7 @@ static void *sh_strdup(const char *s)
 #   define e_unknown	 	"unknown"
 #   define sh_translate(x)	(x)
     char login_sh =		0;
-    char hist_fname[] =		"/.history";
+    const char hist_fname[] =	"/.history";
 #endif	/* KSHELL */
 
 #ifndef O_BINARY

--- a/src/cmd/ksh93/edit/history.c
+++ b/src/cmd/ksh93/edit/history.c
@@ -309,7 +309,7 @@ retry:
 	if(!(hp=new_of(History_t,(--histmask)*sizeof(off_t))))
 	{
 		close(fd);
-		return(0);
+		sh_outofmemory();
 	}
 	shgd->hist_ptr = hist_ptr = hp;
 	hp->histshell = (void*)shp;

--- a/src/cmd/ksh93/edit/vi.c
+++ b/src/cmd/ksh93/edit/vi.c
@@ -231,7 +231,9 @@ int ed_viread(void *context, int fd, register char *shbuf, int nchar, int reedit
 #endif /* SHOPT_RAWONLY */
 	if(!vp)
 	{
-		ed->e_vi = vp =  newof(0,Vi_t,1,0);
+		ed->e_vi = vp = newof(0,Vi_t,1,0);
+		if(!vp)
+			sh_outofmemory();
 		vp->lastline = (genchar*)malloc(MAXLINE*CHARSIZE);
 		if(!vp->lastline)
 			sh_outofmemory();

--- a/src/cmd/ksh93/edit/vi.c
+++ b/src/cmd/ksh93/edit/vi.c
@@ -231,12 +231,8 @@ int ed_viread(void *context, int fd, register char *shbuf, int nchar, int reedit
 #endif /* SHOPT_RAWONLY */
 	if(!vp)
 	{
-		ed->e_vi = vp = newof(0,Vi_t,1,0);
-		if(!vp)
-			sh_outofmemory();
-		vp->lastline = (genchar*)malloc(MAXLINE*CHARSIZE);
-		if(!vp->lastline)
-			sh_outofmemory();
+		ed->e_vi = vp = sh_newof(0,Vi_t,1,0);
+		vp->lastline = (genchar*)sh_malloc(MAXLINE*CHARSIZE);
 		vp->direction = -1;
 		vp->ed = ed;
 	}
@@ -385,17 +381,9 @@ int ed_viread(void *context, int fd, register char *shbuf, int nchar, int reedit
 	window[0] = '\0';
 
 	if(!yankbuf)
-	{
-		yankbuf = (genchar*)malloc(MAXLINE*CHARSIZE);
-		if(!yankbuf)
-			sh_outofmemory();
-	}
+		yankbuf = (genchar*)sh_malloc(MAXLINE*CHARSIZE);
 	if(!vp->lastline)
-	{
-		vp->lastline = (genchar*)malloc(MAXLINE*CHARSIZE);
-		if(!vp->lastline)
-			sh_outofmemory();
-	}
+		vp->lastline = (genchar*)sh_malloc(MAXLINE*CHARSIZE);
 	if( vp->last_cmd == '\0' )
 	{
 		/*** first time for this shell ***/

--- a/src/cmd/ksh93/include/defs.h
+++ b/src/cmd/ksh93/include/defs.h
@@ -290,8 +290,6 @@ struct shared
 /* error exits from various parts of shell */
 #define	NIL(type)	((type)0)
 
-#define new_of(type,x)	((type*)malloc((unsigned)sizeof(type)+(x)))
-
 #define exitset()	(sh.savexit=sh.exitval)
 
 #ifndef SH_DICT
@@ -367,7 +365,6 @@ extern Sfdouble_t	sh_mathfun(Shell_t*, void*, int, Sfdouble_t*);
 extern int		sh_outtype(Shell_t*, Sfio_t*);
 extern char 		*sh_mactry(Shell_t*,char*);
 extern int		sh_mathstd(const char*);
-extern void		sh_outofmemory(void);
 extern void		sh_printopts(Shopt_t,int,Shopt_t*);
 extern int 		sh_readline(Shell_t*,char**,volatile int,int,ssize_t,long);
 extern Sfio_t		*sh_sfeval(char*[]);
@@ -391,6 +388,15 @@ extern int 		sh_whence(char**,int);
 #if SHOPT_NAMESPACE
     extern Namval_t	*sh_fsearch(Shell_t*,const char *,int);
 #endif /* SHOPT_NAMESPACE */
+
+/* malloc related wrappers */
+extern void		*sh_malloc(size_t size);
+extern void		*sh_realloc(void *ptr, size_t size);
+extern void		*sh_calloc(size_t nmemb, size_t size);
+extern char		*sh_strdup(const char *s);
+extern void		*sh_memdup(const void *s, size_t n);
+#define new_of(type,x)	((type*)sh_malloc((unsigned)sizeof(type)+(x)))
+#define sh_newof(p,t,n,x)	((p)?(t*)sh_realloc((char*)(p),sizeof(t)*(n)+(x)):(t*)sh_calloc(1,sizeof(t)*(n)+(x)))
 
 #define URI_RFC3986_UNRESERVED "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
 

--- a/src/cmd/ksh93/sh/args.c
+++ b/src/cmd/ksh93/sh/args.c
@@ -101,6 +101,8 @@ static void 		sh_argset(Arg_t*, char *[]);
 void *sh_argopen(Shell_t *shp)
 {
 	void *addr = newof(0,Arg_t,1,0);
+	if(!addr)
+		sh_outofmemory();
 	Arg_t *ap = (Arg_t*)addr;
 	ap->sh = shp;
 	return(addr);
@@ -476,6 +478,8 @@ struct dolnod *sh_argcreate(register char *argv[])
 		size += strlen(sp);
 	n = (pp - argv)-1;
 	dp=new_of(struct dolnod,n*sizeof(char*)+size+n);
+	if(!dp)
+		sh_outofmemory();
 	dp->dolrefcnt=1;	/* use count */
 	dp->dolnum = n;
 	dp->dolnxt = 0;

--- a/src/cmd/ksh93/sh/args.c
+++ b/src/cmd/ksh93/sh/args.c
@@ -100,9 +100,7 @@ static void 		sh_argset(Arg_t*, char *[]);
 
 void *sh_argopen(Shell_t *shp)
 {
-	void *addr = newof(0,Arg_t,1,0);
-	if(!addr)
-		sh_outofmemory();
+	void *addr = sh_newof(0,Arg_t,1,0);
 	Arg_t *ap = (Arg_t*)addr;
 	ap->sh = shp;
 	return(addr);
@@ -344,7 +342,7 @@ int sh_argopts(int argc,register char *argv[], void *context)
 		sfputr(lp->kiafile,";vdb;CIAO/ksh",'\n');
 		lp->kiabegin = sftell(lp->kiafile);
 		lp->entity_tree = dtopen(&_Nvdisc,Dtbag);
-		lp->scriptname = strdup(sh_fmtq(argv[0]));
+		lp->scriptname = sh_strdup(sh_fmtq(argv[0]));
 		lp->script=kiaentity(lp,lp->scriptname,-1,'p',-1,0,0,'s',0,"");
 		lp->fscript=kiaentity(lp,lp->scriptname,-1,'f',-1,0,0,'s',0,"");
 		lp->unknown=kiaentity(lp,"<unknown>",-1,'p',-1,0,0,'0',0,"");
@@ -478,8 +476,6 @@ struct dolnod *sh_argcreate(register char *argv[])
 		size += strlen(sp);
 	n = (pp - argv)-1;
 	dp=new_of(struct dolnod,n*sizeof(char*)+size+n);
-	if(!dp)
-		sh_outofmemory();
 	dp->dolrefcnt=1;	/* use count */
 	dp->dolnum = n;
 	dp->dolnxt = 0;

--- a/src/cmd/ksh93/sh/args.c
+++ b/src/cmd/ksh93/sh/args.c
@@ -735,7 +735,7 @@ struct argnod *sh_argprocsub(Shell_t *shp,struct argnod *argp)
 		break;
 	}
 	if(!shp->fifo)
-		errormsg(SH_DICT,ERROR_PANIC,"process substitution: FIFO creation failed");
+		errormsg(SH_DICT, ERROR_SYSTEM|ERROR_PANIC, "process substitution: FIFO creation failed");
 	chmod(shp->fifo,S_IRUSR|S_IWUSR);	/* mkfifo + chmod works regardless of umask */
 	sfputr(shp->stk,shp->fifo,0);
 #endif /* SHOPT_DEVFD */

--- a/src/cmd/ksh93/sh/array.c
+++ b/src/cmd/ksh93/sh/array.c
@@ -87,8 +87,8 @@ static Namarr_t *array_scope(Namval_t *np, Namarr_t *ap, int flags)
 	size_t size = ap->hdr.dsize;
 	if(size==0)
 		size = ap->hdr.disc->dsize;
-        if(!(aq=newof(NIL(Namarr_t*),Namarr_t,1,size-sizeof(Namarr_t))))
-                return(0);
+	if(!(aq=newof(NIL(Namarr_t*),Namarr_t,1,size-sizeof(Namarr_t))))
+		sh_outofmemory();
         memcpy(aq,ap,size);
 	aq->hdr.nofree &= ~1;
         aq->hdr.nofree |= (flags&NV_RDONLY)?1:0;
@@ -816,6 +816,8 @@ static struct index_array *array_grow(Namval_t *np, register struct index_array 
 		errormsg(SH_DICT,ERROR_exit(1),e_subscript, fmtbase((long)maxi,10,0));
 	i = (newsize-1)*sizeof(union Value*)+newsize;
 	ap = new_of(struct index_array,i);
+	if(!ap)
+		sh_outofmemory();
 	memset((void*)ap,0,sizeof(*ap)+i);
 	ap->maxi = newsize;
 	ap->cur = maxi;
@@ -1393,8 +1395,8 @@ static int array_fixed_init(Namval_t *np, char *sub, char *cp)
 	if(*ep)
 		return(0);
 	sz = sizeof(struct fixed_array)+ 3*n*sizeof(int);
-        if(!(ap=newof(NIL(Namarr_t*),Namarr_t,1,sz)))
-                return(0);
+	if(!(ap=newof(NIL(Namarr_t*),Namarr_t,1,sz)))
+		sh_outofmemory();
 	ap->hdr.disc = &array_disc;
 	ap->hdr.dsize = sizeof(Namarr_t)+sz;
 	ap->hdr.nofree &= ~1;

--- a/src/cmd/ksh93/sh/array.c
+++ b/src/cmd/ksh93/sh/array.c
@@ -87,11 +87,10 @@ static Namarr_t *array_scope(Namval_t *np, Namarr_t *ap, int flags)
 	size_t size = ap->hdr.dsize;
 	if(size==0)
 		size = ap->hdr.disc->dsize;
-	if(!(aq=newof(NIL(Namarr_t*),Namarr_t,1,size-sizeof(Namarr_t))))
-		sh_outofmemory();
-        memcpy(aq,ap,size);
+	aq = sh_newof(NIL(Namarr_t*),Namarr_t,1,size-sizeof(Namarr_t));
+	memcpy(aq,ap,size);
 	aq->hdr.nofree &= ~1;
-        aq->hdr.nofree |= (flags&NV_RDONLY)?1:0;
+	aq->hdr.nofree |= (flags&NV_RDONLY)?1:0;
 	if(is_associative(aq))
 	{
 		aq->scope = (void*)dtopen(&_Nvdisc,Dtoset);
@@ -346,9 +345,7 @@ static Namval_t *array_find(Namval_t *np,Namarr_t *arp, int flag)
 		{
 			if(data)
 			{
-				fp->data = (char*)malloc(fp->nelem*fp->size);
-				if(!fp->data)
-					sh_outofmemory();
+				fp->data = (char*)sh_malloc(fp->nelem*fp->size);
 				memcpy(fp->data,data,fp->nelem*fp->size);
 			}
 			else
@@ -490,7 +487,7 @@ static Namfun_t *array_clone(Namval_t *np, Namval_t *mp, int flags, Namfun_t *fp
 	mp->nvflag &= NV_MINIMAL;
 	mp->nvflag |= (np->nvflag&~(NV_MINIMAL|NV_NOFREE));
 	if(!(nelem&(ARRAY_SCAN|ARRAY_UNDEF)) && (sub=nv_getsub(np)))
-		sub = strdup(sub);
+		sub = sh_strdup(sub);
 	ar = (struct index_array*)ap;
 	if(!is_associative(ap))
 		ar->bits = (unsigned char*)&ar->val[ar->maxi];
@@ -816,8 +813,6 @@ static struct index_array *array_grow(Namval_t *np, register struct index_array 
 		errormsg(SH_DICT,ERROR_exit(1),e_subscript, fmtbase((long)maxi,10,0));
 	i = (newsize-1)*sizeof(union Value*)+newsize;
 	ap = new_of(struct index_array,i);
-	if(!ap)
-		sh_outofmemory();
 	memset((void*)ap,0,sizeof(*ap)+i);
 	ap->maxi = newsize;
 	ap->cur = maxi;
@@ -903,9 +898,7 @@ int nv_atypeindex(Namval_t *np, const char *tname)
 			errormsg(SH_DICT,ERROR_exit(1),e_notenum,tp->nvname);
 		if(!ap)
 			ap = array_grow(np,ap,1);
-		ap->xp = calloc(NV_MINSZ,1);
-		if(!ap->xp)
-			sh_outofmemory();
+		ap->xp = sh_calloc(NV_MINSZ,1);
 		np = nv_namptr(ap->xp,0);
 		np->nvname = tp->nvname;
 		nv_onattr(np,NV_MINIMAL);
@@ -1370,9 +1363,7 @@ static void array_fixed_setdata(Namval_t *np,Namarr_t* ap,struct fixed_array* fp
 	ap->nelem = 1;
 	fp->size = fp->ptr?sizeof(void*):nv_datasize(np,0);
 	ap->nelem = n;
-	fp->data = (char*)calloc(fp->nelem,fp->size);
-	if(!fp->data)
-		sh_outofmemory();
+	fp->data = (char*)sh_calloc(fp->nelem,fp->size);
 	if(fp->ptr)
 	{
 		char **cp = (char**)fp->data;
@@ -1395,8 +1386,7 @@ static int array_fixed_init(Namval_t *np, char *sub, char *cp)
 	if(*ep)
 		return(0);
 	sz = sizeof(struct fixed_array)+ 3*n*sizeof(int);
-	if(!(ap=newof(NIL(Namarr_t*),Namarr_t,1,sz)))
-		sh_outofmemory();
+	ap = sh_newof(NIL(Namarr_t*),Namarr_t,1,sz);
 	ap->hdr.disc = &array_disc;
 	ap->hdr.dsize = sizeof(Namarr_t)+sz;
 	ap->hdr.nofree &= ~1;
@@ -1657,19 +1647,15 @@ void *nv_associative(register Namval_t *np,const char *sp,int mode)
 	switch(mode)
 	{
 	    case NV_AINIT:
-		if(ap = (struct assoc_array*)calloc(1,sizeof(struct assoc_array)))
-		{
-			ap->header.table = dtopen(&_Nvdisc,Dtoset);
-			dtuserdata(ap->header.table,&sh,1);
-			ap->cur = 0;
-			ap->pos = 0;
-			ap->header.hdr.disc = &array_disc;
-			nv_disc(np,(Namfun_t*)ap, NV_FIRST);
-			ap->header.hdr.dsize = sizeof(struct assoc_array);
-			ap->header.hdr.nofree &= ~1;
-		}
-		else
-			sh_outofmemory();
+		ap = (struct assoc_array*)sh_calloc(1,sizeof(struct assoc_array));
+		ap->header.table = dtopen(&_Nvdisc,Dtoset);
+		dtuserdata(ap->header.table,&sh,1);
+		ap->cur = 0;
+		ap->pos = 0;
+		ap->header.hdr.disc = &array_disc;
+		nv_disc(np,(Namfun_t*)ap, NV_FIRST);
+		ap->header.hdr.dsize = sizeof(struct assoc_array);
+		ap->header.hdr.nofree &= ~1;
 		return((void*)ap);
 	    case NV_ADELETE:
 		if(ap->cur)

--- a/src/cmd/ksh93/sh/fault.c
+++ b/src/cmd/ksh93/sh/fault.c
@@ -250,11 +250,9 @@ void sh_siginit(void *ptr)
 		tp++;
 	}
 	shp->gd->sigmax = n++;
-	shp->st.trapcom = (char**)calloc(n,sizeof(char*));
-	shp->sigflag = (unsigned char*)calloc(n,1);
-	shp->gd->sigmsg = (char**)calloc(n,sizeof(char*));
-	if(!shp->st.trapcom || !shp->sigflag || !shp->gd->sigmsg)
-		sh_outofmemory();
+	shp->st.trapcom = (char**)sh_calloc(n,sizeof(char*));
+	shp->sigflag = (unsigned char*)sh_calloc(n,1);
+	shp->gd->sigmsg = (char**)sh_calloc(n,sizeof(char*));
 	for(tp=shtab_signals; sig=tp->sh_number; tp++)
 	{
 		n = (sig>>SH_SIGBITS);

--- a/src/cmd/ksh93/sh/init.c
+++ b/src/cmd/ksh93/sh/init.c
@@ -577,6 +577,8 @@ static void put_seconds(register Namval_t* np,const char *val,int flags,Namfun_t
 		nv_setsize(np,3);
 		nv_onattr(np,NV_DOUBLE);
 		np->nvalue.dp = new_of(double,0);
+		if(!np->nvalue.dp)
+			sh_outofmemory();
 	}
 	nv_putv(np, val, flags, fp);
 	d = *np->nvalue.dp;
@@ -1212,6 +1214,8 @@ Shell_t *sh_init(register int argc,register char *argv[], Shinit_f userinit)
 		sh_regress_init(shp);
 #endif
 		shgd = newof(0,struct shared,1,0);
+		if(!shgd)
+			sh_outofmemory();
 		shgd->current_pid = shgd->pid = getpid();
 		shgd->ppid = getppid();
 		shgd->userid=getuid();
@@ -1235,7 +1239,11 @@ Shell_t *sh_init(register int argc,register char *argv[], Shinit_f userinit)
 		error_info.id = path_basename(argv[0]);
 	}
 	else
+	{
 		shp = newof(0,Shell_t,1,0);
+		if(!shp)
+			sh_outofmemory();
+	}
 	umask(shp->mask=umask(0));
 	shp->gd = shgd;
 	shp->mac_context = sh_macopen(shp);
@@ -1398,8 +1406,11 @@ Shell_t *sh_init(register int argc,register char *argv[], Shinit_f userinit)
 #if _lib_pathposix
 					char*	p;
 
-					if((n = pathposix(name, NIL(char*), 0)) > 0 && (p = (char*)malloc(++n)))
+					if((n = pathposix(name, NIL(char*), 0)) > 0)
 					{
+						p = (char*)malloc(++n);
+						if(!p)
+							sh_outofmemory();
 						pathposix(name, p, n);
 						name = p;
 					}
@@ -1710,6 +1721,9 @@ static void stat_init(Shell_t *shp)
 	int		i,nstat = STAT_SUBSHELL+1;
 	struct Stats	*sp = newof(0,struct Stats,1,nstat*NV_MINSZ);
 	Namval_t	*np;
+
+	if(!sp)
+		sh_outofmemory();
 	sp->numnodes = nstat;
 	sp->nodes = (char*)(sp+1);
 	shgd->stats = (int*)calloc(sizeof(int),nstat);
@@ -1743,7 +1757,7 @@ static Init_t *nv_init(Shell_t *shp)
 	double d=0;
 	ip = newof(0,Init_t,1,0);
 	if(!ip)
-		return(0);
+		sh_outofmemory();
 	shp->nvfun.last = (char*)shp;
 	shp->nvfun.nofree = 1;
 	ip->sh = shp;
@@ -1855,6 +1869,8 @@ static Init_t *nv_init(Shell_t *shp)
 	nv_onattr(DOTSHNOD,NV_RDONLY);
 	SH_LINENO->nvalue.ip = &shp->st.lineno;
 	VERSIONNOD->nvalue.nrp = newof(0,struct Namref,1,0);
+	if(!VERSIONNOD->nvalue.nrp)
+		sh_outofmemory();
         VERSIONNOD->nvalue.nrp->np = SH_VERSIONNOD;
         VERSIONNOD->nvalue.nrp->root = nv_dict(DOTSHNOD);
         VERSIONNOD->nvalue.nrp->table = DOTSHNOD;
@@ -2137,6 +2153,8 @@ Namfun_t	*nv_mapchar(Namval_t *np,const char *name)
 			free((void*)mp);
 	}
 	mp = newof(0,struct Mapchar,1,n);
+	if(!mp)
+		sh_outofmemory();
 	mp->trans = trans;
 	mp->lctype = lctype;
 	if(low==0)

--- a/src/cmd/ksh93/sh/init.c
+++ b/src/cmd/ksh93/sh/init.c
@@ -219,6 +219,16 @@ static int		shlvl;
 static int		rand_shift;
 
 /*
+ * out of memory routine for stak routines
+ */
+static char *nospace(int unused)
+{
+	NOT_USED(unused);
+	errormsg(SH_DICT, ERROR_SYSTEM|ERROR_PANIC, "out of memory");
+	return(NIL(char*));
+}
+
+/*
  * The following are wrapper functions for memory allocation.
  * These functions will error out if the allocation fails.
  */
@@ -226,7 +236,7 @@ void *sh_malloc(size_t size)
 {
 	void *cp = malloc(size);
 	if(!cp)
-		errormsg(SH_DICT, ERROR_PANIC, "out of memory");
+		nospace(0);
 	return(cp);
 }
 
@@ -234,7 +244,7 @@ void *sh_realloc(void *ptr, size_t size)
 {
 	void *cp = realloc(ptr, size);
 	if(!cp)
-		errormsg(SH_DICT, ERROR_PANIC, "out of memory");
+		nospace(0);
 	return(cp);
 }
 
@@ -242,7 +252,7 @@ void *sh_calloc(size_t nmemb, size_t size)
 {
 	void *cp = calloc(nmemb, size);
 	if(!cp)
-		errormsg(SH_DICT, ERROR_PANIC, "out of memory");
+		nospace(0);
 	return(cp);
 }
 
@@ -250,7 +260,7 @@ char *sh_strdup(const char *s)
 {
 	char *dup = strdup(s);
 	if(!dup)
-		errormsg(SH_DICT, ERROR_PANIC, "out of memory");
+		nospace(0);
 	return(dup);
 }
 
@@ -258,18 +268,8 @@ void *sh_memdup(const void *s, size_t n)
 {
 	void *dup = memdup(s, n);
 	if(!dup)
-		errormsg(SH_DICT, ERROR_PANIC, "out of memory");
+		nospace(0);
 	return(dup);
-}
-
-/*
- * out of memory routine for stak routines
- */
-static char *nospace(int unused)
-{
-	NOT_USED(unused);
-	errormsg(SH_DICT, ERROR_PANIC, "out of memory");
-	return(NIL(char*));
 }
 
 #if SHOPT_VSH || SHOPT_ESH

--- a/src/cmd/ksh93/sh/init.c
+++ b/src/cmd/ksh93/sh/init.c
@@ -218,10 +218,48 @@ static int		shlvl;
 
 static int		rand_shift;
 
-
-void sh_outofmemory(void)
+/*
+ * The following are wrapper functions for memory allocation.
+ * These functions will error out if the allocation fails.
+ */
+void *sh_malloc(size_t size)
 {
-	errormsg(SH_DICT,ERROR_PANIC,"out of memory");
+	void *cp = malloc(size);
+	if(!cp)
+		errormsg(SH_DICT, ERROR_PANIC, "out of memory");
+	return(cp);
+}
+
+void *sh_realloc(void *ptr, size_t size)
+{
+	void *cp = realloc(ptr, size);
+	if(!cp)
+		errormsg(SH_DICT, ERROR_PANIC, "out of memory");
+	return(cp);
+}
+
+void *sh_calloc(size_t nmemb, size_t size)
+{
+	void *cp = calloc(nmemb, size);
+	if(!cp)
+		errormsg(SH_DICT, ERROR_PANIC, "out of memory");
+	return(cp);
+}
+
+char *sh_strdup(const char *s)
+{
+	char *dup = strdup(s);
+	if(!dup)
+		errormsg(SH_DICT, ERROR_PANIC, "out of memory");
+	return(dup);
+}
+
+void *sh_memdup(const void *s, size_t n)
+{
+	void *dup = memdup(s, n);
+	if(!dup)
+		errormsg(SH_DICT, ERROR_PANIC, "out of memory");
+	return(dup);
 }
 
 /*
@@ -230,7 +268,7 @@ void sh_outofmemory(void)
 static char *nospace(int unused)
 {
 	NOT_USED(unused);
-	sh_outofmemory();
+	errormsg(SH_DICT, ERROR_PANIC, "out of memory");
 	return(NIL(char*));
 }
 
@@ -317,9 +355,7 @@ static Sfdouble_t nget_optindex(register Namval_t* np, Namfun_t *fp)
 
 static Namfun_t *clone_optindex(Namval_t* np, Namval_t *mp, int flags, Namfun_t *fp)
 {
-	Namfun_t *dp = (Namfun_t*)malloc(sizeof(Namfun_t));
-	if(!dp)
-		sh_outofmemory();
+	Namfun_t *dp = (Namfun_t*)sh_malloc(sizeof(Namfun_t));
 	memcpy((void*)dp,(void*)fp,sizeof(Namfun_t));
 	mp->nvalue.lp = np->nvalue.lp;
 	dp->nofree = 0;
@@ -436,9 +472,7 @@ static void put_cdpath(register Namval_t* np,const char *val,int flags,Namfun_t 
 		{
 			register int c;
 			char *state[4];
-			sh_lexstates[ST_BEGIN] = state[0] = (char*)malloc(4*(1<<CHAR_BIT));
-			if(!state[0])
-				sh_outofmemory();
+			sh_lexstates[ST_BEGIN] = state[0] = (char*)sh_malloc(4*(1<<CHAR_BIT));
 			memcpy(state[0],sh_lexrstates[ST_BEGIN],(1<<CHAR_BIT));
 			sh_lexstates[ST_NAME] = state[1] = state[0] + (1<<CHAR_BIT);
 			memcpy(state[1],sh_lexrstates[ST_NAME],(1<<CHAR_BIT));
@@ -577,8 +611,6 @@ static void put_seconds(register Namval_t* np,const char *val,int flags,Namfun_t
 		nv_setsize(np,3);
 		nv_onattr(np,NV_DOUBLE);
 		np->nvalue.dp = new_of(double,0);
-		if(!np->nvalue.dp)
-			sh_outofmemory();
 	}
 	nv_putv(np, val, flags, fp);
 	d = *np->nvalue.dp;
@@ -713,7 +745,7 @@ static void put_lastarg(Namval_t* np,const char *val,int flags,Namfun_t *fp)
 		val = sfstruse(shp->strbuf);
 	}
 	if(val)
-		val = strdup(val);
+		val = sh_strdup(val);
 	if(shp->lastarg && !nv_isattr(np,NV_NOFREE))
 		free((void*)shp->lastarg);
 	else
@@ -801,11 +833,9 @@ void sh_setmatch(Shell_t *shp,const char *v, int vsize, int nmatch, regoff_t mat
 		if((i+vsize) >= mp->vsize)
 		{
 			if(mp->vsize)
-				mp->match = (int*)realloc(mp->match,i+vsize+1);
+				mp->match = (int*)sh_realloc(mp->match,i+vsize+1);
 			else
-				mp->match = (int*)malloc(i+vsize+1);
-			if(!mp->match)
-				sh_outofmemory();
+				mp->match = (int*)sh_malloc(i+vsize+1);
 			mp->vsize = i+vsize+1;
 		}
 		mp->val =  ((char*)mp->match)+i; 
@@ -857,9 +887,7 @@ static char* get_match(register Namval_t* np, Namfun_t *fp)
 		free((void*)mp->rval[i]);
 		mp->rval[i] = 0;
 	}
-	mp->rval[i] = (char*)malloc(n+1);
-	if(!mp->rval[i])
-		sh_outofmemory();
+	mp->rval[i] = (char*)sh_malloc(n+1);
 	mp->lastsub[i] = sub;
 	memcpy(mp->rval[i],val,n);
 	mp->rval[i][n] = 0;
@@ -931,9 +959,7 @@ static void math_init(Shell_t *shp)
 	Namval_t	*np;
 	char		*name;
 	int		i;
-	shp->mathnodes = (char*)calloc(1,MAX_MATH_ARGS*(NV_MINSZ+5));
-	if(!shp->mathnodes)
-		sh_outofmemory();
+	shp->mathnodes = (char*)sh_calloc(1,MAX_MATH_ARGS*(NV_MINSZ+5));
 	name = shp->mathnodes+MAX_MATH_ARGS*NV_MINSZ;
 	for(i=0; i < MAX_MATH_ARGS; i++)
 	{
@@ -1062,9 +1088,7 @@ static int newconf(const char *name, const char *path, const char *value)
     static void init_ebcdic(void)
     {
 	int i;
-	char *cp = (char*)malloc(ST_NONE*(1<<CHAR_BIT));
-	if(!cp)
-		sh_outofmemory();
+	char *cp = (char*)sh_malloc(ST_NONE*(1<<CHAR_BIT));
 	for(i=0; i < ST_NONE; i++)
 	{
 		a2e(cp,sh_lexrstates[i]);
@@ -1213,9 +1237,7 @@ Shell_t *sh_init(register int argc,register char *argv[], Shinit_f userinit)
 #if SHOPT_REGRESS
 		sh_regress_init(shp);
 #endif
-		shgd = newof(0,struct shared,1,0);
-		if(!shgd)
-			sh_outofmemory();
+		shgd = sh_newof(0,struct shared,1,0);
 		shgd->current_pid = shgd->pid = getpid();
 		shgd->ppid = getppid();
 		shgd->userid=getuid();
@@ -1239,11 +1261,7 @@ Shell_t *sh_init(register int argc,register char *argv[], Shinit_f userinit)
 		error_info.id = path_basename(argv[0]);
 	}
 	else
-	{
-		shp = newof(0,Shell_t,1,0);
-		if(!shp)
-			sh_outofmemory();
-	}
+		shp = sh_newof(0,Shell_t,1,0);
 	umask(shp->mask=umask(0));
 	shp->gd = shgd;
 	shp->mac_context = sh_macopen(shp);
@@ -1338,11 +1356,11 @@ Shell_t *sh_init(register int argc,register char *argv[], Shinit_f userinit)
 		char buff[PATH_MAX+1];
 		shp->gd->shpath = 0;
 		if((n = pathprog(NiL, buff, sizeof(buff))) > 0 && n <= sizeof(buff))
-			shp->gd->shpath = strdup(buff);
+			shp->gd->shpath = sh_strdup(buff);
 		else if((cp && (sh_type(cp)&SH_TYPE_SH)) || (argc>0 && strchr(cp= *argv,'/')))
 		{
 			if(*cp=='/')
-				shp->gd->shpath = strdup(cp);
+				shp->gd->shpath = sh_strdup(cp);
 			else if(cp = nv_getval(PWDNOD))
 			{
 				int offset = staktell();
@@ -1350,7 +1368,7 @@ Shell_t *sh_init(register int argc,register char *argv[], Shinit_f userinit)
 				stakputc('/');
 				stakputs(argv[0]);
 				pathcanon(stakptr(offset),PATH_DOTDOT);
-				shp->gd->shpath = strdup(stakptr(offset));
+				shp->gd->shpath = sh_strdup(stakptr(offset));
 				stakseek(offset);
 			}
 		}
@@ -1408,9 +1426,7 @@ Shell_t *sh_init(register int argc,register char *argv[], Shinit_f userinit)
 
 					if((n = pathposix(name, NIL(char*), 0)) > 0)
 					{
-						p = (char*)malloc(++n);
-						if(!p)
-							sh_outofmemory();
+						p = (char*)sh_malloc(++n);
 						pathposix(name, p, n);
 						name = p;
 					}
@@ -1439,7 +1455,7 @@ Shell_t *sh_init(register int argc,register char *argv[], Shinit_f userinit)
 	{
 		struct passwd *pw = getpwuid(shp->gd->userid);
 		if(pw)
-			shp->gd->user = strdup(pw->pw_name);
+			shp->gd->user = sh_strdup(pw->pw_name);
 		
 	}
 #endif
@@ -1466,14 +1482,14 @@ Shell_t *sh_init(register int argc,register char *argv[], Shinit_f userinit)
 		sh_offoption(SH_PRIVILEGED);
 	/* shname for $0 in profiles and . scripts */
 	if(sh_isdevfd(argv[1]))
-		shp->shname = strdup(argv[0]);
+		shp->shname = sh_strdup(argv[0]);
 	else
-		shp->shname = strdup(shp->st.dolv[0]);
+		shp->shname = sh_strdup(shp->st.dolv[0]);
 	/*
 	 * return here for shell script execution
 	 * but not for parenthesis subshells
 	 */
-	error_info.id = strdup(shp->st.dolv[0]); /* error_info.id is $0 */
+	error_info.id = sh_strdup(shp->st.dolv[0]); /* error_info.id is $0 */
 	shp->jmpbuffer = (void*)&shp->checkbase;
 	sh_pushcontext(shp,&shp->checkbase,SH_JMPSCRIPT);
 	shp->st.self = &shp->global;
@@ -1598,7 +1614,7 @@ int sh_reinit(char *argv[])
 		sh_argreset(shp,shp->arglist,NIL(struct dolnod*));
 	shp->envlist=0;
 	shp->curenv = 0;
-	shp->shname = error_info.id = strdup(shp->st.dolv[0]);
+	shp->shname = error_info.id = sh_strdup(shp->st.dolv[0]);
 	sh_offstate(SH_FORKED);
 	shp->fn_depth = shp->dot_depth = 0;
 	sh_sigreset(0);
@@ -1610,7 +1626,7 @@ int sh_reinit(char *argv[])
 	}
 	*SHLVL->nvalue.ip +=1;
 	nv_offattr(SHLVL,NV_IMPORT);
-	shp->st.filename = strdup(shp->lastarg);
+	shp->st.filename = sh_strdup(shp->lastarg);
 	nv_delete((Namval_t*)0, (Dt_t*)0, 0);
 	job.exitval = 0;
 	shp->inpipe = shp->outpipe = 0;
@@ -1719,16 +1735,11 @@ static Namfun_t	 stat_child_fun =
 static void stat_init(Shell_t *shp)
 {
 	int		i,nstat = STAT_SUBSHELL+1;
-	struct Stats	*sp = newof(0,struct Stats,1,nstat*NV_MINSZ);
+	struct Stats	*sp = sh_newof(0,struct Stats,1,nstat*NV_MINSZ);
 	Namval_t	*np;
-
-	if(!sp)
-		sh_outofmemory();
 	sp->numnodes = nstat;
 	sp->nodes = (char*)(sp+1);
-	shgd->stats = (int*)calloc(sizeof(int),nstat);
-	if(!shgd->stats)
-		sh_outofmemory();
+	shgd->stats = (int*)sh_calloc(sizeof(int),nstat);
 	sp->sh = shp;
 	for(i=0; i < nstat; i++)
 	{
@@ -1755,9 +1766,7 @@ static void stat_init(Shell_t *shp)
 static Init_t *nv_init(Shell_t *shp)
 {
 	double d=0;
-	ip = newof(0,Init_t,1,0);
-	if(!ip)
-		sh_outofmemory();
+	ip = sh_newof(0,Init_t,1,0);
 	shp->nvfun.last = (char*)shp;
 	shp->nvfun.nofree = 1;
 	ip->sh = shp;
@@ -1868,9 +1877,7 @@ static Init_t *nv_init(Shell_t *shp)
 	DOTSHNOD->nvalue.cp = Empty;
 	nv_onattr(DOTSHNOD,NV_RDONLY);
 	SH_LINENO->nvalue.ip = &shp->st.lineno;
-	VERSIONNOD->nvalue.nrp = newof(0,struct Namref,1,0);
-	if(!VERSIONNOD->nvalue.nrp)
-		sh_outofmemory();
+	VERSIONNOD->nvalue.nrp = sh_newof(0,struct Namref,1,0);
         VERSIONNOD->nvalue.nrp->np = SH_VERSIONNOD;
         VERSIONNOD->nvalue.nrp->root = nv_dict(DOTSHNOD);
         VERSIONNOD->nvalue.nrp->table = DOTSHNOD;
@@ -1894,9 +1901,7 @@ Dt_t *sh_inittree(Shell_t *shp,const struct shtable2 *name_vals)
 	Dt_t *base_treep, *dict = 0;
 	for(tp=name_vals;*tp->sh_name;tp++)
 		n++;
-	np = (Namval_t*)calloc(n,sizeof(Namval_t));
-	if(!np)
-		sh_outofmemory();
+	np = (Namval_t*)sh_calloc(n,sizeof(Namval_t));
 	if(!shgd->bltin_nodes)
 	{
 		shgd->bltin_nodes = np;
@@ -2152,9 +2157,7 @@ Namfun_t	*nv_mapchar(Namval_t *np,const char *name)
 		if(!(mp->hdr.nofree&1))
 			free((void*)mp);
 	}
-	mp = newof(0,struct Mapchar,1,n);
-	if(!mp)
-		sh_outofmemory();
+	mp = sh_newof(0,struct Mapchar,1,n);
 	mp->trans = trans;
 	mp->lctype = lctype;
 	if(low==0)

--- a/src/cmd/ksh93/sh/io.c
+++ b/src/cmd/ksh93/sh/io.c
@@ -181,8 +181,7 @@ getaddrinfo(const char* node, const char* service, const struct addrinfo* hint, 
 		errno = EADDRNOTAVAIL;
 		return EAI_SYSTEM;
 	}
-	if (!(ap = newof(0, struct addrinfo, 1, sizeof(struct sockaddr_in))))
-		sh_outofmemory();
+	ap = sh_newof(0, struct addrinfo, 1, sizeof(struct sockaddr_in));
 	if (hint)
 		*ap = *hint;
 	ap->ai_family = hp->h_addrtype;
@@ -264,13 +263,12 @@ inetopen(const char* path, int flags, Inetintr_f onintr, void* handle)
 	}
 	if(flags==O_NONBLOCK)
 		return 1;
-	if (!(s = strdup(path)))
-		return -1;
+	s = sh_strdup(path);
 	if (t = strchr(s, '/'))
 	{
 		*t++ = 0;
 		if (streq(s, "local"))
-			s = strdup("localhost");
+			s = sh_strdup("localhost");
 		fd = getaddrinfo(s, t, &hint, &addr);
 	}
 	else
@@ -413,9 +411,7 @@ int  sh_iovalidfd(Shell_t *shp, int fd)
 	if(n > max)
 		n = max;
 	max = shp->gd->lim.open_max;
-	shp->sftable = (Sfio_t**)calloc((n+1)*(sizeof(int*)+sizeof(Sfio_t*)+1),1);
-	if(!shp->sftable)
-		sh_outofmemory();
+	shp->sftable = (Sfio_t**)sh_calloc((n+1)*(sizeof(int*)+sizeof(Sfio_t*)+1),1);
 	if(max)
 		memcpy(shp->sftable,sftable,max*sizeof(Sfio_t*));
 	shp->fdptrs = (int**)(&shp->sftable[n]);
@@ -462,9 +458,7 @@ int  sh_inuse(Shell_t *shp, int fd)
 void sh_ioinit(Shell_t *shp)
 {
 	filemapsize = 8;
-	filemap = (struct fdsave*)malloc(filemapsize*sizeof(struct fdsave));
-	if(!filemap)
-		sh_outofmemory();
+	filemap = (struct fdsave*)sh_malloc(filemapsize*sizeof(struct fdsave));
 	sh_iovalidfd(shp,16);
 	shp->sftable[0] = sfstdin;
 	shp->sftable[1] = sfstdout;
@@ -474,10 +468,8 @@ void sh_ioinit(Shell_t *shp)
 	sh_iostream(shp,1);
 	/* all write streams are in the same pool and share outbuff */
 	shp->outpool = sfopen(NIL(Sfio_t*),NIL(char*),"sw");  /* pool identifier */
-	shp->outbuff = (char*)malloc(IOBSIZE+4);
-	shp->errbuff = (char*)malloc(IOBSIZE/4);
-	if(!shp->outbuff || !shp->errbuff)
-		sh_outofmemory();
+	shp->outbuff = (char*)sh_malloc(IOBSIZE+4);
+	shp->errbuff = (char*)sh_malloc(IOBSIZE/4);
 	sfsetbuf(sfstderr,shp->errbuff,IOBSIZE/4);
 	sfsetbuf(sfstdout,shp->outbuff,IOBSIZE);
 	sfpool(sfstdout,shp->outpool,SF_WRITE);
@@ -557,8 +549,7 @@ Sfio_t *sh_iostream(Shell_t *shp, register int fd)
 	}
 	if(status&IOREAD)
 	{
-		if(!(bp = (char *)malloc(IOBSIZE+1)))
-			sh_outofmemory();
+		bp = (char *)sh_malloc(IOBSIZE+1);
 		flags |= SF_READ;
 		if(!(status&IOWRITE))
 			flags &= ~SF_WRITE;
@@ -575,9 +566,7 @@ Sfio_t *sh_iostream(Shell_t *shp, register int fd)
 	}
 	else if(!(iop=sfnew((fd<=2?iop:0),bp,IOBSIZE,fd,flags)))
 		return(NIL(Sfio_t*));
-	dp = newof(0,struct Iodisc,1,0);
-	if(!dp)
-		sh_outofmemory();
+	dp = sh_newof(0,struct Iodisc,1,0);
 	dp->sh = shp;
 	if(status&IOREAD)
 	{
@@ -1575,9 +1564,7 @@ static int io_heredoc(Shell_t *shp,register struct ionod *iop, const char *name,
 			sfclose(infile);
 			if(sffileno(tmp)>0)
 			{
-				sfsetbuf(tmp,malloc(IOBSIZE+1),IOBSIZE);
-				if(!tmp)
-					sh_outofmemory();
+				sfsetbuf(tmp,sh_malloc(IOBSIZE+1),IOBSIZE);
 				sfset(tmp,SF_MALLOC,1);
 			}
 			sfseek(shp->heredocs,off,SEEK_SET);
@@ -1641,8 +1628,7 @@ void sh_iosave(Shell_t *shp, register int origfd, int oldtop, char *name)
 		char 	*oldend = (char*)&filemap[filemapsize];
 		long	moved;
 		filemapsize += 8;
-		if(!(filemap = (struct fdsave*)realloc(filemap,filemapsize*sizeof(struct fdsave))))
-			sh_outofmemory();
+		filemap = (struct fdsave*)sh_realloc(filemap,filemapsize*sizeof(struct fdsave));
 		if(moved = (char*)filemap - oldptr)
 		{
 			for(savefd=shp->gd->lim.open_max; --savefd>=0; )
@@ -2246,8 +2232,6 @@ static void	sftrack(Sfio_t* sp, int flag, void* data)
 			 * built-ins from cleanup
 			 */
 			item = new_of(struct openlist, 0);
-			if(!item)
-				sh_outofmemory();
 			item->strm = sp;
 			item->next = pp->olist;
 			pp->olist = item;
@@ -2298,8 +2282,7 @@ Sfio_t *sh_sfeval(register char *argv[])
 	if(argv[1])
 	{
 		register struct eval *ep;
-		if(!(ep = new_of(struct eval,0)))
-			sh_outofmemory();
+		ep = new_of(struct eval,0);
 		ep->disc = eval_disc;
 		ep->argv = argv;
 		ep->slen  = -1;
@@ -2358,8 +2341,7 @@ static Sfio_t *subopen(Shell_t *shp,Sfio_t* sp, off_t offset, long size)
 	register struct subfile *disp;
 	if(sfseek(sp,offset,SEEK_SET) <0)
 		return(NIL(Sfio_t*));
-	if(!(disp = (struct subfile*)malloc(sizeof(struct subfile)+IOBSIZE+1)))
-		sh_outofmemory();
+	disp = (struct subfile*)sh_malloc(sizeof(struct subfile)+IOBSIZE+1);
 	disp->disc = sub_disc;
 	disp->oldsp = sp;
 	disp->offset = offset;

--- a/src/cmd/ksh93/sh/io.c
+++ b/src/cmd/ksh93/sh/io.c
@@ -182,7 +182,7 @@ getaddrinfo(const char* node, const char* service, const struct addrinfo* hint, 
 		return EAI_SYSTEM;
 	}
 	if (!(ap = newof(0, struct addrinfo, 1, sizeof(struct sockaddr_in))))
-		return EAI_SYSTEM;
+		sh_outofmemory();
 	if (hint)
 		*ap = *hint;
 	ap->ai_family = hp->h_addrtype;
@@ -558,7 +558,7 @@ Sfio_t *sh_iostream(Shell_t *shp, register int fd)
 	if(status&IOREAD)
 	{
 		if(!(bp = (char *)malloc(IOBSIZE+1)))
-			return(NIL(Sfio_t*));
+			sh_outofmemory();
 		flags |= SF_READ;
 		if(!(status&IOWRITE))
 			flags &= ~SF_WRITE;
@@ -576,6 +576,8 @@ Sfio_t *sh_iostream(Shell_t *shp, register int fd)
 	else if(!(iop=sfnew((fd<=2?iop:0),bp,IOBSIZE,fd,flags)))
 		return(NIL(Sfio_t*));
 	dp = newof(0,struct Iodisc,1,0);
+	if(!dp)
+		sh_outofmemory();
 	dp->sh = shp;
 	if(status&IOREAD)
 	{
@@ -2244,6 +2246,8 @@ static void	sftrack(Sfio_t* sp, int flag, void* data)
 			 * built-ins from cleanup
 			 */
 			item = new_of(struct openlist, 0);
+			if(!item)
+				sh_outofmemory();
 			item->strm = sp;
 			item->next = pp->olist;
 			pp->olist = item;
@@ -2295,7 +2299,7 @@ Sfio_t *sh_sfeval(register char *argv[])
 	{
 		register struct eval *ep;
 		if(!(ep = new_of(struct eval,0)))
-			return(NIL(Sfio_t*));
+			sh_outofmemory();
 		ep->disc = eval_disc;
 		ep->argv = argv;
 		ep->slen  = -1;
@@ -2355,7 +2359,7 @@ static Sfio_t *subopen(Shell_t *shp,Sfio_t* sp, off_t offset, long size)
 	if(sfseek(sp,offset,SEEK_SET) <0)
 		return(NIL(Sfio_t*));
 	if(!(disp = (struct subfile*)malloc(sizeof(struct subfile)+IOBSIZE+1)))
-		return(NIL(Sfio_t*));
+		sh_outofmemory();
 	disp->disc = sub_disc;
 	disp->oldsp = sp;
 	disp->offset = offset;

--- a/src/cmd/ksh93/sh/jobs.c
+++ b/src/cmd/ksh93/sh/jobs.c
@@ -85,9 +85,7 @@ static void init_savelist(void)
 	register struct jobsave *jp;
 	while(njob_savelist < NJOB_SAVELIST)
 	{
-		jp = newof(0,struct jobsave,1,0);
-		if(!jp)
-			sh_outofmemory();
+		jp = sh_newof(0,struct jobsave,1,0);
 		jp->next = job_savelist;
 		job_savelist = jp;
 		njob_savelist++;
@@ -245,11 +243,7 @@ static struct jobsave *jobsave_create(pid_t pid)
 		job_savelist = jp->next;
 	}
 	else
-	{
-		jp = newof(0,struct jobsave,1,0);
-		if(!jp)
-			sh_outofmemory();
-	}
+		jp = sh_newof(0,struct jobsave,1,0);
 	if(jp)
 	{
 		jp->pid = pid;
@@ -1210,11 +1204,7 @@ void	job_clear(void)
 	job.curpgid = 0;
 	job.toclear = 0;
 	if(!job.freejobs)
-	{
-		job.freejobs = (unsigned char*)malloc((unsigned)(j+1));
-		if(!job.freejobs)
-			sh_outofmemory();
-	}
+		job.freejobs = (unsigned char*)sh_malloc((unsigned)(j+1));
 	while(j >=0)
 		job.freejobs[j--]  = 0;
 	job_unlock();
@@ -1270,11 +1260,7 @@ int job_post(Shell_t *shp,pid_t pid, pid_t join)
 	if(pw=freelist)
 		freelist = pw->p_nxtjob;
 	else
-	{
 		pw = new_of(struct process,0);
-		if(!pw)
-			sh_outofmemory();
-	}
 	pw->p_flag = 0;
 	job.numpost++;
 	if(join && job.pwlist)
@@ -1906,8 +1892,6 @@ again:
 void *job_subsave(void)
 {
 	struct back_save *bp = new_of(struct back_save,0);
-	if(!bp)
-		sh_outofmemory();
 	job_lock();
 	*bp = bck;
 	bp->prev = bck.prev;

--- a/src/cmd/ksh93/sh/jobs.c
+++ b/src/cmd/ksh93/sh/jobs.c
@@ -86,6 +86,8 @@ static void init_savelist(void)
 	while(njob_savelist < NJOB_SAVELIST)
 	{
 		jp = newof(0,struct jobsave,1,0);
+		if(!jp)
+			sh_outofmemory();
 		jp->next = job_savelist;
 		job_savelist = jp;
 		njob_savelist++;
@@ -243,7 +245,11 @@ static struct jobsave *jobsave_create(pid_t pid)
 		job_savelist = jp->next;
 	}
 	else
+	{
 		jp = newof(0,struct jobsave,1,0);
+		if(!jp)
+			sh_outofmemory();
+	}
 	if(jp)
 	{
 		jp->pid = pid;
@@ -1264,7 +1270,11 @@ int job_post(Shell_t *shp,pid_t pid, pid_t join)
 	if(pw=freelist)
 		freelist = pw->p_nxtjob;
 	else
+	{
 		pw = new_of(struct process,0);
+		if(!pw)
+			sh_outofmemory();
+	}
 	pw->p_flag = 0;
 	job.numpost++;
 	if(join && job.pwlist)
@@ -1896,6 +1906,8 @@ again:
 void *job_subsave(void)
 {
 	struct back_save *bp = new_of(struct back_save,0);
+	if(!bp)
+		sh_outofmemory();
 	job_lock();
 	*bp = bck;
 	bp->prev = bck.prev;

--- a/src/cmd/ksh93/sh/lex.c
+++ b/src/cmd/ksh93/sh/lex.c
@@ -266,9 +266,7 @@ Lex_t *sh_lexopen(Lex_t *lp, Shell_t *sp, int mode)
 {
 	if(!lp)
 	{
-		lp = (Lex_t*)newof(0,Lex_t,1,0);
-		if(!lp)
-			sh_outofmemory();
+		lp = (Lex_t*)sh_newof(0,Lex_t,1,0);
 		lp->sh = sp;
 	}
 	fcnotify(lex_advance,lp);
@@ -1706,9 +1704,7 @@ static void nested_here(register Lex_t *lp)
 		base = stkfreeze(stkp,0);
 	if(lp->lexd.docend)
 		n = fcseek(0)-lp->lexd.docend;
-	iop = newof(0,struct ionod,1,lp->lexd.docextra+n+ARGVAL);
-	if(!iop)
-		sh_outofmemory();
+	iop = sh_newof(0,struct ionod,1,lp->lexd.docextra+n+ARGVAL);
 	iop->iolst = lp->heredoc;
 	stkseek(stkp,ARGVAL);
 	if(lp->lexd.docextra)
@@ -2489,9 +2485,7 @@ done:
 static void setupalias(Lex_t *lp, const char *string,Namval_t *np)
 {
 	register Sfio_t *iop, *base;
-	struct alias *ap = (struct alias*)malloc(sizeof(struct alias));
-	if(!ap)
-		sh_outofmemory();
+	struct alias *ap = (struct alias*)sh_malloc(sizeof(struct alias));
 	ap->disc = alias_disc;
 	ap->lp = lp;
 	ap->buf[1] = 0;
@@ -2528,11 +2522,9 @@ static int stack_grow(Lex_t *lp)
 {
 	lp->lexd.lex_max += STACK_ARRAY;
 	if(lp->lexd.lex_match)
-		lp->lexd.lex_match = (int*)realloc((char*)lp->lexd.lex_match,sizeof(int)*lp->lexd.lex_max);
+		lp->lexd.lex_match = (int*)sh_realloc((char*)lp->lexd.lex_match,sizeof(int)*lp->lexd.lex_max);
 	else
-		lp->lexd.lex_match = (int*)malloc(sizeof(int)*STACK_ARRAY);
-	if(!lp->lexd.lex_match)
-		sh_outofmemory();
+		lp->lexd.lex_match = (int*)sh_malloc(sizeof(int)*STACK_ARRAY);
 	return(1);
 }
 

--- a/src/cmd/ksh93/sh/lex.c
+++ b/src/cmd/ksh93/sh/lex.c
@@ -267,6 +267,8 @@ Lex_t *sh_lexopen(Lex_t *lp, Shell_t *sp, int mode)
 	if(!lp)
 	{
 		lp = (Lex_t*)newof(0,Lex_t,1,0);
+		if(!lp)
+			sh_outofmemory();
 		lp->sh = sp;
 	}
 	fcnotify(lex_advance,lp);
@@ -1705,6 +1707,8 @@ static void nested_here(register Lex_t *lp)
 	if(lp->lexd.docend)
 		n = fcseek(0)-lp->lexd.docend;
 	iop = newof(0,struct ionod,1,lp->lexd.docextra+n+ARGVAL);
+	if(!iop)
+		sh_outofmemory();
 	iop->iolst = lp->heredoc;
 	stkseek(stkp,ARGVAL);
 	if(lp->lexd.docextra)

--- a/src/cmd/ksh93/sh/macro.c
+++ b/src/cmd/ksh93/sh/macro.c
@@ -119,6 +119,8 @@ static int	charlen(const char*,int);
 void *sh_macopen(Shell_t *shp)
 {
 	void *addr = newof(0,Mac_t,1,0);
+	if(!addr)
+		sh_outofmemory();
 	Mac_t *mp = (Mac_t*)addr;
 	mp->shp = shp;
 	return(addr);

--- a/src/cmd/ksh93/sh/macro.c
+++ b/src/cmd/ksh93/sh/macro.c
@@ -118,9 +118,7 @@ static int	charlen(const char*,int);
 
 void *sh_macopen(Shell_t *shp)
 {
-	void *addr = newof(0,Mac_t,1,0);
-	if(!addr)
-		sh_outofmemory();
+	void *addr = sh_newof(0,Mac_t,1,0);
 	Mac_t *mp = (Mac_t*)addr;
 	mp->shp = shp;
 	return(addr);
@@ -973,9 +971,7 @@ static char *prefix(Shell_t *shp, char *id)
 				if(sub)
 					nv_putsub(np,sub,0L);
 			}
-			id = (char*)malloc(strlen(cp)+1+(n=strlen(sp=nv_name(np)))+ (sub?strlen(sub)+3:1));
-			if(!id)
-				sh_outofmemory();
+			id = (char*)sh_malloc(strlen(cp)+1+(n=strlen(sp=nv_name(np)))+ (sub?strlen(sub)+3:1));
 			memcpy(id,sp,n);
 			if(sub)
 			{
@@ -988,7 +984,7 @@ static char *prefix(Shell_t *shp, char *id)
 			return(id);
 		}
 	}
-	return(strdup(id));
+	return(sh_strdup(id));
 }
 
 /*
@@ -1043,7 +1039,7 @@ int sh_macfun(Shell_t *shp, const char *name, int offset)
 		t.node.com.comarg = &d.arg;
 		t.node.com.comline = shp->inlineno;
 		d.dol.dolnum = 1;
-		d.dol.dolval[0] = strdup(name);
+		d.dol.dolval[0] = sh_strdup(name);
 		stkseek(shp->stk,offset);
 		comsubst((Mac_t*)shp->mac_context,&t.node,2);
 		free(d.dol.dolval[0]);
@@ -1365,7 +1361,7 @@ retry1:
 					v = stkptr(stkp,mp->dotdot);
 					dolmax =1;
 					if(array_assoc(ap))
-						arrmax = strdup(v);
+						arrmax = sh_strdup(v);
 					else if((dolmax = (int)sh_arith(mp->shp,v))<0)
 						dolmax += array_maxindex(np);
 					if(type==M_SUBNAME)
@@ -1784,7 +1780,7 @@ retry1:
 			else
 				type = 0;
 		}
-		pattern = strdup(argp);
+		pattern = sh_strdup(argp);
 		if((type=='/' || c=='/') && (repstr = mac_getstring(pattern)))
 		{
 			Mac_t	savemac;
@@ -1796,7 +1792,7 @@ retry1:
 			mp->split = 0;
 			copyto(mp,0,0);
 			sfputc(stkp,0);
-			repstr = strdup(stkptr(stkp,n));
+			repstr = sh_strdup(stkptr(stkp,n));
 			replen = strlen(repstr);
 			stkseek(stkp,n);
 			*mp = savemac;
@@ -2167,9 +2163,7 @@ static void comsubst(Mac_t *mp,register Shnode_t* t, int type)
 			}
 			if(!(sp=mp->shp->sftable[fd]))
 			{
-				char *cp = (char*)malloc(IOBSIZE+1);
-				if(!cp)
-					sh_outofmemory();
+				char *cp = (char*)sh_malloc(IOBSIZE+1);
 				sp = sfnew(NIL(Sfio_t*),cp,IOBSIZE,fd,SF_READ|SF_MALLOC);
 			}
 			type = 3;

--- a/src/cmd/ksh93/sh/main.c
+++ b/src/cmd/ksh93/sh/main.c
@@ -103,7 +103,7 @@ int sh_source(Shell_t *shp, Sfio_t *iop, const char *file)
 		return 0;
 	}
 	oid = error_info.id;
-	nid = error_info.id = strdup(file);
+	nid = error_info.id = sh_strdup(file);
 	shp->st.filename = path_fullname(shp,stakptr(PATH_OFFSET));
 	REGRESS(source, "sh_source", ("%s", file));
 	exfile(shp, iop, fd);
@@ -221,7 +221,7 @@ int sh_main(int ac, char *av[], Shinit_f userinit)
 			if(!sh_isoption(SH_NOUSRPROFILE) && !sh_isoption(SH_PRIVILEGED) && sh_isoption(SH_RC))
 			{
 				if(name = sh_mactry(shp,nv_getval(ENVNOD)))
-					name = *name ? strdup(name) : (char*)0;
+					name = *name ? sh_strdup(name) : (char*)0;
 #if SHOPT_SYSRC
 				if(!strmatch(name, "?(.)/./*"))
 					sh_source(shp, iop, e_sysrc);
@@ -320,9 +320,7 @@ int sh_main(int ac, char *av[], Shinit_f userinit)
 							errormsg(SH_DICT,ERROR_system(ERROR_NOEXEC),e_open,name);
 						/* try sh -c 'name "$@"' */
 						sh_onoption(SH_CFLAG);
-						shp->comdiv = (char*)malloc(strlen(name)+7);
-						if(!shp->comdiv)
-							sh_outofmemory();
+						shp->comdiv = (char*)sh_malloc(strlen(name)+7);
 						name = strcopy(shp->comdiv,name);
 						if(shp->st.dolc)
 							strcopy(name," \"$@\"");

--- a/src/cmd/ksh93/sh/name.c
+++ b/src/cmd/ksh93/sh/name.c
@@ -124,11 +124,9 @@ static char *getbuf(size_t len)
 	if(buflen < len)
 	{
 		if(buflen==0)
-			buf = (char*)malloc(len);
+			buf = (char*)sh_malloc(len);
 		else
-			buf = (char*)realloc(buf,len);
-		if(!buf)
-			sh_outofmemory();
+			buf = (char*)sh_realloc(buf,len);
 		buflen = len;
 	}
 	return(buf);
@@ -230,9 +228,7 @@ Namval_t *nv_addnode(Namval_t* np, int remove)
 	if(sp->numnodes==sp->maxnodes)
 	{
 		sp->maxnodes += 20;
-		sp->nodes = (Namval_t**)realloc(sp->nodes,sizeof(Namval_t*)*sp->maxnodes);
-		if(!sp->nodes)
-			sh_outofmemory();
+		sp->nodes = (Namval_t**)sh_realloc(sp->nodes,sizeof(Namval_t*)*sp->maxnodes);
 	}
 	sp->nodes[sp->numnodes++] = np;
 	return(np);
@@ -285,9 +281,7 @@ void nv_setlist(register struct argnod *arg,register int flags, Namval_t *typ)
 		shtp.numnodes=0;
 		shtp.maxnodes = 20;
 		shtp.rp = 0;
-		shtp.nodes =(Namval_t**)malloc(shtp.maxnodes*sizeof(Namval_t*));
-		if(!shtp.nodes)
-			sh_outofmemory();
+		shtp.nodes = (Namval_t**)sh_malloc(shtp.maxnodes*sizeof(Namval_t*));
 	}
 #endif /* SHOPT_TYPEDEF*/
 #if SHOPT_NAMESPACE
@@ -1431,11 +1425,9 @@ Namval_t *nv_open(const char *name, Dt_t *root, int flags)
 		if(c > xp->size)
 		{
 			if(xp->size==0)
-				xp->name = malloc(c);
+				xp->name = sh_malloc(c);
 			else
-				xp->name = realloc(xp->name,c);
-			if(!xp->name)
-				sh_outofmemory();
+				xp->name = sh_realloc(xp->name,c);
 			xp->size = c;
 		}
 		memcpy(xp->name,name,xp->len);
@@ -1658,11 +1650,7 @@ void nv_putval(register Namval_t *np, const char *string, int flags)
 				else
 					ld = sh_arith(shp,sp);
 				if(!up->ldp)
-				{
 					up->ldp = new_of(Sfdouble_t,0);
-					if(!up->ldp)
-						sh_outofmemory();
-				}
 				else if(flags&NV_APPEND)
 					old = *(up->ldp);
 				*(up->ldp) = old?ld+old:ld;
@@ -1682,11 +1670,7 @@ void nv_putval(register Namval_t *np, const char *string, int flags)
 				else
 					d = sh_arith(shp,sp);
 				if(!up->dp)
-				{
 					up->dp = new_of(double,0);
-					if(!up->dp)
-						sh_outofmemory();
-				}
 				else if(flags&NV_APPEND)
 					od = *(up->dp);
 				*(up->dp) = od?d+od:d;
@@ -1730,11 +1714,7 @@ void nv_putval(register Namval_t *np, const char *string, int flags)
 				else if(sp)
 					ll = (Sflong_t)sh_arith(shp,sp);
 				if(!up->llp)
-				{
 					up->llp = new_of(Sflong_t,0);
-					if(!up->llp)
-						sh_outofmemory();
-				}
 				else if(flags&NV_APPEND)
 					oll = *(up->llp);
 				*(up->llp) = ll+oll;
@@ -1795,11 +1775,7 @@ void nv_putval(register Namval_t *np, const char *string, int flags)
 				else
 				{
 					if(!up->lp)
-					{
 						up->lp = new_of(int32_t,0);
-						if(!up->lp)
-							sh_outofmemory();
-					}
 					else if(flags&NV_APPEND)	
 						ol =  *(up->lp);
 					*(up->lp) = l+ol;
@@ -1921,9 +1897,7 @@ void nv_putval(register Namval_t *np, const char *string, int flags)
 					size = nv_size(np);
 				if(size==0)
 					size = oldsize + (3*dot/4);
-				cp = (char*)malloc(size+1);
-				if(!cp)
-					sh_outofmemory();
+				cp = (char*)sh_malloc(size+1);
 				*cp = 0;
 				nv_offattr(np,NV_NOFREE);
 				if(oldsize)
@@ -1982,13 +1956,11 @@ void nv_putval(register Namval_t *np, const char *string, int flags)
 				{
 					if(tofree && tofree!=Empty && tofree!=Null)
 					{
-						cp = (char*)realloc((void*)tofree, dot+append+1);
+						cp = (char*)sh_realloc((void*)tofree, dot+append+1);
 						tofree = 0;
 					}
 					else
-						cp = (char*)malloc(dot+append+1);
-					if(!cp)
-						sh_outofmemory();
+						cp = (char*)sh_malloc(dot+append+1);
 					cp[dot+append] = 0;
 					nv_offattr(np,NV_NOFREE);
 				}
@@ -2380,7 +2352,7 @@ void	sh_envnolocal (register Namval_t *np, void *data)
 	{
 		nv_putsub(np,NIL(char*),0);
 		if(cp = nv_getval(np))
-			cp = strdup(cp);
+			cp = sh_strdup(cp);
 	}
 	if(nv_isattr(np,NV_EXPORT|NV_NOFREE))
 	{
@@ -2430,7 +2402,7 @@ static void table_unset(Shell_t *shp, register Dt_t *root, int flags, Dt_t *oroo
 					nv_putval(nq,(char*)&d,NV_LDOUBLE);
 				}
 				else if(shp->test&4)
-					nv_putval(nq, strdup(nv_getval(nq)), NV_RDONLY);
+					nv_putval(nq, sh_strdup(nv_getval(nq)), NV_RDONLY);
 				else
 					nv_putval(nq, nv_getval(nq), NV_RDONLY);
 				shp->subshell = subshell;
@@ -2710,11 +2682,7 @@ void nv_optimize(Namval_t *np)
 		if(op = opt_free)
 			opt_free = op->next;
 		else
-		{
-			op=(struct optimize*)calloc(1,sizeof(struct optimize));
-			if(!op)
-				sh_outofmemory();
-		}
+			op=(struct optimize*)sh_calloc(1,sizeof(struct optimize));
 		op->ptr = shp->argaddr;
 		op->np = np;
 		if(xp)
@@ -3069,25 +3037,19 @@ void nv_newattr (register Namval_t *np, unsigned newatts, int size)
 			if(size==0 || (newatts&(NV_INTEGER|NV_BINARY)))
 			{
 				/* allocate to match existing value for numerics and auto length assignment for -L/R/Z */
-				cp = (char*)malloc((size_t)n + 1);
-				if(!cp)
-					sh_outofmemory();
+				cp = (char*)sh_malloc((size_t)n + 1);
 				strcpy(cp, sp);
 			}
 			else if(size>=n)
 			{
 				/* growing string */
-				cp = (char*)malloc((size_t)size + 1);
-				if(!cp)
-					sh_outofmemory();
+				cp = (char*)sh_malloc((size_t)size + 1);
 				strcpy(cp, sp);
 			}
 			else
 			{
 				/* shrinking string */
-				cp = (char*)malloc((size_t)size + 1);
-				if(!cp)
-					sh_outofmemory();
+				cp = (char*)sh_malloc((size_t)size + 1);
 				if(newatts&NV_RJUST)
 					strncpy(cp, n - size + sp, size);
 				else
@@ -3349,7 +3311,7 @@ int nv_rename(register Namval_t *np, int flags)
 		if(index<0)
 			return(0);
 		if(cp = nv_getval(np))
-			cp = strdup(cp);
+			cp = sh_strdup(cp);
 	}
 	_nv_unset(np,NV_EXPORT);
 	if(nr==np)
@@ -3508,9 +3470,7 @@ void nv_setref(register Namval_t *np, Dt_t *hp, int flags)
 	shp->last_root = root;
 	_nv_unset(np,0);
 	nv_delete(np,(Dt_t*)0,0);
-	np->nvalue.nrp = newof(0,struct Namref,1,sizeof(Dtlink_t));
-	if(!np->nvalue.nrp)
-		sh_outofmemory();
+	np->nvalue.nrp = sh_newof(0,struct Namref,1,sizeof(Dtlink_t));
 	np->nvalue.nrp->np = nq;
 	np->nvalue.nrp->root = hp;
 	if(ep)
@@ -3520,7 +3480,7 @@ void nv_setref(register Namval_t *np, Dt_t *hp, int flags)
 			np->nvalue.nrp->curi = ARRAY_FIXED|nv_arrfixed(nq,(Sfio_t*)0,1,&np->nvalue.nrp->dim);
 		else
 #endif /* SHOPT_FIXEDARRAY */
-			np->nvalue.nrp->sub = strdup(ep);
+			np->nvalue.nrp->sub = sh_strdup(ep);
 	}
 	np->nvalue.nrp->table = shp->last_table;
 	nv_onattr(np,NV_REF|NV_NOFREE);
@@ -3616,7 +3576,7 @@ void nv_unref(register Namval_t *np)
 		dtdelete(Refdict,(void*)np->nvalue.nrp);
 	}
 	free((void*)np->nvalue.nrp);
-	np->nvalue.cp = strdup(nv_name(nq));
+	np->nvalue.cp = sh_strdup(nv_name(nq));
 #if SHOPT_OPTIMIZE
 	{
 		Namfun_t *fp;

--- a/src/cmd/ksh93/sh/name.c
+++ b/src/cmd/ksh93/sh/name.c
@@ -1658,7 +1658,11 @@ void nv_putval(register Namval_t *np, const char *string, int flags)
 				else
 					ld = sh_arith(shp,sp);
 				if(!up->ldp)
+				{
 					up->ldp = new_of(Sfdouble_t,0);
+					if(!up->ldp)
+						sh_outofmemory();
+				}
 				else if(flags&NV_APPEND)
 					old = *(up->ldp);
 				*(up->ldp) = old?ld+old:ld;
@@ -1678,7 +1682,11 @@ void nv_putval(register Namval_t *np, const char *string, int flags)
 				else
 					d = sh_arith(shp,sp);
 				if(!up->dp)
+				{
 					up->dp = new_of(double,0);
+					if(!up->dp)
+						sh_outofmemory();
+				}
 				else if(flags&NV_APPEND)
 					od = *(up->dp);
 				*(up->dp) = od?d+od:d;
@@ -1722,7 +1730,11 @@ void nv_putval(register Namval_t *np, const char *string, int flags)
 				else if(sp)
 					ll = (Sflong_t)sh_arith(shp,sp);
 				if(!up->llp)
+				{
 					up->llp = new_of(Sflong_t,0);
+					if(!up->llp)
+						sh_outofmemory();
+				}
 				else if(flags&NV_APPEND)
 					oll = *(up->llp);
 				*(up->llp) = ll+oll;
@@ -1783,7 +1795,11 @@ void nv_putval(register Namval_t *np, const char *string, int flags)
 				else
 				{
 					if(!up->lp)
+					{
 						up->lp = new_of(int32_t,0);
+						if(!up->lp)
+							sh_outofmemory();
+					}
 					else if(flags&NV_APPEND)	
 						ol =  *(up->lp);
 					*(up->lp) = l+ol;
@@ -2694,7 +2710,11 @@ void nv_optimize(Namval_t *np)
 		if(op = opt_free)
 			opt_free = op->next;
 		else
+		{
 			op=(struct optimize*)calloc(1,sizeof(struct optimize));
+			if(!op)
+				sh_outofmemory();
+		}
 		op->ptr = shp->argaddr;
 		op->np = np;
 		if(xp)
@@ -3489,6 +3509,8 @@ void nv_setref(register Namval_t *np, Dt_t *hp, int flags)
 	_nv_unset(np,0);
 	nv_delete(np,(Dt_t*)0,0);
 	np->nvalue.nrp = newof(0,struct Namref,1,sizeof(Dtlink_t));
+	if(!np->nvalue.nrp)
+		sh_outofmemory();
 	np->nvalue.nrp->np = nq;
 	np->nvalue.nrp->root = hp;
 	if(ep)

--- a/src/cmd/ksh93/sh/nvdisc.c
+++ b/src/cmd/ksh93/sh/nvdisc.c
@@ -519,8 +519,7 @@ char *nv_setdisc(register Namval_t* np,register const char *event,Namval_t *acti
 		Namdisc_t	*dp;
 		if(action==np)
 			return((char*)action);
-		if(!(vp = newof(NIL(struct vardisc*),struct vardisc,1,sizeof(Namdisc_t))))
-			sh_outofmemory();
+		vp = sh_newof(NIL(struct vardisc*),struct vardisc,1,sizeof(Namdisc_t));
 		dp = (Namdisc_t*)(vp+1);
 		vp->fun.disc = dp;
 		memset(dp,0,sizeof(*dp));
@@ -647,8 +646,7 @@ Namfun_t *nv_clone_disc(register Namfun_t *fp, int flags)
 		return(fp);
 	if(!(size=fp->dsize) && (!fp->disc || !(size=fp->disc->dsize)))
 		size = sizeof(Namfun_t);
-	if(!(nfp=newof(NIL(Namfun_t*),Namfun_t,1,size-sizeof(Namfun_t))))
-		sh_outofmemory();
+	nfp = sh_newof(NIL(Namfun_t*),Namfun_t,1,size-sizeof(Namfun_t));
 	memcpy(nfp,fp,size);
 	nfp->nofree &= ~1;
 	nfp->nofree |= (flags&NV_RDONLY)?1:0;
@@ -665,8 +663,7 @@ int nv_adddisc(Namval_t *np, const char **names, Namval_t **funs)
 		while(*av++)
 			n++;
 	}
-	if(!(vp = newof(NIL(Nambfun_t*),Nambfun_t,1,n*sizeof(Namval_t*))))
-		sh_outofmemory();
+	vp = sh_newof(NIL(Nambfun_t*),Nambfun_t,1,n*sizeof(Namval_t*));
 	vp->fun.dsize = sizeof(Nambfun_t)+n*sizeof(Namval_t*);
 	vp->fun.nofree |= 2;
 	vp->num = n;
@@ -824,9 +821,7 @@ int nv_unsetnotify(Namval_t *np, char **addr)
 
 int nv_setnotify(Namval_t *np, char **addr)
 {
-	struct notify *pp = newof(0,struct notify, 1,0);
-	if(!pp)
-		sh_outofmemory();
+	struct notify *pp = sh_newof(0,struct notify, 1,0);
 	pp->ptr = addr;
 	pp->hdr.disc = &notify_disc;
 	nv_stack(np,&pp->hdr);
@@ -836,10 +831,8 @@ int nv_setnotify(Namval_t *np, char **addr)
 static void *newnode(const char *name)
 {
 	register int s;
-	register Namval_t *np = newof(0,Namval_t,1,s=strlen(name)+1);
-	if(!np)
-		sh_outofmemory();
-	else
+	register Namval_t *np = sh_newof(0,Namval_t,1,s=strlen(name)+1);
+	if(np)
 	{
 		np->nvname = (char*)np+sizeof(Namval_t);
 		memcpy(np->nvname,name,s);
@@ -879,8 +872,7 @@ static void *num_clone(register Namval_t *np, void *val)
 		else
 			size = sizeof(int32_t);
 	}
-	if(!(nval = malloc(size)))
-		sh_outofmemory();
+	nval = sh_malloc(size);
 	memcpy(nval,val,size);
 	return(nval);
 }
@@ -959,9 +951,9 @@ int nv_clone(Namval_t *np, Namval_t *mp, int flags)
 		if(np->nvalue.cp && np->nvalue.cp!=Empty && (flags&NV_COMVAR) && !(flags&NV_MOVE))
 		{
 			if(size)
-				mp->nvalue.cp = (char*)memdup(np->nvalue.cp,size);
+				mp->nvalue.cp = (char*)sh_memdup(np->nvalue.cp,size);
 			else
-			        mp->nvalue.cp = strdup(np->nvalue.cp);
+			        mp->nvalue.cp = sh_strdup(np->nvalue.cp);
 			nv_offattr(mp,NV_NOFREE);
 		}
 		else if((np->nvfun || !nv_isattr(np,NV_ARRAY)) && !(mp->nvalue.cp = np->nvalue.cp))
@@ -1038,17 +1030,13 @@ Namval_t *nv_mkclone(Namval_t *mp)
 {
 	Namval_t *np;
 	Namfun_t *dp;
-	np = newof(0,Namval_t,1,0);
-	if(!np)
-		sh_outofmemory();
+	np = sh_newof(0,Namval_t,1,0);
 	np->nvflag = mp->nvflag;
 	np->nvsize = mp->nvsize;
 	np->nvname = mp->nvname;
 	np->nvalue.np = mp;
 	np->nvflag = mp->nvflag;
-	dp = newof(0,Namfun_t,1,0);
-	if(!dp)
-		sh_outofmemory();
+	dp = sh_newof(0,Namfun_t,1,0);
 	dp->disc = &clone_disc;
 	nv_stack(np,dp);
 	dtinsert(nv_dict(sh.namespace),np);
@@ -1445,8 +1433,7 @@ Namval_t *nv_mount(Namval_t *np, const char *name, Dt_t *dict)
 		pp = np;
 	else
 		pp = nv_lastdict();
-	if(!(tp = newof((struct table*)0, struct table,1,0)))
-		sh_outofmemory();
+	tp = sh_newof((struct table*)0, struct table,1,0);
 	if(name)
 	{
 		Namfun_t *fp = pp->nvfun;

--- a/src/cmd/ksh93/sh/nvdisc.c
+++ b/src/cmd/ksh93/sh/nvdisc.c
@@ -520,7 +520,7 @@ char *nv_setdisc(register Namval_t* np,register const char *event,Namval_t *acti
 		if(action==np)
 			return((char*)action);
 		if(!(vp = newof(NIL(struct vardisc*),struct vardisc,1,sizeof(Namdisc_t))))
-			return(0);
+			sh_outofmemory();
 		dp = (Namdisc_t*)(vp+1);
 		vp->fun.disc = dp;
 		memset(dp,0,sizeof(*dp));
@@ -648,7 +648,7 @@ Namfun_t *nv_clone_disc(register Namfun_t *fp, int flags)
 	if(!(size=fp->dsize) && (!fp->disc || !(size=fp->disc->dsize)))
 		size = sizeof(Namfun_t);
 	if(!(nfp=newof(NIL(Namfun_t*),Namfun_t,1,size-sizeof(Namfun_t))))
-		return(0);
+		sh_outofmemory();
 	memcpy(nfp,fp,size);
 	nfp->nofree &= ~1;
 	nfp->nofree |= (flags&NV_RDONLY)?1:0;
@@ -666,7 +666,7 @@ int nv_adddisc(Namval_t *np, const char **names, Namval_t **funs)
 			n++;
 	}
 	if(!(vp = newof(NIL(Nambfun_t*),Nambfun_t,1,n*sizeof(Namval_t*))))
-		return(0);
+		sh_outofmemory();
 	vp->fun.dsize = sizeof(Nambfun_t)+n*sizeof(Namval_t*);
 	vp->fun.nofree |= 2;
 	vp->num = n;
@@ -826,7 +826,7 @@ int nv_setnotify(Namval_t *np, char **addr)
 {
 	struct notify *pp = newof(0,struct notify, 1,0);
 	if(!pp)
-		return(0);
+		sh_outofmemory();
 	pp->ptr = addr;
 	pp->hdr.disc = &notify_disc;
 	nv_stack(np,&pp->hdr);
@@ -837,7 +837,9 @@ static void *newnode(const char *name)
 {
 	register int s;
 	register Namval_t *np = newof(0,Namval_t,1,s=strlen(name)+1);
-	if(np)
+	if(!np)
+		sh_outofmemory();
+	else
 	{
 		np->nvname = (char*)np+sizeof(Namval_t);
 		memcpy(np->nvname,name,s);
@@ -1037,12 +1039,16 @@ Namval_t *nv_mkclone(Namval_t *mp)
 	Namval_t *np;
 	Namfun_t *dp;
 	np = newof(0,Namval_t,1,0);
+	if(!np)
+		sh_outofmemory();
 	np->nvflag = mp->nvflag;
 	np->nvsize = mp->nvsize;
 	np->nvname = mp->nvname;
 	np->nvalue.np = mp;
 	np->nvflag = mp->nvflag;
 	dp = newof(0,Namfun_t,1,0);
+	if(!dp)
+		sh_outofmemory();
 	dp->disc = &clone_disc;
 	nv_stack(np,dp);
 	dtinsert(nv_dict(sh.namespace),np);
@@ -1440,7 +1446,7 @@ Namval_t *nv_mount(Namval_t *np, const char *name, Dt_t *dict)
 	else
 		pp = nv_lastdict();
 	if(!(tp = newof((struct table*)0, struct table,1,0)))
-		return(0);
+		sh_outofmemory();
 	if(name)
 	{
 		Namfun_t *fp = pp->nvfun;

--- a/src/cmd/ksh93/sh/nvtree.c
+++ b/src/cmd/ksh93/sh/nvtree.c
@@ -150,7 +150,7 @@ void *nv_diropen(Namval_t *np,const char *name)
 	Namval_t *nq=0,fake;
 	Namfun_t *nfp=0;
 	if(!dp)
-		return(0);
+		sh_outofmemory();
 	memset((void*)dp, 0, sizeof(*dp));
 	dp->data = (char*)(dp+1);
 	if(name[len-1]=='*' || name[len-1]=='@')
@@ -226,7 +226,7 @@ void *nv_diropen(Namval_t *np,const char *name)
 		if(np && ((nfp=nextdisc(np)) || nv_istable(np)))
 		{
 			if(!(save = new_of(struct nvdir,0)))
-				return(0);
+				sh_outofmemory();
 			*save = *dp;
 			dp->prev = save;
 			if(nv_istable(np))
@@ -313,7 +313,7 @@ char *nv_dirnext(void *dir)
 						return(cp);
 					len = strlen(cp);
 					if(!(save = new_of(struct nvdir,len+1)))
-						return(0);
+						sh_outofmemory();
 					*save = *dp;
 					dp->prev = save;
 					dp->root = root;
@@ -1142,6 +1142,8 @@ void nv_setvtree(register Namval_t *np)
 	if(nv_hasdisc(np, &treedisc))
 		return;
 	nfp = newof(NIL(void*),Namfun_t,1,0);
+	if(!nfp)
+		sh_outofmemory();
 	nfp->disc = &treedisc;
 	nfp->dsize = sizeof(Namfun_t);
 	nv_stack(np, nfp);

--- a/src/cmd/ksh93/sh/nvtree.c
+++ b/src/cmd/ksh93/sh/nvtree.c
@@ -149,8 +149,6 @@ void *nv_diropen(Namval_t *np,const char *name)
 	struct nvdir *save, *dp = new_of(struct nvdir,len+1);
 	Namval_t *nq=0,fake;
 	Namfun_t *nfp=0;
-	if(!dp)
-		sh_outofmemory();
 	memset((void*)dp, 0, sizeof(*dp));
 	dp->data = (char*)(dp+1);
 	if(name[len-1]=='*' || name[len-1]=='@')
@@ -225,8 +223,7 @@ void *nv_diropen(Namval_t *np,const char *name)
 			dp->hp = (Namval_t*)dtnext(dp->root,dp->hp);
 		if(np && ((nfp=nextdisc(np)) || nv_istable(np)))
 		{
-			if(!(save = new_of(struct nvdir,0)))
-				sh_outofmemory();
+			save = new_of(struct nvdir,0);
 			*save = *dp;
 			dp->prev = save;
 			if(nv_istable(np))
@@ -312,8 +309,7 @@ char *nv_dirnext(void *dir)
 					if(save)
 						return(cp);
 					len = strlen(cp);
-					if(!(save = new_of(struct nvdir,len+1)))
-						sh_outofmemory();
+					save = new_of(struct nvdir,len+1);
 					*save = *dp;
 					dp->prev = save;
 					dp->root = root;
@@ -1141,11 +1137,8 @@ void nv_setvtree(register Namval_t *np)
 		sh_assignok(np,1);
 	if(nv_hasdisc(np, &treedisc))
 		return;
-	nfp = newof(NIL(void*),Namfun_t,1,0);
-	if(!nfp)
-		sh_outofmemory();
+	nfp = sh_newof(NIL(void*),Namfun_t,1,0);
 	nfp->disc = &treedisc;
 	nfp->dsize = sizeof(Namfun_t);
 	nv_stack(np, nfp);
 }
-

--- a/src/cmd/ksh93/sh/nvtype.c
+++ b/src/cmd/ksh93/sh/nvtype.c
@@ -326,13 +326,11 @@ static int fixnode(Namtype_t *dp, Namtype_t *pp, int i, struct Namref *nrp,int f
 				if(i=nv_size(nq))
 				{
 					const char *cp = nq->nvalue.cp;
-					nq->nvalue.cp = (char*)malloc(i);
-					if(!nq->nvalue.cp)
-						sh_outofmemory();
+					nq->nvalue.cp = (char*)sh_malloc(i);
 					memcpy((char*)nq->nvalue.cp,cp,i);
 				}
 				else
-					nq->nvalue.cp = strdup(nq->nvalue.cp);
+					nq->nvalue.cp = sh_strdup(nq->nvalue.cp);
 				nv_offattr(nq,NV_NOFREE);
 			}
 		}
@@ -367,9 +365,7 @@ static Namfun_t *clone_type(Namval_t* np, Namval_t *mp, int flags, Namfun_t *fp)
 		return(nv_clone_disc(fp,flags));
 	if(size==0 && (!fp->disc || (size=fp->disc->dsize)==0)) 
 		size = sizeof(Namfun_t);
-	dp = (Namtype_t*)malloc(size+pp->nref*sizeof(struct Namref));
-	if(!dp)
-		sh_outofmemory();
+	dp = (Namtype_t*)sh_malloc(size+pp->nref*sizeof(struct Namref));
 	if(pp->nref)
 	{
 		nrp = (struct Namref*)((char*)dp + size);
@@ -579,9 +575,7 @@ static Namval_t *next_type(register Namval_t* np, Dt_t *root,Namfun_t *fp)
 
 static Namfun_t *clone_inttype(Namval_t* np, Namval_t *mp, int flags, Namfun_t *fp)
 {
-	Namfun_t	*pp=  (Namfun_t*)malloc(fp->dsize);
-	if(!pp)
-		sh_outofmemory();
+	Namfun_t	*pp = (Namfun_t*)sh_malloc(fp->dsize);
 	memcpy((void*)pp, (void*)fp, fp->dsize);
 	fp->nofree &= ~1;
 	if(nv_isattr(mp,NV_NOFREE) && mp->nvalue.cp)
@@ -777,9 +771,7 @@ found:
 
 void nv_addtype(Namval_t *np, const char *optstr, Optdisc_t *op, size_t optsz)
 {
-	Namdecl_t	*cp = newof((Namdecl_t*)0,Namdecl_t,1,optsz);
-	if(!cp)
-		sh_outofmemory();
+	Namdecl_t	*cp = sh_newof((Namdecl_t*)0,Namdecl_t,1,optsz);
 	Optdisc_t	*dp = (Optdisc_t*)(cp+1);
 	Shell_t		*shp = sh_getinterp();
 	Namval_t	*mp,*bp;
@@ -915,9 +907,7 @@ Namval_t *nv_mktype(Namval_t **nodes, int numnodes)
 	offset = roundof(offset,sizeof(char*));
 	nv_setsize(mp,offset);
 	k = roundof(sizeof(Namtype_t),sizeof(Sfdouble_t)) - sizeof(Namtype_t);
-	pp = newof(NiL, Namtype_t, 1, nnodes*NV_MINSZ + offset + size + (nnodes+nd)*sizeof(char*) + iref*sizeof(struct Namref)+k);
-	if(!pp)
-		sh_outofmemory();
+	pp = sh_newof(NiL, Namtype_t, 1, nnodes*NV_MINSZ + offset + size + (nnodes+nd)*sizeof(char*) + iref*sizeof(struct Namref)+k);
 	pp->fun.dsize = sizeof(Namtype_t)+nnodes*NV_MINSZ +offset+k;
 	pp->fun.type = mp;
 	pp->parent = nv_lastdict();
@@ -938,11 +928,7 @@ Namval_t *nv_mktype(Namval_t **nodes, int numnodes)
 	pp->strsize = size;
 	cp = (char*)&pp->names[nd+nnodes];
 	if(qp)
-	{
-		mnodes = newof(NiL, Namval_t*, nd+1, 0);
-		if(!mnodes)
-			sh_outofmemory();
-	}
+		mnodes = sh_newof(NiL, Namval_t*, nd+1, 0);
 	nd = 0;
 	nq = nv_namptr(pp->nodes,0);
 	nq->nvname = cp;
@@ -1103,7 +1089,7 @@ Namval_t *nv_mktype(Namval_t **nodes, int numnodes)
 						nv_onattr(nq,NV_NOFREE);
 					}
 					else
-						nq->nvalue.cp = strdup(nr->nvalue.cp);
+						nq->nvalue.cp = sh_strdup(nr->nvalue.cp);
 					nv_disc(nq, &pp->childfun.fun, NV_LAST);
 				}
 				nq->nvsize = nr->nvsize;
@@ -1214,9 +1200,7 @@ Namval_t *nv_mkinttype(char *name, size_t size, int sign, const char *help, Namd
         mp = nv_open(stakptr(offset), sh.var_tree, NV_VARNAME);
 	stakseek(offset);
 	offset = size + sizeof(Namdisc_t);
-	fp = newof(NiL, Namfun_t, 1, offset);
-	if(!fp)
-		sh_outofmemory();
+	fp = sh_newof(NiL, Namfun_t, 1, offset);
 	fp->type = mp;
 	fp->nofree |= 1;
 	fp->dsize = sizeof(Namfun_t)+size;
@@ -1349,7 +1333,7 @@ int nv_settype(Namval_t* np, Namval_t *tp, int flags)
 			flags &= ~NV_APPEND;
 		else if(!nv_isvtree(np))
 		{
-			val = strdup(nv_getval(np));
+			val = sh_strdup(nv_getval(np));
 			if(!(flags&NV_APPEND))
 				_nv_unset(np, NV_RDONLY);
 		}
@@ -1454,9 +1438,7 @@ Namval_t *nv_mkstruct(const char *name, int rsize, Fields_t *fields)
 			}
 		}
 	}
-	pp = newof(NiL,Namtype_t, 1,  nnodes*NV_MINSZ + rsize + size);
-	if(!pp)
-		sh_outofmemory();
+	pp = sh_newof(NiL,Namtype_t, 1,  nnodes*NV_MINSZ + rsize + size);
 	pp->fun.dsize = sizeof(Namtype_t)+nnodes*NV_MINSZ +rsize;
 	pp->fun.type = mp;
 	pp->np = mp;
@@ -1565,9 +1547,7 @@ void nv_mkstat(void)
 	tp = nv_mkstruct("stat_t", sizeof(struct stat), foo);
 	nv_offattr(tp,NV_RDONLY);
 	nv_setvtree(tp);
-	fp = newof(NiL,Namfun_t,1,0);
-	if(!fp)
-		sh_outofmemory();
+	fp = sh_newof(NiL,Namfun_t,1,0);
 	fp->type = tp;
 	fp->disc = &stat_disc;
 	nv_disc(tp,fp,NV_FIRST);

--- a/src/cmd/ksh93/sh/nvtype.c
+++ b/src/cmd/ksh93/sh/nvtype.c
@@ -778,6 +778,8 @@ found:
 void nv_addtype(Namval_t *np, const char *optstr, Optdisc_t *op, size_t optsz)
 {
 	Namdecl_t	*cp = newof((Namdecl_t*)0,Namdecl_t,1,optsz);
+	if(!cp)
+		sh_outofmemory();
 	Optdisc_t	*dp = (Optdisc_t*)(cp+1);
 	Shell_t		*shp = sh_getinterp();
 	Namval_t	*mp,*bp;
@@ -914,6 +916,8 @@ Namval_t *nv_mktype(Namval_t **nodes, int numnodes)
 	nv_setsize(mp,offset);
 	k = roundof(sizeof(Namtype_t),sizeof(Sfdouble_t)) - sizeof(Namtype_t);
 	pp = newof(NiL, Namtype_t, 1, nnodes*NV_MINSZ + offset + size + (nnodes+nd)*sizeof(char*) + iref*sizeof(struct Namref)+k);
+	if(!pp)
+		sh_outofmemory();
 	pp->fun.dsize = sizeof(Namtype_t)+nnodes*NV_MINSZ +offset+k;
 	pp->fun.type = mp;
 	pp->parent = nv_lastdict();
@@ -934,7 +938,11 @@ Namval_t *nv_mktype(Namval_t **nodes, int numnodes)
 	pp->strsize = size;
 	cp = (char*)&pp->names[nd+nnodes];
 	if(qp)
+	{
 		mnodes = newof(NiL, Namval_t*, nd+1, 0);
+		if(!mnodes)
+			sh_outofmemory();
+	}
 	nd = 0;
 	nq = nv_namptr(pp->nodes,0);
 	nq->nvname = cp;
@@ -1207,6 +1215,8 @@ Namval_t *nv_mkinttype(char *name, size_t size, int sign, const char *help, Namd
 	stakseek(offset);
 	offset = size + sizeof(Namdisc_t);
 	fp = newof(NiL, Namfun_t, 1, offset);
+	if(!fp)
+		sh_outofmemory();
 	fp->type = mp;
 	fp->nofree |= 1;
 	fp->dsize = sizeof(Namfun_t)+size;
@@ -1445,6 +1455,8 @@ Namval_t *nv_mkstruct(const char *name, int rsize, Fields_t *fields)
 		}
 	}
 	pp = newof(NiL,Namtype_t, 1,  nnodes*NV_MINSZ + rsize + size);
+	if(!pp)
+		sh_outofmemory();
 	pp->fun.dsize = sizeof(Namtype_t)+nnodes*NV_MINSZ +rsize;
 	pp->fun.type = mp;
 	pp->np = mp;
@@ -1554,6 +1566,8 @@ void nv_mkstat(void)
 	nv_offattr(tp,NV_RDONLY);
 	nv_setvtree(tp);
 	fp = newof(NiL,Namfun_t,1,0);
+	if(!fp)
+		sh_outofmemory();
 	fp->type = tp;
 	fp->disc = &stat_disc;
 	nv_disc(tp,fp,NV_FIRST);

--- a/src/cmd/ksh93/sh/parse.c
+++ b/src/cmd/ksh93/sh/parse.c
@@ -829,6 +829,8 @@ static Shnode_t *funct(Lex_t *lexp)
 			{
 				Namval_t *np= nv_open(t->funct.functnam,shp->fun_tree,NV_ADD|NV_VARNAME);
 				np->nvalue.rp = new_of(struct Ufunction,shp->funload?sizeof(Dtlink_t):0);
+				if(!np->nvalue.rp)
+					sh_outofmemory();
 				memset((void*)np->nvalue.rp,0,sizeof(struct Ufunction));
 				np->nvalue.rp->argc = ((struct dolnod*)ac->comarg)->dolnum;
 			}

--- a/src/cmd/ksh93/sh/parse.c
+++ b/src/cmd/ksh93/sh/parse.c
@@ -172,9 +172,7 @@ static void typeset_order(const char *str,int line)
 		return;
 	if(!table)
 	{
-		table = calloc(1,256);
-		if(!table)
-			sh_outofmemory();
+		table = sh_calloc(1,256);
 		for(cp=(unsigned char*)"bflmnprstuxACHS";c = *cp; cp++)
 			table[c] = 1;
 		for(cp=(unsigned char*)"aiEFLRXhTZ";c = *cp; cp++)
@@ -829,8 +827,6 @@ static Shnode_t *funct(Lex_t *lexp)
 			{
 				Namval_t *np= nv_open(t->funct.functnam,shp->fun_tree,NV_ADD|NV_VARNAME);
 				np->nvalue.rp = new_of(struct Ufunction,shp->funload?sizeof(Dtlink_t):0);
-				if(!np->nvalue.rp)
-					sh_outofmemory();
 				memset((void*)np->nvalue.rp,0,sizeof(struct Ufunction));
 				np->nvalue.rp->argc = ((struct dolnod*)ac->comarg)->dolnum;
 			}

--- a/src/cmd/ksh93/sh/path.c
+++ b/src/cmd/ksh93/sh/path.c
@@ -1496,6 +1496,8 @@ static Pathcomp_t *path_addcomp(Shell_t *shp,Pathcomp_t *first, Pathcomp_t *old,
 	}
 	for(pp=first, oldpp=0; pp; oldpp=pp, pp=pp->next);
 	pp = newof((Pathcomp_t*)0,Pathcomp_t,1,len+1);
+	if(!pp)
+		sh_outofmemory();
 	pp->shp = shp;
 	pp->refcount = 1;
 	memcpy((char*)(pp+1),name,len+1);

--- a/src/cmd/ksh93/sh/path.c
+++ b/src/cmd/ksh93/sh/path.c
@@ -185,9 +185,7 @@ static pid_t path_xargs(Shell_t *shp,const char *path, char *argv[],char *const 
 		if(xv==&argv[shp->xargmin])
 		{
 			n = nlast*sizeof(char*);
-			saveargs = (char**)malloc(n);
-			if(!saveargs)
-				sh_outofmemory();
+			saveargs = (char**)sh_malloc(n);
 			memcpy((void*)saveargs, (void*)av, n);
 			memcpy((void*)av,(void*)avlast,n);
 		}
@@ -567,9 +565,7 @@ char *path_fullname(Shell_t *shp,const char *name)
 		pwd = path_pwd(shp,1);
 		dirlen = strlen(pwd)+1;
 	}
-	path = (char*)malloc(len+dirlen);
-	if(!path)
-		sh_outofmemory();
+	path = (char*)sh_malloc(len+dirlen);
 	if(dirlen)
 	{
 		memcpy((void*)path,(void*)pwd,dirlen);
@@ -1180,9 +1176,7 @@ pid_t path_spawn(Shell_t *shp,const char *opath,register char **argv, char **env
 		 * The following code because execv(foo,) and execv(./foo,)
 		 * may not yield the same results
 		 */
-		char *sp = (char*)malloc(strlen(path)+3);
-		if(!sp)
-			sh_outofmemory();
+		char *sp = (char*)sh_malloc(strlen(path)+3);
 		sp[0] = '.';
 		sp[1] = '/';
 		strcpy(sp+2,path);
@@ -1358,7 +1352,7 @@ static void exscript(Shell_t *shp,register char *path,register char *argv[],char
 	sh_accbegin(path) ;  /* reset accounting */
 #endif	/* SHOPT_ACCT */
 	shp->arglist = sh_argcreate(argv);
-	shp->lastarg = strdup(path);
+	shp->lastarg = sh_strdup(path);
 	/* save name of calling command */
 	shp->readscript = error_info.id;
 	/* close history file if name has changed */
@@ -1495,9 +1489,7 @@ static Pathcomp_t *path_addcomp(Shell_t *shp,Pathcomp_t *first, Pathcomp_t *old,
 		}
 	}
 	for(pp=first, oldpp=0; pp; oldpp=pp, pp=pp->next);
-	pp = newof((Pathcomp_t*)0,Pathcomp_t,1,len+1);
-	if(!pp)
-		sh_outofmemory();
+	pp = sh_newof((Pathcomp_t*)0,Pathcomp_t,1,len+1);
 	pp->shp = shp;
 	pp->refcount = 1;
 	memcpy((char*)(pp+1),name,len+1);
@@ -1512,9 +1504,7 @@ static Pathcomp_t *path_addcomp(Shell_t *shp,Pathcomp_t *first, Pathcomp_t *old,
 	{
 		pp->dev = 1;
 		pp->flags |= PATH_BUILTIN_LIB;
-		pp->blib = pp->bbuf = malloc(sizeof(LIBCMD));
-		if(!pp->blib)
-			sh_outofmemory();
+		pp->blib = pp->bbuf = sh_malloc(sizeof(LIBCMD));
 		strcpy(pp->blib,LIBCMD);
 		return(first);
 	}
@@ -1580,13 +1570,11 @@ static int path_chkpaths(Shell_t *shp,Pathcomp_t *first, Pathcomp_t* old,Pathcom
 			{
 				if(pp->bbuf)
 					free(pp->bbuf);
-				pp->blib = pp->bbuf = strdup(ep);
+				pp->blib = pp->bbuf = sh_strdup(ep);
 			}
 			else if(m)
 			{
-				pp->lib = (char*)malloc(cp-sp+pp->len+2);
-				if(!pp->lib)
-					sh_outofmemory();
+				pp->lib = (char*)sh_malloc(cp-sp+pp->len+2);
 				memcpy((void*)pp->lib,(void*)sp,m);
 				memcpy((void*)&pp->lib[m],stakptr(offset),pp->len);
 				pp->lib[k=m+pp->len] = '/';

--- a/src/cmd/ksh93/sh/subshell.c
+++ b/src/cmd/ksh93/sh/subshell.c
@@ -188,7 +188,7 @@ void sh_subfork(void)
 	pid_t pid;
 	char *trap = shp->st.trapcom[0];
 	if(trap)
-		trap = strdup(trap);
+		trap = sh_strdup(trap);
 	/* see whether inside $(...) */
 	if(sp->pipe)
 		sh_subtmpfile(shp->comsub);
@@ -307,9 +307,7 @@ Namval_t *sh_assignok(register Namval_t *np,int add)
 			return(np);
 	}
 	/* first two pointers use linkage from np */
-	lp = (struct Link*)malloc(sizeof(*np)+2*sizeof(void*));
-	if(!lp)
-		sh_outofmemory();
+	lp = (struct Link*)sh_malloc(sizeof(*np)+2*sizeof(void*));
 	memset(lp,0, sizeof(*mp)+2*sizeof(void*));
 	lp->node = np;
 	if(!add &&  nv_isvtree(np))
@@ -609,7 +607,7 @@ Sfio_t *sh_subshell(Shell_t *shp,Shnode_t *t, volatile int flags, int comsub)
 			}
 		}
 #endif /* _lib_fchdir */
-		sp->pwd = (shp->pwd?strdup(shp->pwd):0);
+		sp->pwd = (shp->pwd?sh_strdup(shp->pwd):0);
 		sp->mask = shp->mask;
 		sh_stats(STAT_SUBSHELL);
 		/* save trap table */
@@ -617,12 +615,10 @@ Sfio_t *sh_subshell(Shell_t *shp,Shnode_t *t, volatile int flags, int comsub)
 		shp->st.otrap = savst.trap;
 		if((nsig=shp->st.trapmax)>0 || shp->st.trapcom[0])
 		{
-			savsig = malloc(nsig * sizeof(char*));
-			if(!savsig)
-				sh_outofmemory();
+			savsig = sh_malloc(nsig * sizeof(char*));
 			/*
 			 * the data is, usually, modified in code like:
-			 *	tmp = buf[i]; buf[i] = strdup(tmp); free(tmp);
+			 *	tmp = buf[i]; buf[i] = sh_strdup(tmp); free(tmp);
 			 * so shp->st.trapcom needs a "deep copy" to properly save/restore pointers.
 			 */
 			for (isig = 0; isig < nsig; ++isig)
@@ -630,7 +626,7 @@ Sfio_t *sh_subshell(Shell_t *shp,Shnode_t *t, volatile int flags, int comsub)
 				if(shp->st.trapcom[isig] == Empty)
 					savsig[isig] = Empty;
 				else if(shp->st.trapcom[isig])
-					savsig[isig] = strdup(shp->st.trapcom[isig]);
+					savsig[isig] = sh_strdup(shp->st.trapcom[isig]);
 				else
 					savsig[isig] = NULL;
 			}

--- a/src/cmd/ksh93/sh/timers.c
+++ b/src/cmd/ksh93/sh/timers.c
@@ -189,7 +189,7 @@ void *sh_timeradd(unsigned long msec,int flags,void (*action)(void*),void *handl
 	if(tp=tpfree)
 		tpfree = tp->next;
 	else if(!(tp=(Timer_t*)malloc(sizeof(Timer_t))))
-		return((void*)0);
+		sh_outofmemory();
 	tp->wakeup = getnow() + t;
 	tp->incr = (flags?t:0);
 	tp->action = action;
@@ -204,7 +204,9 @@ void *sh_timeradd(unsigned long msec,int flags,void (*action)(void*),void *handl
 		if((t= setalarm(t))>0 && fn  && fn!=(Handler_t)sigalrm)
 		{
 			Handler_t *hp = (Handler_t*)malloc(sizeof(Handler_t));
-			if(hp)
+			if(!hp)
+				sh_outofmemory();
+			else
 			{
 				*hp = fn;
 				sh_timeradd((long)(1000*t), 0, oldalrm, (void*)hp);

--- a/src/cmd/ksh93/sh/timers.c
+++ b/src/cmd/ksh93/sh/timers.c
@@ -188,8 +188,8 @@ void *sh_timeradd(unsigned long msec,int flags,void (*action)(void*),void *handl
 		return((void*)0);
 	if(tp=tpfree)
 		tpfree = tp->next;
-	else if(!(tp=(Timer_t*)malloc(sizeof(Timer_t))))
-		sh_outofmemory();
+	else
+		tp = (Timer_t*)sh_malloc(sizeof(Timer_t));
 	tp->wakeup = getnow() + t;
 	tp->incr = (flags?t:0);
 	tp->action = action;
@@ -203,14 +203,9 @@ void *sh_timeradd(unsigned long msec,int flags,void (*action)(void*),void *handl
 		fn = (Handler_t)signal(SIGALRM,sigalrm);
 		if((t= setalarm(t))>0 && fn  && fn!=(Handler_t)sigalrm)
 		{
-			Handler_t *hp = (Handler_t*)malloc(sizeof(Handler_t));
-			if(!hp)
-				sh_outofmemory();
-			else
-			{
-				*hp = fn;
-				sh_timeradd((long)(1000*t), 0, oldalrm, (void*)hp);
-			}
+			Handler_t *hp = (Handler_t*)sh_malloc(sizeof(Handler_t));
+			*hp = fn;
+			sh_timeradd((long)(1000*t), 0, oldalrm, (void*)hp);
 		}
 		tp = tptop;
 	}

--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -627,6 +627,8 @@ static const Namdisc_t level_disc = {  sizeof(struct Level), put_level };
 static struct Level *init_level(Shell_t *shp,int level)
 {
 	struct Level *lp = newof(NiL,struct Level,1,0);
+	if(!lp)
+		sh_outofmemory();
 	lp->maxlevel = level;
 	_nv_unset(SH_LEVELNOD,0);
 	nv_onattr(SH_LEVELNOD,NV_INT16|NV_NOFREE);
@@ -2528,6 +2530,8 @@ int sh_exec(register const Shnode_t *t, int flags)
 			if(!np->nvalue.rp)
 			{
 				np->nvalue.rp = new_of(struct Ufunction,shp->funload?sizeof(Dtlink_t):0);
+				if(!np->nvalue.rp)
+					sh_outofmemory();
 				memset((void*)np->nvalue.rp,0,sizeof(struct Ufunction));
 			}
 			if(t->funct.functstak)
@@ -3172,6 +3176,8 @@ int sh_funscope(int argn, char *argv[],int(*fun)(void*),void *arg,int execflg)
 					if(np && (nq=*nref++))
 					{
 						np->nvalue.nrp = newof(0,struct Namref,1,0);
+						if(!np->nvalue.nrp)
+							sh_outofmemory();
 						np->nvalue.nrp->np = nq;
 						nv_onattr(np,NV_REF|NV_NOFREE);
 					}

--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -626,9 +626,7 @@ static const Namdisc_t level_disc = {  sizeof(struct Level), put_level };
 
 static struct Level *init_level(Shell_t *shp,int level)
 {
-	struct Level *lp = newof(NiL,struct Level,1,0);
-	if(!lp)
-		sh_outofmemory();
+	struct Level *lp = sh_newof(NiL,struct Level,1,0);
 	lp->maxlevel = level;
 	_nv_unset(SH_LEVELNOD,0);
 	nv_onattr(SH_LEVELNOD,NV_INT16|NV_NOFREE);
@@ -837,7 +835,7 @@ static int set_instance(Shell_t *shp,Namval_t *nq, Namval_t *node, struct Namref
 #endif /* SHOPT_NAMESPACE */
 	shp->instance = 1;
 	if((ap=nv_arrayptr(nq)) && (sp = nv_getsub(nq)))
-		sp = strdup(sp);
+		sp = sh_strdup(sp);
 	shp->instance = 0;
 	if(shp->var_tree!=shp->var_base && !nv_search((char*)nq,nr->root,HASH_BUCKET|HASH_NOSCOPE))
 	{
@@ -1123,7 +1121,7 @@ int sh_exec(register const Shnode_t *t, int flags)
 								if(!shp->strbuf2)
 									shp->strbuf2 = sfstropen();
 								sfprintf(shp->strbuf2,"%s%s%c",NV_CLASS,nv_name(shp->namespace),0);
-								shp->prefix = strdup(sfstruse(shp->strbuf2));
+								shp->prefix = sh_strdup(sfstruse(shp->strbuf2));
 								nv_open(shp->prefix,shp->var_base,NV_VARNAME);
 							}
 							else
@@ -1870,9 +1868,7 @@ int sh_exec(register const Shnode_t *t, int flags)
 				if((nsig=shp->st.trapmax*sizeof(char*))>0 || shp->st.trapcom[0])
 				{
 					nsig += sizeof(char*);
-					savsig = malloc(nsig);
-					if(!savsig)
-						sh_outofmemory();
+					savsig = sh_malloc(nsig);
 					memcpy(savsig,(char*)&shp->st.trapcom[0],nsig);
 					shp->st.otrapcom = (char**)savsig;
 				}
@@ -2530,8 +2526,6 @@ int sh_exec(register const Shnode_t *t, int flags)
 			if(!np->nvalue.rp)
 			{
 				np->nvalue.rp = new_of(struct Ufunction,shp->funload?sizeof(Dtlink_t):0);
-				if(!np->nvalue.rp)
-					sh_outofmemory();
 				memset((void*)np->nvalue.rp,0,sizeof(struct Ufunction));
 			}
 			if(t->funct.functstak)
@@ -2692,7 +2686,7 @@ int sh_exec(register const Shnode_t *t, int flags)
 			else
 			{
 				nv_offattr(L_ARGNOD,NV_NOFREE);
-				shp->lastarg = strdup(comn);
+				shp->lastarg = sh_strdup(comn);
 			}
 		}
 		if(!skipexitset)
@@ -3118,12 +3112,10 @@ int sh_funscope(int argn, char *argv[],int(*fun)(void*),void *arg,int execflg)
 	/* save trap table */
 	if((nsig=shp->st.trapmax)>0 || shp->st.trapcom[0])
 	{
-		savsig = malloc(nsig * sizeof(char*));
-		if(!savsig)
-			sh_outofmemory();
+		savsig = sh_malloc(nsig * sizeof(char*));
 		/*
 		 * the data is, usually, modified in code like:
-		 *	tmp = buf[i]; buf[i] = strdup(tmp); free(tmp);
+		 *	tmp = buf[i]; buf[i] = sh_strdup(tmp); free(tmp);
 		 * so shp->st.trapcom needs a "deep copy" to properly save/restore pointers.
 		 */
 		for (isig = 0; isig < nsig; ++isig)
@@ -3131,7 +3123,7 @@ int sh_funscope(int argn, char *argv[],int(*fun)(void*),void *arg,int execflg)
 			if(shp->st.trapcom[isig] == Empty)
 				savsig[isig] = Empty;
 			else if(shp->st.trapcom[isig])
-				savsig[isig] = strdup(shp->st.trapcom[isig]);
+				savsig[isig] = sh_strdup(shp->st.trapcom[isig]);
 			else
 				savsig[isig] = NULL;
 		}
@@ -3175,9 +3167,7 @@ int sh_funscope(int argn, char *argv[],int(*fun)(void*),void *arg,int execflg)
 					np = nv_search(arg[r],shp->var_tree,HASH_NOSCOPE|NV_ADD);
 					if(np && (nq=*nref++))
 					{
-						np->nvalue.nrp = newof(0,struct Namref,1,0);
-						if(!np->nvalue.nrp)
-							sh_outofmemory();
+						np->nvalue.nrp = sh_newof(0,struct Namref,1,0);
 						np->nvalue.nrp->np = nq;
 						nv_onattr(np,NV_REF|NV_NOFREE);
 					}


### PR DESCRIPTION
Most of the changes in this pull request are additional out of memory checks run after the `newof` and `new_of` macros, which both allocate memory:
https://github.com/ksh93/ksh/blob/caf7ab6c71fdc0ed357582b03e93db41c609731e/src/lib/libast/include/ast.h#L219-L220
https://github.com/ksh93/ksh/blob/caf7ab6c71fdc0ed357582b03e93db41c609731e/src/cmd/ksh93/include/defs.h#L293

Additionally, one memory allocation in src/cmd/ksh93/edit/edit.c that checked a variable before it was initialized has been fixed.