### PR TITLE
Fix two SHOPT_DEVFD process substitution file descriptor leaks

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,10 @@ Any uppercase BUG_* names are modernish shell bug IDs.
 - Fixed a file descriptor leak that occurred when ksh used /dev/fd for
   process substitutions passed to functions.
 
+- Fixed a separate file descriptor leak that when 'command' was passed
+  a function and process substitution as arguments (like above, this
+  occurred when SHOPT_DEVFD is enabled).
+
 2021-03-11:
 
 - Fixed an intermittent bug that caused process substitutions to infinitely

--- a/NEWS
+++ b/NEWS
@@ -8,9 +8,9 @@ Any uppercase BUG_* names are modernish shell bug IDs.
 - Fixed a file descriptor leak that occurred when ksh used /dev/fd for
   process substitutions passed to functions.
 
-- Fixed a separate file descriptor leak that happened when 'command' was
-  passed a function and process substitution as arguments (like above, this
-  occurred when SHOPT_DEVFD is enabled).
+- Fixed a separate file descriptor leak that happened when a command not
+  found error occurred in a script and a process substitution was an argument
+  to the invalid command.
 
 2021-03-11:
 

--- a/NEWS
+++ b/NEWS
@@ -8,9 +8,8 @@ Any uppercase BUG_* names are modernish shell bug IDs.
 - Fixed a file descriptor leak that occurred when ksh used /dev/fd for
   process substitutions passed to functions.
 
-- Fixed a separate file descriptor leak that happened when a command not
-  found error occurred in a script and a process substitution was an argument
-  to the invalid command.
+- Fixed a separate file descriptor leak that happened when a process
+  substitution was passed to a nonexistent command.
 
 2021-03-11:
 

--- a/NEWS
+++ b/NEWS
@@ -8,8 +8,8 @@ Any uppercase BUG_* names are modernish shell bug IDs.
 - Fixed a file descriptor leak that occurred when ksh used /dev/fd for
   process substitutions passed to functions.
 
-- Fixed a separate file descriptor leak that when 'command' was passed
-  a function and process substitution as arguments (like above, this
+- Fixed a separate file descriptor leak that happened when 'command' was
+  passed a function and process substitution as arguments (like above, this
   occurred when SHOPT_DEVFD is enabled).
 
 2021-03-11:

--- a/NEWS
+++ b/NEWS
@@ -3,7 +3,7 @@ For full details, see the git log at: https://github.com/ksh93/ksh
 
 Any uppercase BUG_* names are modernish shell bug IDs.
 
-2021-03-12:
+2021-03-13:
 
 - Fixed a file descriptor leak that occurred when ksh used /dev/fd for
   process substitutions passed to functions.

--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,11 @@ For full details, see the git log at: https://github.com/ksh93/ksh
 
 Any uppercase BUG_* names are modernish shell bug IDs.
 
+2021-03-12:
+
+- Fixed a file descriptor leak that occurred when ksh used /dev/fd for
+  process substitutions passed to functions.
+
 2021-03-11:
 
 - Fixed an intermittent bug that caused process substitutions to infinitely

--- a/src/cmd/ksh93/SHOPT.sh
+++ b/src/cmd/ksh93/SHOPT.sh
@@ -13,6 +13,7 @@ SHOPT BRACEPAT=1			# C-shell {...,...} expansions (, required)
 SHOPT CMDLIB_HDR=  # '<cmdlist.h>'	# custom -lcmd list for path-bound builtins
 SHOPT CMDLIB_DIR=  # '\"/opt/ast/bin\"'	# virtual directory prefix for path-bound builtins
 SHOPT CRNL=				# accept MS Windows newlines (<cr><nl>) for <nl>
+SHOPT DEVFD=				# use /dev/fd instead of FIFOs for process substitutions
 SHOPT DYNAMIC=1				# dynamic loading for builtins
 SHOPT ECHOPRINT=			# make echo equivalent to print
 SHOPT EDPREDICT=1			# predictive editing

--- a/src/cmd/ksh93/include/defs.h
+++ b/src/cmd/ksh93/include/defs.h
@@ -43,14 +43,6 @@
 #   define mbmax()	1
 #endif
 
-/*
- * Until a file descriptor leak with process substitution
- * is fixed, disable /dev/fd use to avoid the problem.
- * https://github.com/ksh93/ksh/issues/67
- */
-#undef SHOPT_DEVFD
-#define SHOPT_DEVFD	0
-
 #include	<sfio.h>
 #include	<error.h>
 #include	"FEATURE/externs"

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -20,7 +20,7 @@
 
 #define SH_RELEASE_FORK	"93u+m"		/* only change if you develop a new ksh93 fork */
 #define SH_RELEASE_SVER	"1.0.0-alpha"	/* semantic version number: https://semver.org */
-#define SH_RELEASE_DATE	"2021-03-11"	/* must be in this format for $((.sh.version)) */
+#define SH_RELEASE_DATE	"2021-03-13"	/* must be in this format for $((.sh.version)) */
 #define SH_RELEASE_CPYR	"(c) 2020-2021 Contributors to ksh " SH_RELEASE_FORK
 
 /* Scripts sometimes field-split ${.sh.version}, so don't change amount of whitespace. */

--- a/src/cmd/ksh93/sh/args.c
+++ b/src/cmd/ksh93/sh/args.c
@@ -758,7 +758,7 @@ struct argnod *sh_argprocsub(Shell_t *shp,struct argnod *argp)
 	job.jobcontrol = savejobcontrol;
 	sh_setstate(savestates);
 #if SHOPT_DEVFD
-	close(pv[1-fd]);
+	sh_close(pv[1-fd]);
 	sh_iosave(shp,-pv[fd], shp->topfd, (char*)0);
 #else
 	/* remember the FIFO for cleanup in case the command never opens it (see fifo_cleanup(), xec.c) */

--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -1542,6 +1542,8 @@ int sh_exec(register const Shnode_t *t, int flags)
 						sh_popcontext(shp,buffp);
 						sh_iorestore(shp,indx,jmpval);
 					}
