### PR TITLE
Readonly attribute size fix

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,11 @@ For full details, see the git log at: https://github.com/ksh93/ksh
 
 Any uppercase BUG_* names are modernish shell bug IDs.
 
+2021-03-01:
+
+- Fixed the retention of size attributes when 'readonly' or 'typeset -r'
+  was applied to an existing variable.
+
 2021-02-26:
 
 - Fixed three long-standing bugs with tab completion in the emacs editor:

--- a/src/cmd/ksh93/bltins/typeset.c
+++ b/src/cmd/ksh93/bltins/typeset.c
@@ -835,7 +835,12 @@ static int     setall(char **argv,register int flag,Dt_t *troot,struct tdata *tp
 				{
 					if(np->nvfun && !nv_isarray(np) && name[strlen(name)-1]=='.')
 						newflag |= NV_NODISC;
-					nv_newattr (np, newflag&~NV_ASSIGN,tp->argnum);
+					if(flag&NV_RDONLY && !tp->argnum && !(flag&(NV_INTEGER|NV_BINARY)) && !(flag&(NV_LJUST|NV_RJUST|NV_ZFILL)))
+						/* New requested attribute(s) are readonly, have a provided or defaulted size of 0, and are
+						   not a string justification nor numeric. Justified or binary strings can have a size of 0. */
+						nv_newattr(np, newflag&~NV_ASSIGN, np->nvsize);
+					else
+						nv_newattr(np, newflag&~NV_ASSIGN, tp->argnum);
 				}
 			}
 			if(tp->help && !nv_isattr(np,NV_MINIMAL|NV_EXPORT))

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -20,7 +20,7 @@
 
 #define SH_RELEASE_FORK	"93u+m"		/* only change if you develop a new ksh93 fork */
 #define SH_RELEASE_SVER	"1.0.0-alpha"	/* semantic version number: https://semver.org */
-#define SH_RELEASE_DATE	"2021-02-26"	/* must be in this format for $((.sh.version)) */
+#define SH_RELEASE_DATE	"2021-03-01"	/* must be in this format for $((.sh.version)) */
 #define SH_RELEASE_CPYR	"(c) 2020-2021 Contributors to ksh " SH_RELEASE_FORK
 
 /* Scripts sometimes field-split ${.sh.version}, so don't change amount of whitespace. */


### PR DESCRIPTION
Corrected the size of attribute(s) being overwritten with 0 when
'readonly' or 'typeset -r' was applied to an existing variable. Since
one cannot set any attributes with the 'readonly' command, its function
call to setall() needs to be adjusted to acquire the current size from
the old size or existing size of the variable. A plain 'typeset -r' is
the same as 'readonly' in that it needs to load the old size as its
current size for use in the subsequent to call to nv_newattr().

src/cmd/ksh93/bltins/typeset.c: setall():
- Both 'readonly' and 'typeset -r' end up calling setall(). setall()
  has full visibility into all user supplied values and existing
  values that are needed to differentiate whereas name.c newattr()
  acquires combined state flags.
- Added a conditional check if the readonly flag was requested by
  user then meets the criteria of having present size of 0, cannot
  be a numeric nor binary string, and is void of presence of any of
  the justified string attributes.
- -L/R/Z justified string attributes if not given a value default
  to a size of 0 which means to autosize. A binary string can have
  a fixed field size, e.g. -bZ. The present of any of the -L/R/Z
  attribules means that current size is valid and should be used
  even if it is zero.

src/cmd/ksh93/tests/attributes.sh:
- Added various tests to capture and reiterate that 'readonly' should
  be equivalent to 'typeset -r' and applying them should not alter the
  previous existing size unless additional attributes are set along
  with typeset command.