### PR TITLE
Add more regression tests, mostly from ksh93v- and ksh2020

### DIFF
--- a/src/cmd/ksh93/tests/arrays.sh
+++ b/src/cmd/ksh93/tests/arrays.sh
@@ -524,6 +524,7 @@ typeset -m 'a[0]=a[1]'
 typeset -m 'a[1]=j'
 [[ ${a[@]} == 'bb aa cc' ]] || err_exit 'moving index array elements not working'
 unset a j
+[[ $(typeset -p a) ]] && err_exit 'unset associative array after typeset -m not working'
 
 typeset -A a=( [0]="aa" [1]="bb" [2]="cc" )
 typeset -m 'j=a[0]'

--- a/src/cmd/ksh93/tests/arrays2.sh
+++ b/src/cmd/ksh93/tests/arrays2.sh
@@ -224,6 +224,15 @@ print -v cx > /dev/null
 print -v cx | read -C l 2> /dev/null || err_exit 'read -C fails from output of print -v'
 ((SHOPT_FIXEDARRAY)) && [[ ${cx%cx=} != "${l%l=}" ]] && err_exit 'print -v for compound variable with fixed 2d array not working'
 
+unset foo
+typeset -A foo
+typeset -A foo[bar]
+foo[bar][x]=2
+(( foo[bar][x]++ ))
+exp=3
+[[ ${foo[bar][x]} == $exp ]] || err_ext "subscript gets added incorrectly to an associative array when ++ operator is called" \
+	"(expected '$exp', got '${foo[bar][x]}')"
+
 # ======
 # Multidimensional arrays with an unset method shouldn't cause a crash.
 # The test itself must be run inside of a function.

--- a/src/cmd/ksh93/tests/bracket.sh
+++ b/src/cmd/ksh93/tests/bracket.sh
@@ -409,4 +409,12 @@ do	unset var
 done
 
 # ======
+# Tests from ksh93v- for the -eq operator
+[[ 010 -eq 10 ]] || err_exit '010 is not 10 in [[...]]'
+
+unset foo
+foo=10
+([[ foo -eq 10 ]]) || err_exit 'foo -eq 10 fails in [[...]] with foo=10'
+
+# ======
 exit $((Errors<125?Errors:125))

--- a/src/cmd/ksh93/tests/case.sh
+++ b/src/cmd/ksh93/tests/case.sh
@@ -103,4 +103,10 @@ got=$(eval 'case x in foo);; if);; esac' 2>&1) || err_exit "'if' as nth pattern 
 got=$(eval 'case x in (foo);; (if);; esac' 2>&1) || err_exit "'(' + 'if' as nth pattern fails: got $(printf %q "$got")"
 
 # ======
+# Verify an invalid character class name is handled without a SIGSEGV or similar failure
+# https://github.com/att/ast/issues/1409
+got="$($SHELL -c 'case x in [x[:bogus:]]) echo x ;; esac')"
+[[ -z $got ]] || err_exit "invalid char class name (got $(printf %q "$got"))"
+
+# ======
 exit $((Errors<125?Errors:125))

--- a/src/cmd/ksh93/tests/exit.sh
+++ b/src/cmd/ksh93/tests/exit.sh
@@ -76,4 +76,64 @@ cd /
 cd ~- || err_exit "cd back failed"
 $SHELL -c 'builtin -f cmd getconf; getconf --"?-version"; exit 0' >/dev/null 2>&1 || err_exit 'ksh plugin exit failed -- was ksh built with CCFLAGS+=$(CC.EXPORT.DYNAMIC)?'
 