+					if(shp->topfd>topfd)
+						sh_iorestore(shp,topfd,jmpval);
 					if(nq)
 						unset_instance(nq,&node,&nr,mode);
 					sh_funstaks(slp->slchild,-1);
@@ -1550,6 +1552,8 @@ int sh_exec(register const Shnode_t *t, int flags)
 						siglongjmp(*shp->jmplist,jmpval);
 					goto setexit;
 				}
+				else if(command && shp->topfd>topfd)
+					sh_iorestore(shp,topfd,0);
 			}
 			else if(!io)
 			{

--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -1628,6 +1628,10 @@ int sh_exec(register const Shnode_t *t, int flags)
 #   endif /* _lib_fork */
 				if(parent<0)
 				{
+					/* prevent a file descriptor leak from 'command not found */
+					if(shp->topfd > topfd)
+						sh_iorestore(shp,topfd,0);
+
 					if(shp->comsub==1 && usepipe && unpipe)
 						sh_iounpipe(shp);
 					break;

--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -1552,7 +1552,7 @@ int sh_exec(register const Shnode_t *t, int flags)
 						siglongjmp(*shp->jmplist,jmpval);
 					goto setexit;
 				}
-				else if(command && shp->topfd>topfd)
+				else if(command && np && shp->topfd>topfd)
 					sh_iorestore(shp,topfd,0);
 			}
 			else if(!io)

--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -1014,7 +1014,7 @@ int sh_exec(register const Shnode_t *t, int flags)
 			char		*trap;
 			Namval_t	*np, *nq, *last_table;
 			struct ionod	*io;
-			int		command=0, flgs=NV_ASSIGN;
+			int		command=0, flgs=NV_ASSIGN, jmpval=0;
 			shp->bltindata.invariant = type>>(COMBITS+2);
 			type &= (COMMSK|COMSCAN);
 			sh_stats(STAT_SCMDS);
@@ -1258,7 +1258,7 @@ int sh_exec(register const Shnode_t *t, int flags)
 					volatile int scope=0, share=0;
 					volatile void *save_ptr;
 					volatile void *save_data;
-					int jmpval, save_prompt;
+					int save_prompt;
 					int was_nofork = execflg?sh_isstate(SH_NOFORK):0;
 					struct checkpt *buffp = (struct checkpt*)stkalloc(shp->stk,sizeof(struct checkpt));
 #if SHOPT_VSH
@@ -1440,10 +1440,6 @@ int sh_exec(register const Shnode_t *t, int flags)
 						sh_unscope(shp);
 					bp->ptr = (void*)save_ptr;
 					bp->data = (void*)save_data;
