### PR TITLE
Fix Ctrl+D after ksh receives SIGWINCH

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,6 +9,9 @@ Any uppercase BUG_* names are modernish shell bug IDs.
   did not perform an assignment and yielded the value 0 if 'var' was typeset as
   numeric (integer or float) but had not yet been assigned a value.
 
+- Fixed a bug introduced on 2020-08-19: Ctrl+D would break after an
+  interactive shell received SIGWINCH.
+
 2021-03-05:
 
 - Unbalanced quotes and backticks now correctly produce a syntax error


### PR DESCRIPTION
src/cmd/ksh93/edit/edit.c: ed_read():
- The loop that handles `SIGWINCH` assumes `sfpkrd` will return and set `errno` to `EINTR` when ksh is sent `SIGWINCH`. This only happens if `select` is used to wait for input, so tell `sfpkrd` to use `select` if possible. This is only done if the last argument given to `sfpkrd` is '2', which should avoid regressions.

src/lib/libast/sfio/sfpkrd.c: sfpkrd():
- Always use `select` if the last argument is '2'. This allows `sfpkrd` to intercept `SIGWINCH` when necessary.

Fixes #202