### PR TITLE
Fix a few regression test failures

### DIFF
--- a/src/cmd/ksh93/tests/_common
+++ b/src/cmd/ksh93/tests/_common
@@ -21,7 +21,7 @@ _message()
 }
 function err_exit
 {
-	print -r $'\t'"${Command}[$1]: ${@:2}" >&2
+	_message "$@"
 	let Errors+=1
 }
 alias err_exit='err_exit $LINENO'  # inaccurate err_exit name kept for historical integrity :)

--- a/src/cmd/ksh93/tests/_common
+++ b/src/cmd/ksh93/tests/_common
@@ -19,7 +19,12 @@ _message()
 {
 	print -r $'\t'"${Command}[$1]: ${@:2}" >&2
 }
-alias err_exit='_message "$((Errors++,LINENO))"'   # inaccurate err_exit name kept for historical integrity :)
+function err_exit
+{
+	print -r $'\t'"${Command}[$1]: ${@:2}" >&2
+	let Errors+=1
+}
+alias err_exit='err_exit $LINENO'  # inaccurate err_exit name kept for historical integrity :)
 alias warning='_message "$LINENO" "warning:"'
 
 Command=${0##*/}

--- a/src/cmd/ksh93/tests/builtins.sh
+++ b/src/cmd/ksh93/tests/builtins.sh
@@ -963,7 +963,7 @@ EOF
 # Builtins should handle unrecognized options correctly
 while IFS= read -r bltin <&3
 do	case $bltin in
-	echo | test | true | false | \[ | : | getconf | */getconf | uname | */uname | login | newgrp)
+	echo | test | true | false | \[ | : | getconf | */getconf | uname | */uname | Dt* | X* | login | newgrp )
 		continue ;;
 	/*/*)	expect="Usage: ${bltin##*/} "
 		actual=$({ PATH=${bltin%/*}; "${bltin##*/}" --this-option-does-not-exist; } 2>&1) ;;

--- a/src/cmd/ksh93/tests/glob.sh
+++ b/src/cmd/ksh93/tests/glob.sh
@@ -57,7 +57,7 @@ function test_glob
 		fi
 	fi
 	if	[[ $got != "$expected" ]]
-	then	'err_exit' $lineno "glob${ [[ -o globstar ]] && print star; } -- expected '$expected', got '$got'"
+	then	err_exit $lineno "glob${ [[ -o globstar ]] && print star; } -- expected '$expected', got '$got'"
 	fi
 }
 alias test_glob='test_glob $LINENO'
@@ -73,7 +73,7 @@ function test_case
 		esac
 	"
 	if	[[ $got != "$expected" ]]
-	then	'err_exit' $lineno "case $subject in $pattern) -- expected '$expected', got '$got'"
+	then	err_exit $lineno "case $subject in $pattern) -- expected '$expected', got '$got'"
 	fi
 }
 alias test_case='test_case $LINENO'
@@ -302,7 +302,7 @@ function test_sub
 	x='${subject'$2'}'
 	eval g=$x
 	if	[[ "$g" != "$3" ]]
-	then	'err_exit' $1 subject="'$subject' $x failed, expected '$3', got '$g'"
+	then	err_exit $1 subject="'$subject' $x failed, expected '$3', got '$g'"
 	fi
 }
 alias test_sub='test_sub $LINENO'

--- a/src/cmd/ksh93/tests/glob.sh
+++ b/src/cmd/ksh93/tests/glob.sh
@@ -57,7 +57,7 @@ function test_glob
 		fi
 	fi
 	if	[[ $got != "$expected" ]]
-	then	err_exit $lineno "glob${ [[ -o globstar ]] && print star; } -- expected '$expected', got '$got'"
+	then	'err_exit' $lineno "glob${ [[ -o globstar ]] && print star; } -- expected '$expected', got '$got'"
 	fi
 }
 alias test_glob='test_glob $LINENO'
@@ -73,7 +73,7 @@ function test_case
 		esac
 	"
 	if	[[ $got != "$expected" ]]
-	then	err_exit $lineno "case $subject in $pattern) -- expected '$expected', got '$got'"
+	then	'err_exit' $lineno "case $subject in $pattern) -- expected '$expected', got '$got'"
 	fi
 }
 alias test_case='test_case $LINENO'
@@ -302,7 +302,7 @@ function test_sub
 	x='${subject'$2'}'
 	eval g=$x
 	if	[[ "$g" != "$3" ]]
-	then	err_exit $1 subject="'$subject' $x failed, expected '$3', got '$g'"
+	then	'err_exit' $1 subject="'$subject' $x failed, expected '$3', got '$g'"
 	fi
 }
 alias test_sub='test_sub $LINENO'

--- a/src/cmd/ksh93/tests/pty.sh
+++ b/src/cmd/ksh93/tests/pty.sh
@@ -391,7 +391,7 @@ r history
 fi
 
 # err_exit #
-((SHOPT_VSH)) && tst $LINENO <<"!"
+((SHOPT_VSH)) && whence -q vi && tst $LINENO <<"!"
 L POSIX sh 137(C)
 
 # If the User Portability Utilities Option is supported and shell


### PR DESCRIPTION
src/cmd/ksh93/tests/builtins.sh:
\- The [`dtksh`](https://sourceforge.net/p/cdesktopenv/code/ci/master/tree/cde/programs/dtksh/) builtins don't have optget option parsing, so skip the unrecognized options test for those (this of course only has relevance when running `dtksh` against the regression tests).

src/cmd/ksh93/tests/glob.sh:
\- Commit aed5c6d7 ~turned `err_exit` into an alias~ removed the `err_exit` function, leaving it as an alias. Aliases can't be called with single quotes, so to produce proper error messages when a test fails remove the single quotes around the `err_exit` calls.

src/cmd/ksh93/tests/pty.sh:
\- If the `vi` editor couldn't be found on the `$PATH`, skip the regression test that requires it.