-					/* don't restore for 'exec' or 'redirect' in subshell */
-					if((shp->topfd>topfd) && !(shp->subshell && (np==SYSEXEC || np==SYSREDIR)))
-						sh_iorestore(shp,topfd,jmpval);
-			
 					shp->redir0 = 0;
 					if(jmpval)
 						siglongjmp(*shp->jmplist,jmpval);
@@ -1456,7 +1452,6 @@ int sh_exec(register const Shnode_t *t, int flags)
 				if(!command && np && nv_isattr(np,NV_FUNCTION))
 				{
 					volatile int indx;
-					int jmpval=0;
 					struct checkpt *buffp = (struct checkpt*)stkalloc(shp->stk,sizeof(struct checkpt));
 #if SHOPT_NAMESPACE
 					Namval_t node, *namespace=0;
@@ -1542,8 +1537,6 @@ int sh_exec(register const Shnode_t *t, int flags)
 						sh_popcontext(shp,buffp);
 						sh_iorestore(shp,indx,jmpval);
 					}
-					if(shp->topfd>topfd)
-						sh_iorestore(shp,topfd,jmpval);
 					if(nq)
 						unset_instance(nq,&node,&nr,mode);
 					sh_funstaks(slp->slchild,-1);
@@ -1552,8 +1545,6 @@ int sh_exec(register const Shnode_t *t, int flags)
 						siglongjmp(*shp->jmplist,jmpval);
 					goto setexit;
 				}
-				else if(command && np && shp->topfd>topfd)
-					sh_iorestore(shp,topfd,0);
 			}
 			else if(!io)
 			{
@@ -1561,6 +1552,8 @@ int sh_exec(register const Shnode_t *t, int flags)
 #if !SHOPT_DEVFD
 				fifo_cleanup();
 #endif
+				if(shp->topfd > topfd && !(shp->subshell && (np==SYSEXEC || np==SYSREDIR)))
+					sh_iorestore(shp,topfd,jmpval);
 				exitset();
 				break;
 			}

--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -1628,7 +1628,7 @@ int sh_exec(register const Shnode_t *t, int flags)
 #   endif /* _lib_fork */
 				if(parent<0)
 				{
-					/* prevent a file descriptor leak from 'command not found */
+					/* prevent a file descriptor leak from a 'not found' error */
 					if(shp->topfd > topfd)
 						sh_iorestore(shp,topfd,0);
 

--- a/src/cmd/ksh93/tests/io.sh
+++ b/src/cmd/ksh93/tests/io.sh
@@ -764,7 +764,7 @@ got=$(procsub_delay <(echo hi) <(echo there) <(echo world))
 [[ $got == "$exp" ]] || err_exit "process substitutions passed to function failed" \
 	"(expected $(printf %q "$exp"), got $(printf %q "$got"))"
 
-got="$(command cat <($(whence -p echo foo)) 2>&1)" || err_exit "process substitution doesn't work with 'command'" \
+got=$(command -x cat <(command -x echo foo) 2>&1) || err_exit "process substitution doesn't work with 'command'" \
 	"(got $(printf %q "$got"))"
 
 # ======

--- a/src/cmd/ksh93/tests/io.sh
+++ b/src/cmd/ksh93/tests/io.sh
@@ -764,7 +764,7 @@ got=$(procsub_delay <(echo hi) <(echo there) <(echo world))
 [[ $got == "$exp" ]] || err_exit "process substitutions passed to function failed" \
 	"(expected $(printf %q "$exp"), got $(printf %q "$got"))"
 
-got="$(command cat <($(whence -p echo foo)) 2>&1)" || err_exit "process substitution don't work with 'command'" \
+got="$(command cat <($(whence -p echo foo)) 2>&1)" || err_exit "process substitution doesn't work with 'command'" \
 	"(got $(printf %q "$got"))"
 
 # ======

--- a/src/cmd/ksh93/tests/io.sh
+++ b/src/cmd/ksh93/tests/io.sh
@@ -641,6 +641,18 @@ err=$(
 ) || err_exit 'Process substitution leaks file descriptors when used as argument to function' \
 	"(got $(printf %q "$err"))"
 
+# File descriptor leak after 'command not found' with process substitution as argument
+err=$(
+	ulimit -n 25 || exit 0
+	set +x
+	PATH=/dev/null
+	for ((i=1; i<10; i++))
+	do	notfound <(:) >(:) 2> /dev/null
+	done
+	return 0
+) || err_exit "Process substitution leaks file descriptors when used as argument to 'command' alongside a function" \
+	"(got $(printf %q "$err"))"
+
 # ======
 # A redirection with a null command could crash under certain circumstances (rhbz#1200534)
 "$SHELL" -i >/dev/null 2>&1 -c '

--- a/src/cmd/ksh93/tests/io.sh
+++ b/src/cmd/ksh93/tests/io.sh
@@ -780,6 +780,5 @@ got=$(procsub_delay <(echo hi) <(echo there) <(echo world))
 [[ $got == "$exp" ]] || err_exit "process substitutions passed to function failed" \
 	"(expected $(printf %q "$exp"), got $(printf %q "$got"))"
 
-
 # ======
 exit $((Errors<125?Errors:125))

--- a/src/cmd/ksh93/tests/io.sh
+++ b/src/cmd/ksh93/tests/io.sh
@@ -650,7 +650,7 @@ err=$(
 	do	notfound <(:) >(:) 2> /dev/null
 	done
 	return 0
-) || err_exit "Process substitution leaks file descriptors when used as argument to 'command' alongside a function" \
+) || err_exit "Process substitution leaks file descriptors when used as argument to nonexistent command" \
 	"(got $(printf %q "$err"))"
 
 # ======