+# ======
+# Verify the 'exit' command behaves as expected
+
+got=$($SHELL -c 'exit' 2>&1)
+status=$?
+exp=0
+[[ -z $got ]] || err_exit 'bare exit' \
+	"(got $(printf %q "$got"))"
+[[ $exp == $status ]] || err_exit 'bare exit' \
+	"(expected '$exp', got '$status')"
+
+got=$($SHELL -c 'exit 0' 2>&1)
+status=$?
+exp=0
+[[ -z $got ]] || err_exit 'exit 0' \
+	"(got $(printf %q "$got"))"
+[[ $exp == $status ]] || err_exit 'exit 0' \
+	"(expected '$exp', got '$status')"
+
+got=$($SHELL -c 'exit 1' 2>&1)
+status=$?
+exp=1
+[[ -z $got ]] || err_exit 'exit 1' \
+	"(got $(printf %q "$got"))"
+[[ $exp == $status ]] || err_exit 'exit 1' \
+	"(expected '$exp', got '$status')"
+
+got=$($SHELL -c 'function e37 { return 37; } ; e37' 2>&1)
+status=$?
+exp=37
+[[ -z $got ]] || err_exit 'exit 37' \
+	"(got $(printf %q "$got"))"
+[[ $exp == $status ]] || err_exit 'exit 37' \
+	"(expected '$exp', got '$status')"
+
+got=$($SHELL -c 'exit -1' 2>&1)
+status=$?
+exp=255
+[[ -z $got ]] || err_exit 'exit -1' \
+	"(got $(printf %q "$got"))"
+[[ $exp == $status ]] || err_exit 'exit -1' \
+	"(expected '$exp', got '$status')"
+
+got=$($SHELL -c 'exit -2' 2>&1)
+status=$?
+exp=254
+[[ -z $got ]] || err_exit 'exit -2' \
+	"(got $(printf %q "$got"))"
+[[ $exp == $status ]] || err_exit 'exit -2' \
+	"(expected '$exp', got '$status')"
+
+$SHELL +E -i 2>/dev/null <<- \! && err_exit 'interactive shell should not exit 0 after false'
+	false
+	exit
+!
+status=$?
+exp=1
+[[ $exp == $status ]] || err_exit 'bare exit after false' \
+	"(expected '$exp', got '$status')"
+
 exit $((Errors<125?Errors:125))

--- a/src/cmd/ksh93/tests/exit.sh
+++ b/src/cmd/ksh93/tests/exit.sh
@@ -127,7 +127,7 @@ exp=254
 [[ $exp == $status ]] || err_exit 'exit -2' \
 	"(expected '$exp', got '$status')"
 
-$SHELL +E -i 2>/dev/null <<- \! && err_exit 'interactive shell should not exit 0 after false'
+$SHELL +E -i 2>/dev/null <<- \!
 	false
 	exit
 !
@@ -136,4 +136,5 @@ exp=1
 [[ $exp == $status ]] || err_exit 'bare exit after false' \
 	"(expected '$exp', got '$status')"
 
+# ======
 exit $((Errors<125?Errors:125))

