### PR TITLE
Fix the .sh.tilde mess, allow proper tilde expansion overrides

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,17 +5,17 @@ Any uppercase BUG_* names are modernish shell bug IDs.
 
 2021-03-16:
 
+- Tilde expansion can now be extended or modified by defining a .sh.tilde.get
+  or .sh.tilde.set discipline function. This replaces a 2004 undocumented
+  attempt to add this functionality via a .sh.tilde built-in, which never
+  worked and crashed the shell. See the manual for details on the new method.
+
 - Fixed a bug in interactive shells: if a variable used by the shell called
   a discipline function (such as PS1.get() or COLUMNS.set()), the value of $?
   was set to the exit status of the discipline function instead of the last
   command run.
 
 2021-03-15:
-
-- Tidle expansion can now be extended or modified by defining a discipline
-  function called '.sh.tilde.set'. This replaces a 2004 attempt to add this
-  functionality via a '.sh.tilde' function, which never worked and crashed
-  the shell. See the manual for details on the new method.
 
 - If the HOME variable is unset, the bare tilde ~ now expands to the current
   user's system-configured home directory instead of merely the username.

--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,11 @@ Any uppercase BUG_* names are modernish shell bug IDs.
 
 2021-03-15:
 
+- Tidle expansion can now be extended or modified by defining a discipline
+  function called '.sh.tilde.set'. This replaces a 2004 attempt to add this
+  functionality via a '.sh.tilde' function, which never worked and crashed
+  the shell. See the manual for details on the new method.
+
 - If the HOME variable is unset, the bare tilde ~ now expands to the current
   user's system-configured home directory instead of merely the username.
 

--- a/src/cmd/ksh93/TYPES
+++ b/src/cmd/ksh93/TYPES
@@ -17,7 +17,7 @@ To define a type, use
 where definition contains assignment commands, declaration commands,
 and function definitions.  A declaration command (for example typeset,
 readonly, and export), is a built-in that differs from other builtins in
-that tilde substitution is performed on arguments after an =, assignments
+that tilde expansion is performed on arguments after an =, assignments
 do not have to precede the command name, and field splitting and pathname
 expansion is not performed on the arguments.
 For example,