--- a/src/cmd/ksh93/tests/io.sh
+++ b/src/cmd/ksh93/tests/io.sh
@@ -764,5 +764,8 @@ got=$(procsub_delay <(echo hi) <(echo there) <(echo world))
 [[ $got == "$exp" ]] || err_exit "process substitutions passed to function failed" \
 	"(expected $(printf %q "$exp"), got $(printf %q "$got"))"
 
+got="$(command cat <($(whence -p echo foo)) 2>&1)" || err_exit "process substitution don't work with 'command'" \
+	"(got $(printf %q "$got"))"
+
 # ======
 exit $((Errors<125?Errors:125))


### PR DESCRIPTION
This pull request fixes a long-standing bug that caused a file descriptor leak when passing a process substitution to a function. The leak only occured when ksh was compiled with `SHOPT_DEVFD`; the FIFO method was unaffected.

src/cmd/ksh93/sh/xec.c:
\- When a process substitution is passed to a builtin, the remaining file descriptor is closed with `sh_iorestore`:
https://github.com/ksh93/ksh/blob/d4adc8fcf9e0334646a15f1d82b30b6c06a98973/src/cmd/ksh93/sh/xec.c#L1422-L1424

This is only done for builtins, as this instance of `sh_iorestore` is in the `TCOM` section of `sh_exec` that checks for builtins:
https://github.com/ksh93/ksh/blob/d2c1700f63597e1e1f2399a470446452b1fb12c4/src/cmd/ksh93/sh/xec.c#L1255-L1257
Placing an equivalent `sh_iorestore` inside of the if statement that checks for functions fixes the file descriptor leak:
https://github.com/ksh93/ksh/blob/d2c1700f63597e1e1f2399a470446452b1fb12c4/src/cmd/ksh93/sh/xec.c#L1455-L1457

\- The change above isn't enough, as a second file descriptor leak could still occur if ~`command` was given a function as an argument, then~ _edit:_ a command not found error occurred (see https://github.com/ksh93/ksh/pull/218#issuecomment-797871156). Reproducer:
```sh
$ cat ./command-leak.sh
fdUser() {
	cat "$1"
}

for ((i=1; i<10; i++))
do	command fdUser <(echo '========') 2> /dev/null
	if	[ -d /proc ]
	then	ls /proc/$$/fd
	else	lsof -p $$ | wc -l
	fi
done

$ arch/*/bin/ksh ./command-leak.sh
0  1  10  2  3
0  1  10  2  3	4
0  1  10  2  3	4  5
0  1  10  2  3	4  5  6
0  1  10  2  3	4  5  6  7
0  1  10  2  3	4  5  6  7  8
0  1  10  2  3	4  5  6  7  8  9
0  1  10  11  2  3  4  5  6  7	8  9
0  1  10  11  12  2  3	4  5  6  7  8  9
```
Another `sh_iorestore` was added to handle a failure from `sh_ntfork`, fixing this leak.

src/cmd/ksh93/include/defs.h:
\- Since the file descriptor leaks are now fixed, remove the workaround that forced ksh to use the FIFO method.

Fixes: #67