--- a/src/cmd/ksh93/tests/io.sh
+++ b/src/cmd/ksh93/tests/io.sh
@@ -716,4 +716,22 @@ got=$(export tmp; "$SHELL" -ec \
 [[ -r $tmp/v.out && $(<$tmp/v.out) == ok2 ]] || err_exit 'redirect {varname}>file not working in a subshell'
 
 # ======
+# Regression test for a process substitution hang in ksh93v- 2013-10-10 alpha
+{
+	producer() {
+		for ((i = 0; i < 20000; i++ )) do
+			print xxxxx${i}xxxxx
+		done
+	}
+	consumer() {
+		while read var; do
+			print ${var}
+		done < ${1}
+	}
+	consumer <(producer) > /dev/null
+} & pid=$!
+(sleep 5; kill -HUP $pid) 2> /dev/null &
+wait $pid 2> /dev/null || err_exit "process substitution hangs"
+
+# ======
 exit $((Errors<125?Errors:125))

--- a/src/cmd/ksh93/tests/math.sh
+++ b/src/cmd/ksh93/tests/math.sh
@@ -261,4 +261,11 @@ unset x
 [[ $(typeset -lX 0 x=5.67; typeset -p x) == 'typeset -l -X 0 x=0x1p+2' ]] || err_exit 'typeset -lX 0 with assignment failed to round.'
 
 # ======
+# typeset -s used without -i shouldn't set foo to garbage
+exp=30000
+got="$(typeset -s foo=30000; echo $foo)"
+[[ $exp == $got ]] || err_exit "unexpected output from typeset -s without -i" \
+	"(expected $(printf %q "$exp"), got $(printf %q "$got"))"
+
+# ======
 exit $((Errors<125?Errors:125))

--- a/src/cmd/ksh93/tests/variables.sh
+++ b/src/cmd/ksh93/tests/variables.sh
@@ -1259,4 +1259,12 @@ got=$(IFS=/; foo=bar foobar=fbar fool=pity; print -r -- "${!foo*}")
 [[ $got == "$exp" ]] || err_exit "\${!foo*}: expected $(printf %q "$exp"), got $(printf %q "$got")"
 
 # ======
+# In ksh93v- ${.sh.subshell} is unset by the $PS4 prompt
+# https://github.com/att/ast/issues/1092
+exp='0'
+got="$($SHELL -c 'PS4="${.sh.subshell}"; echo ${.sh.subshell}')"
+[[ "$exp" == "$got" ]] || err_exit "\${.sh.subshell} is wrongly unset in the \$PS4 prompt" \
+	"(expected $(printf %q "$exp"), got $(printf %q "$got"))"
+
+# ======
 exit $((Errors<125?Errors:125))


### PR DESCRIPTION
List of added regression tests:

src/cmd/ksh93/tests/arrays.sh,
src/cmd/ksh93/tests/arrays2.sh:
\- Backport some regression tests from ksh93v- for associative arrays.

src/cmd/ksh93/tests/basic.sh:
\- Add ksh93v- regression tests for background process output in backtick and shared-state command substitutions as well as functions  used in command substitutions.
\- Add regression tests for using EXIT traps in subshells. In ksh93v- and ksh2020 EXIT traps don't work in forked subshells: https://github.com/att/ast/issues/1452
\- The `trap` builtin shouldn't segfault after receiving an invalid signal name. ksh2020 regression: https://github.com/att/ast/issues/1403
\- Add a test to make sure invalid flags don't crash ksh. ksh2020 regression: https://github.com/att/ast/issues/1284
\- Test for an illegal seek error when using the `join` command with process substitutions. ksh93v- regression: https://www.mail-archive.com/ast-users@lists.research.att.com/msg00816.html

src/cmd/ksh93/tests/bracket.sh:
\- Add some regression tests from ksh93v- for the `-eq` test operator.

src/cmd/ksh93/tests/builtins.sh:
\- Move the regression test for `exit` in an interactive shell to the exit.sh script.
\- Test for assignments preceding the command builtin persisting after an error. ksh2020 regression: https://github.com/att/ast/issues/1402
\- The `chmod` builtin should modify the permissions of all files passed to it. ksh2020 regression: https://github.com/att/ast/issues/949
\- Add regression tests for the `cd` builtin. In ksh93v- 2013-10-10 alpha, using `cd` on a directory without an execute bit doesn't cause an error. The test for using `cd` on a normal file was backported from ksh93v-.
\- Backport a ksh93v- regression test for the exit status from `kill %`.

src/cmd/ksh93/tests/case.sh:
\- Test for a segfault when ksh handles an invalid character class in a pattern. ksh2020 regression: https://github.com/att/ast/issues/1409

src/cmd/ksh93/tests/exit.sh:
\- Add regression tests from ksh2020 for the `exit` builtin: https://github.com/att/ast/commit/d9491d46902d01fecde59aab5863a6c648ddc63c

src/cmd/ksh93/tests/io.sh:
\- Add a regression test from ksh93v- for a process substitution hang. This test fails in the 93v- 2013 alpha but succeeds in the 2014 beta.

src/cmd/ksh93/tests/math.sh:
\- `typeset -s foo=30000` corrupts `$foo` in ksh93u+, ksh93v- and ksh2020:
```sh
  $ typeset -s foo=30000
  $ echo $foo
  5#1430000
```
This bug was fixed in commit 88a6baa1, but that commit didn't add a regression test for it.

src/cmd/ksh93/tests/variables.sh:
\- Add a regression test for `$PS4` incorrectly unsetting `${.sh.subshell}`: https://github.com/att/ast/issues/1092