--- a/src/cmd/ksh93/bltins/typeset.c
+++ b/src/cmd/ksh93/bltins/typeset.c
@@ -1359,7 +1359,7 @@ static int print_namval(Sfio_t *file,register Namval_t *np,register int flag, st
 		return(0);
 	if(nv_isattr(np,NV_NOPRINT|NV_INTEGER)==NV_NOPRINT)
 	{
-		if(is_abuiltin(np) && strcmp(np->nvname,".sh.tilde"))
+		if(is_abuiltin(np))
 			sfputr(file,nv_name(np),'\n');
 		return(0);
 	}

--- a/src/cmd/ksh93/data/variables.c
+++ b/src/cmd/ksh93/data/variables.c
@@ -102,6 +102,7 @@ const struct shtable2 shtab_variables[] =
 	".sh.math",	0,				(char*)0,
 	".sh.pool",	0,				(char*)0,
 	".sh.pid",	NV_INTEGER|NV_NOFREE,		(char*)0,
+	".sh.tilde",	0,				(char*)0,
 	"SHLVL",	NV_INTEGER|NV_NOFREE|NV_EXPORT,	(char*)0,
 #if SHOPT_MULTIBYTE
 	"CSWIDTH",	0,				(char*)0,

--- a/src/cmd/ksh93/include/variables.h
+++ b/src/cmd/ksh93/include/variables.h
@@ -91,6 +91,7 @@
 #define SH_MATHNOD	(shgd->bltin_nodes+61)
 #define SH_JOBPOOL	(shgd->bltin_nodes+62)
 #define SH_PIDNOD	(shgd->bltin_nodes+63)
-#define SHLVL		(shgd->bltin_nodes+64)
+#define SH_TILDENOD	(shgd->bltin_nodes+64)
+#define SHLVL		(shgd->bltin_nodes+65)
 
 #endif /* SH_VALNOD */

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -20,7 +20,7 @@
 
 #define SH_RELEASE_FORK	"93u+m"		/* only change if you develop a new ksh93 fork */
 #define SH_RELEASE_SVER	"1.0.0-alpha"	/* semantic version number: https://semver.org */
-#define SH_RELEASE_DATE	"2021-03-13"	/* must be in this format for $((.sh.version)) */
+#define SH_RELEASE_DATE	"2021-03-15"	/* must be in this format for $((.sh.version)) */
 #define SH_RELEASE_CPYR	"(c) 2020-2021 Contributors to ksh " SH_RELEASE_FORK
 
 /* Scripts sometimes field-split ${.sh.version}, so don't change amount of whitespace. */

--- a/src/cmd/ksh93/sh.1
+++ b/src/cmd/ksh93/sh.1
@@ -847,14 +847,16 @@ also terminates a
 login name.
 .PP
 The tilde expansion mechanism may be extended or modified
-by defining a shell function called
+by defining a discipline function called either
 .B .sh.tilde.set
+or
+.B .sh.tilde.get
 (see
 .I Functions
 and
 .I Discipline Functions
 below).
-If a function by that name exists,
+If either function exists,
 then upon encountering a tilde word to expand,
 .if \nZ=0 \{\
 .B sh
@@ -865,19 +867,23 @@ then upon encountering a tilde word to expand,
 .if \nZ=2 \{\
 .B ksh93
 .\}
-calls that function with
+calls that function with the tilde word assigned to either
 .B .sh.value
-set to that tilde word.
+(for
+.BR .set )
+or
+.B .sh.tilde
+(for
+.BR .get ).
 Performing tilde expansion within the function will not recursively
 call the function, but default tilde expansion remains active,
 so literal tildes should still be quoted where required.
-If the function assigns a replacement string to
-.B .sh.value
-that is non-empty and does not start with
+Either function may assign a replacement string to
+.BR .sh.value .
+If that string is non-empty and does not start with
 .BR \(ap ,
-then that string,
-with any characters with a special meaning to the shell quoted,
-replaces the default tilde expansion.
+then it replaces the default tilde expansion,
+with any characters with a special meaning to the shell quoted.
 Otherwise, the function has no effect on the expansion.
 .SS Command Substitution.
 The standard output from a command list enclosed in

--- a/src/cmd/ksh93/sh.1
+++ b/src/cmd/ksh93/sh.1
@@ -782,11 +782,11 @@ Preset aliases can be unset or redefined.
 .B "r=\(fmhist \-s\(fm"
 .PD
 .RE
-.SS Tilde Substitution.
+.SS Tilde Expansion.
 After alias substitution is performed, each word
 is checked to see if it begins with an unquoted
 .BR \(ap .
-For tilde substitution,
+For tilde expansion,
 .I word\^
 also refers to the
 .I word\^
@@ -810,7 +810,9 @@ by itself, or in front of a
 .BR / ,
 is replaced by
 .SM
-.BR $HOME .
+.B $HOME
+or, if that variable is not set,
+by the current user's home directory as configured in the operating system.
 A
 .B \(ap
 followed by a
@@ -827,9 +829,10 @@ respectively.
 .PP
 In addition,
 when expanding a
-.IR "variable assignment" ,
-.I tilde
-substitution is attempted when
+variable assignment (see
+.I Variable Assignments
+above),
+tilde expansion is attempted when
 the value of the assignment
 begins with a
 .BR \(ap ,
@@ -842,6 +845,40 @@ The
 also terminates a
 .B \(ap
 login name.
+.PP
+The tilde expansion mechanism may be extended or modified
+by defining a shell function called
+.B .sh.tilde.set
+(see
+.I Functions
+and
+.I Discipline Functions
+below).
+If a function by that name exists,
+then upon encountering a tilde word to expand,
+.if \nZ=0 \{\
+.B sh
+.\}
+.if \nZ=1 \{\
+.B ksh
+.\}
+.if \nZ=2 \{\
+.B ksh93
+.\}
+calls that function with
+.B .sh.value
+set to that tilde word.
+Performing tilde expansion within the function will not recursively
+call the function, but default tilde expansion remains active,
+so literal tildes should still be quoted where required.
+If the function assigns a replacement string to
+.B .sh.value
+that is non-empty and does not start with
+.BR \(ap ,
+then that string,
+with any characters with a special meaning to the shell quoted,
+replaces the default tilde expansion.
+Otherwise, the function has no effect on the expansion.
 .SS Command Substitution.
 The standard output from a command list enclosed in
 parentheses preceded by a dollar sign (
@@ -5549,7 +5586,7 @@ Commands that are preceded by a \(dd symbol below are
 Any following words
 that are in the format of a variable assignment
 are expanded with the same rules as a variable assignment.
-This means that tilde substitution is performed after the
+This means that tilde expansion is performed after the
 .B =
 sign, array assignments of the form
 \f2varname\^\fP\f3=(\fP\f2assign_list\^\fP\f3)\fP

--- a/src/cmd/ksh93/sh.1
+++ b/src/cmd/ksh93/sh.1
@@ -794,10 +794,12 @@ portion of parameter expansion
 (see
 .I "Parameter Expansion\^"
 below).
-If it does, then the word up to a
+If a
+.I word\^
+is preceded by a tilde, then it is checked up to a
 .B /
-is checked to see if it matches a user name in the
-password database (See
+to see if it matches a user name in the
+password database (see
 .IR getpwname (3).)
 If a match is found, the
 .B \(ap
@@ -810,19 +812,22 @@ by itself, or in front of a
 .BR / ,
 is replaced by
 .SM
-.B $HOME
-or, if that variable is not set,
-by the current user's home directory as configured in the operating system.
+.BR $HOME ,
+unless the
+.B HOME
+variable is unset, in which case
+the current user's home directory as configured in the operating system
+is used.
 A
 .B \(ap
 followed by a
 .B +
 or
 .B \-
-is replaced by the value of
+is replaced by
 .B
 .SM $PWD
-and
+or
 .B
 .SM $OLDPWD
 respectively.
@@ -840,14 +845,13 @@ and when a
 .B \(ap
 appears after a
 .BR : .
-The
+A
 .B :
-also terminates a
-.B \(ap
-login name.
+also terminates a user name following a
+.BR \(ap .
 .PP
 The tilde expansion mechanism may be extended or modified
-by defining a discipline function called either
+by defining one of the discipline functions
 .B .sh.tilde.set
 or
 .B .sh.tilde.get
@@ -856,35 +860,26 @@ or
 and
 .I Discipline Functions
 below).
-If either function exists,
+If either exists,
 then upon encountering a tilde word to expand,
-.if \nZ=0 \{\
-.B sh
-.\}
-.if \nZ=1 \{\
-.B ksh
-.\}
-.if \nZ=2 \{\
-.B ksh93
-.\}
-calls that function with the tilde word assigned to either
+that function is called with the tilde word assigned to either
 .B .sh.value
-(for
-.BR .set )
-or
+(for the
+.B .sh.tilde.set
+function) or
 .B .sh.tilde
-(for
-.BR .get ).
-Performing tilde expansion within the function will not recursively
-call the function, but default tilde expansion remains active,
+(for the
+.B .sh.tilde.get
+function).
+Performing tilde expansion within a discipline function will not recursively
+call that function, but default tilde expansion remains active,
 so literal tildes should still be quoted where required.
 Either function may assign a replacement string to
 .BR .sh.value .
-If that string is non-empty and does not start with
+If this value is non-empty and does not start with a
 .BR \(ap ,
-then it replaces the default tilde expansion,
-with any characters with a special meaning to the shell quoted.
-Otherwise, the function has no effect on the expansion.
+it replaces the default tilde expansion when the function terminates.
+Otherwise, the tilde expansion is left unchanged.
 .SS Command Substitution.
 The standard output from a command list enclosed in
 parentheses preceded by a dollar sign (

--- a/src/cmd/ksh93/sh/macro.c
+++ b/src/cmd/ksh93/sh/macro.c
@@ -2670,10 +2670,10 @@ static void tilde_expand2(Shell_t *shp, register int offset)
 		cp = sh_tilde(shp,&stakp[offset]);
 	if(cp)
 	{
-		if(cp[0]=='/' && !cp[1] && fcpeek(0)=='/')
-			cp[0]='\0';		/* for ~ == "/", avoid ~/foo == "//foo" */
 		stakseek(offset);
-		stakputs(cp);
+		/* For ~ == "/", avoid ~/foo == "//foo" */
+		if(!(cp[0]=='/' && !cp[1] && fcpeek(0)=='/'))
+			stakputs(cp);
 	}
 	else
 		stakseek(curoff);

--- a/src/cmd/ksh93/sh/macro.c
+++ b/src/cmd/ksh93/sh/macro.c
@@ -2634,6 +2634,7 @@ static void tilde_expand2(Shell_t *shp, register int offset)
 	if(!loopdetect && nv_search(".sh.tilde.set",shp->fun_tree,0))
 	{
 		Namval_t	*np;			/* node pointer for .sh.tilde variable */
+		int		savexit = shp->savexit;	/* save $? as tilde expansion can happen without running a command */
 		loopdetect++;
 		stakfreeze(1);				/* terminate current stack object with null byte and freeze */
 		stakputs(".sh.tilde=");
@@ -2648,6 +2649,7 @@ static void tilde_expand2(Shell_t *shp, register int offset)
 		}
 		stakset(stakp,curoff);			/* restore stack to state on function entry */
 		loopdetect--;
+		shp->savexit = savexit;
 	}
 	/*
 	 * Perform default tilde expansion unless overridden.

--- a/src/cmd/ksh93/tests/builtins.sh
+++ b/src/cmd/ksh93/tests/builtins.sh
@@ -689,9 +689,6 @@ v=$($SHELL 2> /dev/null +o rc -ic $'getopts a:bc: opt --man\nprint $?')
 read baz <<< 'foo\\\\bar'
 [[ $baz == 'foo\\bar' ]] || err_exit 'read of foo\\\\bar not getting foo\\bar'
 
-: ~root
-[[ $(builtin) == *.sh.tilde* ]] &&  err_exit 'builtin contains .sh.tilde'
-
 # ======
 # Check that I/O errors are detected <https://github.com/att/ast/issues/1093>
 actual=$(

--- a/src/cmd/ksh93/tests/pty.sh
+++ b/src/cmd/ksh93/tests/pty.sh
@@ -708,5 +708,18 @@ r ^:test-2: fc -lN1\r\n$
 r \tdo something\r\n$
 !
 
+# err_exit #
+tst $LINENO <<"!"
+L value of $? after tilde expansion
+
+d 15
+w HOME=/tmp
+w false ~\t
+u HOME=/tmp
+u false /tmp
+w echo "Exit status is: $?"
+u Exit status is: 1
+!
+
 # ======
 exit $((Errors<125?Errors:125))

--- a/src/cmd/ksh93/tests/pty.sh
+++ b/src/cmd/ksh93/tests/pty.sh
@@ -40,8 +40,6 @@ Darwin | FreeBSD | Linux )
 	exit 0 ;;
 esac
 
-integer lineno=1
-
 # On some systems, the stty command does not appear to work correctly on a pty pseudoterminal.
 # To avoid false regressions, we have to set 'erase' and 'kill' on the real terminal.
 if	test -t 0 2>/dev/null </dev/tty && stty_restore=$(stty -g </dev/tty)
@@ -81,7 +79,7 @@ function tst
 	do	if	[[ $text == *debug* ]]
 		then	print -u2 -r -- "$text"
 		else	offset=${text/*: line +([[:digit:]]):*/\1}
-			err_exit "${text/: line $offset:/: line $(( lineno + offset)):}"
+			err\_exit "$lineno" "${text/: line $offset:/: line $(( lineno + offset)):}"
 		fi
 	done
 }
@@ -92,7 +90,7 @@ unset EDITOR
 export VISUAL=vi PS1=':test-!: ' PS2='> ' PS4=': ' ENV=/./dev/null EXINIT= HISTFILE= TERM=dumb
 
 if	! pty $bintrue < /dev/null
-then	err_exit pty command hangs on $bintrue -- tests skipped
+then	warning "pty command hangs on $bintrue -- tests skipped"
 	exit 0
 fi
 # err_exit #
@@ -709,16 +707,22 @@ r \tdo something\r\n$
 !
 
 # err_exit #
-tst $LINENO <<"!"
-L value of $? after tilde expansion
+((SHOPT_VSH || SHOPT_ESH)) && tst $LINENO <<"!"
+L value of $? after tilde expansion in tab completion
 
-d 15
+# Make sure that a .sh.tilde.set discipline function
+# cannot influence the exit status.
+
+w [[ -o ?vi ]] || set -o emacs
+w .sh.tilde.set() { true; }
 w HOME=/tmp
 w false ~\t
-u HOME=/tmp
 u false /tmp
 w echo "Exit status is: $?"
 u Exit status is: 1
+w (exit 42)
+w echo $? ~\t
+u 42 /tmp
 !
 
 # ======

--- a/src/cmd/ksh93/tests/variables.sh
+++ b/src/cmd/ksh93/tests/variables.sh
@@ -937,6 +937,7 @@ set -- \
 	".sh.math" \
 	".sh.pool" \
 	".sh.pid" \
+	".sh.tilde" \
 	"SHLVL" \
 	"CSWIDTH"
 


### PR DESCRIPTION
Here's a little something to play with. :)  Looking forward to seeing people break it.

This now allows properly overriding specific tilde expressions using a `.sh.tilde` function (or even a custom built-in, though I haven't tried that yet). The function is called with one argument, which is the tilde string: either `~` or `~`*word*. There is never a slash in it.

If the function either does not output anything or returns with a non-zero exit status, the result is not used and default tilde expansion is used instead. Otherwise, the tilde expression is replaced by the function's output, with all final newline characters stripped as in a command substitution.

In the `.sh.tilde` function itself, tilde expansion still works, but reverts to default. This avoids a crash due to infinite recursion. Literal tilde strings must be quoted as usual.

Example:
```sh
.sh.tilde()
{
	case $1 in
	'~tmp')	echo "${XDG_RUNTIME_DIR:-${TMPDIR:-/tmp}}" ;;
	'~doc')	echo ~/Documents ;;
	'~ksh')	echo /usr/local/src/ksh93/ksh ;;
	esac
}
```
After which, e.g., `cat ~tmp/foo.txt` will output the file `foo.txt` in the temporary files directory configured in your environment.

It is of course possible to do more creative things with this as well. I'm looking forward to seeing what ideas people come up with.

Documentation and regression tests aren't done yet.

Resolves: https://github.com/ksh93/ksh/issues/217