### PR TITLE
Typeset: Allow last numeric type given to be used

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,12 @@ For full details, see the git log at: https://github.com/ksh93/ksh
 
 Any uppercase BUG_* names are modernish shell bug IDs.
 
+2021-03-14:
+
+- Tighten up potential invalid typeset attribute combos when more than
+  one numeric type has been requested. In particular, -F and -i are no
+  longer masked over by previously given float types.
+
 2021-03-13:
 
 - Fixed a file descriptor leak that occurred when ksh used /dev/fd for

--- a/src/cmd/ksh93/bltins/typeset.c
+++ b/src/cmd/ksh93/bltins/typeset.c
@@ -257,6 +257,11 @@ int    b_typeset(int argc,register char *argv[],Shbltin_t *context)
 				else if (tdata.argnum==0)
 					tdata.argnum = NV_FLTSIZEZERO;
 				isfloat = 1;
+				if(shortint)
+				{
+					shortint = 0;
+					flag &= ~NV_INT16P;
+				}
 				if(n=='E')
 				{
 					flag &= ~NV_HEXFLOAT;
@@ -360,11 +365,14 @@ int    b_typeset(int argc,register char *argv[],Shbltin_t *context)
 				break;
 #endif /*SHOPT_TYPEDEF*/
 			case 's':
-				shortint=1;
-				if(flag&NV_INTEGER)
+				if(!isfloat)
 				{
-					flag &= ~NV_LONG;
-					flag |= NV_INT16P;
+					shortint=1;
+					if(flag&NV_INTEGER)
+					{
+						flag &= ~NV_LONG;
+						flag |= NV_INT16P;
+					}
 				}
 				break;
 			case 't':

--- a/src/cmd/ksh93/bltins/typeset.c
+++ b/src/cmd/ksh93/bltins/typeset.c
@@ -268,8 +268,9 @@ int    b_typeset(int argc,register char *argv[],Shbltin_t *context)
 					flag |= NV_HEXFLOAT;
 				}
 				else
-					/* n=='F' Remove possible collision with NV_UNSIGN/NV_HEXFLOAT */
-					flag &= ~NV_HEXFLOAT;
+					/* n=='F' Remove possible collision with NV_UNSIGN/NV_HEXFLOAT
+					   and allow it to not be covered up by -E */
+					flag &= ~(NV_HEXFLOAT|NV_EXPNOTE);
 				break;
 			case 'b':
 				flag |= NV_BINARY;
@@ -319,6 +320,11 @@ int    b_typeset(int argc,register char *argv[],Shbltin_t *context)
 			case 'i':
 				if(!opt_info.arg || (tdata.argnum = opt_info.num) <2 || tdata.argnum >64)
 					tdata.argnum = 10;
+				if(isfloat)
+				{
+					isfloat = 0;
+					flag &= ~(NV_HEXFLOAT|NV_EXPNOTE);
+				}
 				if(shortint)
 				{
 					flag &= ~NV_LONG;

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -20,7 +20,7 @@
 
 #define SH_RELEASE_FORK	"93u+m"		/* only change if you develop a new ksh93 fork */
 #define SH_RELEASE_SVER	"1.0.0-alpha"	/* semantic version number: https://semver.org */
-#define SH_RELEASE_DATE	"2021-03-13"	/* must be in this format for $((.sh.version)) */
+#define SH_RELEASE_DATE	"2021-03-14"	/* must be in this format for $((.sh.version)) */
 #define SH_RELEASE_CPYR	"(c) 2020-2021 Contributors to ksh " SH_RELEASE_FORK
 
 /* Scripts sometimes field-split ${.sh.version}, so don't change amount of whitespace. */

--- a/src/cmd/ksh93/tests/attributes.sh
+++ b/src/cmd/ksh93/tests/attributes.sh
@@ -607,7 +607,9 @@ typeset -A expect=(
 	[Ei]='typeset -i a=2'
 	[Xi]='typeset -i a=2'
 	[iF]='typeset -F a=2.0000000000'
+	[iFs]='typeset -F a=2.0000000000'
 	[iE]='typeset -E a=2'
+	[iEs]='typeset -E a=2'
 	[iX12]='typeset -X 12 a=0x1.000000000000p+1'
 )
 for flag in "${!expect[@]}"
@@ -624,6 +626,8 @@ do	unset a
 	fi
 done
 unset expect
+
+[[ $(typeset -iX12 -s a=2; typeset -p a) == 'typeset -X 12 a=0x1.000000000000p+1' ]] || err_exit "typeset -iX12 -s failed to become typeset -X 12 a=0x1.000000000000p+1."
 
 # ======
 # Bug introduced in 0e4c4d61: could not alter the size of an existing justified string attribute

--- a/src/cmd/ksh93/tests/attributes.sh
+++ b/src/cmd/ksh93/tests/attributes.sh
@@ -589,6 +589,7 @@ got=$(< $tmpfile)
 # ======
 # Combining -u with -F or -E caused an incorrect variable type
 # https://github.com/ksh93/ksh/pull/163
+# Allow the last numeric type to win out
 typeset -A expect=(
 	[uF]='typeset -F a=2.0000000000'
 	[Fu]='typeset -F a=2.0000000000'
@@ -596,6 +597,18 @@ typeset -A expect=(
 	[Ful]='typeset -l -F a=2.0000000000'
 	[Eu]='typeset -E a=2'
 	[Eul]='typeset -l -E a=2'
+	[EF]='typeset -F a=2.0000000000'
+	[XF]='typeset -F a=2.0000000000'
+	[FE]='typeset -E a=2'
+	[XE]='typeset -E a=2'
+	[FX12]='typeset -X 12 a=0x1.000000000000p+1'
+	[EX12]='typeset -X 12 a=0x1.000000000000p+1'
+	[Fi]='typeset -i a=2'
+	[Ei]='typeset -i a=2'
+	[Xi]='typeset -i a=2'
+	[iF]='typeset -F a=2.0000000000'
+	[iE]='typeset -E a=2'
+	[iX12]='typeset -X 12 a=0x1.000000000000p+1'
 )
 for flag in "${!expect[@]}"
 do	unset a


### PR DESCRIPTION
For most numeric types the last provided one wins out. This commit
closes the gap for -F and -i numerics to not be covered up by
other proceeding float types. Note: -u for requesting an unsigned
float or integer was considered and decided to be left along as it
stands so as to not allow the variable to become an uppercased
string if the requested options ended with a -u. As it stands for
a case when multiple numeric types are requested, a -u option
maybe applied after the last numeric type is processed.

Examples:
-EF becomes -F
-Fi becomes -i
-Fu becomes -F
-uF becomes -F
-Fui becomes -i (because isfloat==1 thus unsigned is not applied)
-Fiu becomes -iu (isfloat is reset and allows unsigned to be set)

src/cmd/ksh93/bltins/typeset.c: b_typeset():
- Reset attribute bit flags for -E and -X when -F is requested by
  adding in NV_EXPNOTE to be removed.
- For -i option if a float proceeds it, reset isfloat and -E/-F
  attribute bit flags.

src/cmd/ksh93/tests/attributes.sh:
- Add some validation tests to confirm that when a -F follows either
  -E or -X, -F is used.
- Add some validation tests to confirm that when a -F/E/X proceed a
  -i, the variable becomes an integer and not a float.