### PR TITLE
Fix the value of $? when PS1.get exists

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,9 +5,10 @@ Any uppercase BUG_* names are modernish shell bug IDs.
 
 2021-03-16:
 
-- Fixed a bug in interactive shells: if the $PS1 prompt used a discipline
-  function (such as PS1.get()), the value of $? was set to the exit status
-  of PS1.get() instead of the last command run.
+- Fixed a bug in interactive shells: if a variable used by the shell called
+  a discipline function (such as PS1.get() or COLUMNS.set()), the value of $?
+  was set to the exit status of the discipline function instead of the last
+  command run.
 
 2021-03-15:
 

--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,12 @@ For full details, see the git log at: https://github.com/ksh93/ksh
 
 Any uppercase BUG_* names are modernish shell bug IDs.
 
+2021-03-16:
+
+- Fixed a bug in interactive shells: if the $PS1 prompt used a discipline
+  function (such as PS1.get()), the value of $? was set to the exit status
+  of PS1.get() instead of the last command run.
+
 2021-03-15:
 
 - If the HOME variable is unset, the bare tilde ~ now expands to the current

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -20,7 +20,7 @@
 
 #define SH_RELEASE_FORK	"93u+m"		/* only change if you develop a new ksh93 fork */
 #define SH_RELEASE_SVER	"1.0.0-alpha"	/* semantic version number: https://semver.org */
-#define SH_RELEASE_DATE	"2021-03-15"	/* must be in this format for $((.sh.version)) */
+#define SH_RELEASE_DATE	"2021-03-16"	/* must be in this format for $((.sh.version)) */
 #define SH_RELEASE_CPYR	"(c) 2020-2021 Contributors to ksh " SH_RELEASE_FORK
 
 /* Scripts sometimes field-split ${.sh.version}, so don't change amount of whitespace. */

--- a/src/cmd/ksh93/sh/io.c
+++ b/src/cmd/ksh93/sh/io.c
@@ -2094,7 +2094,6 @@ static int	io_prompt(Shell_t *shp,Sfio_t *iop,register int flag)
 	sfflags = sfset(sfstderr,SF_SHARE|SF_PUBLIC|SF_READ,0);
 	if(!(shp->prompt=(char*)sfreserve(sfstderr,0,0)))
 		shp->prompt = "";
-	int savexit = shp->savexit;
 	switch(flag)
 	{
 		case 1:
@@ -2143,7 +2142,6 @@ static int	io_prompt(Shell_t *shp,Sfio_t *iop,register int flag)
 	if(cp)
 		sfputr(sfstderr,cp,-1);
 done:
-	shp->savexit = savexit;
 	if(*shp->prompt && (endprompt=(char*)sfreserve(sfstderr,0,0)))
 		*endprompt = 0;
 	if(was_ttywait_on)

--- a/src/cmd/ksh93/sh/io.c
+++ b/src/cmd/ksh93/sh/io.c
@@ -2094,6 +2094,7 @@ static int	io_prompt(Shell_t *shp,Sfio_t *iop,register int flag)
 	sfflags = sfset(sfstderr,SF_SHARE|SF_PUBLIC|SF_READ,0);
 	if(!(shp->prompt=(char*)sfreserve(sfstderr,0,0)))
 		shp->prompt = "";
+	int savexit = shp->savexit;
 	switch(flag)
 	{
 		case 1:
@@ -2142,6 +2143,7 @@ static int	io_prompt(Shell_t *shp,Sfio_t *iop,register int flag)
 	if(cp)
 		sfputr(sfstderr,cp,-1);
 done:
+	shp->savexit = savexit;
 	if(*shp->prompt && (endprompt=(char*)sfreserve(sfstderr,0,0)))
 		*endprompt = 0;
 	if(was_ttywait_on)

--- a/src/cmd/ksh93/sh/nvdisc.c
+++ b/src/cmd/ksh93/sh/nvdisc.c
@@ -289,7 +289,7 @@ static void	assign(Namval_t *np,const char* val,int flags,Namfun_t *handle)
 		nq =  vp->disc[type=UNASSIGN];
 	if(nq && !isblocked(bp,type))
 	{
-		int bflag=0;
+		int bflag=0, savexit=sh.savexit;
 		block(bp,type);
 		if (type==APPEND && (bflag= !isblocked(bp,LOOKUPS)))
 			block(bp,LOOKUPS);
@@ -299,6 +299,7 @@ static void	assign(Namval_t *np,const char* val,int flags,Namfun_t *handle)
 			unblock(bp,LOOKUPS);
 		if(!vp->disc[type])
 			chktfree(np,vp);
+		sh.savexit = savexit;	/* avoid influencing $? */
 	}
 	if(nv_isarray(np))
 		np->nvalue.up = up;
@@ -381,6 +382,7 @@ static char*	lookup(Namval_t *np, int type, Sfdouble_t *dp,Namfun_t *handle)
 	union Value		*up = np->nvalue.up;
 	if(nq && !isblocked(bp,type))
 	{
+		int		savexit = sh.savexit;
 		node = *SH_VALNOD;
 		if(!nv_isnull(SH_VALNOD))
 		{
@@ -410,6 +412,7 @@ static char*	lookup(Namval_t *np, int type, Sfdouble_t *dp,Namfun_t *handle)
 			/* restore everything but the nvlink field */
 			memcpy(&SH_VALNOD->nvname,  &node.nvname, sizeof(node)-sizeof(node.nvlink));
 		}
+		sh.savexit = savexit;	/* avoid influencing $? */
 	}
 	if(nv_isarray(np))
 		np->nvalue.up = up;

--- a/src/cmd/ksh93/tests/pty.sh
+++ b/src/cmd/ksh93/tests/pty.sh
@@ -712,7 +712,6 @@ r \tdo something\r\n$
 tst $LINENO <<"!"
 L value of $? after the shell uses a variable with a discipline function
 
-d 15
 w PS1.get() { true; }; PS2.get() { true; }; false
 u PS1.get\(\) \{ true; \}; PS2.get\(\) \{ true; \}; false
 w echo "Exit status is: $?"

--- a/src/cmd/ksh93/tests/pty.sh
+++ b/src/cmd/ksh93/tests/pty.sh
@@ -713,14 +713,24 @@ tst $LINENO <<"!"
 L value of $? after the shell uses a variable with a discipline function
 
 d 15
-w PS1.get() { true; }; false
-u PS1.get\(\) \{ true; \}; false
+w PS1.get() { true; }; PS2.get() { true; }; false
+u PS1.get\(\) \{ true; \}; PS2.get\(\) \{ true; \}; false
 w echo "Exit status is: $?"
 u Exit status is: 1
 w LINES.set() { return 13; }
 u LINES.set\(\) \{ return 13; \}
 w echo "Exit status is: $?"
 u Exit status is: 0
+
+# It's worth noting that the test below will always fail in ksh93u+ and ksh2020,
+# even when $PS2 lacks a discipline function (see https://github.com/ksh93/ksh/issues/117).
+# After that bug was fixed the test below could still fail if PS2.get() existed.
+w false
+w (
+w exit
+w )
+w echo "Exit status is: $?"
+u Exit status is: 1
 !
 
 # ======

--- a/src/cmd/ksh93/tests/pty.sh
+++ b/src/cmd/ksh93/tests/pty.sh
@@ -710,7 +710,7 @@ r \tdo something\r\n$
 
 # err_exit #
 tst $LINENO <<"!"
-L value of $? after PS1.get
+L value of $? after PS1.get()
 
 d 15
 w PS1.get() {; true; }; false

--- a/src/cmd/ksh93/tests/pty.sh
+++ b/src/cmd/ksh93/tests/pty.sh
@@ -708,5 +708,16 @@ r ^:test-2: fc -lN1\r\n$
 r \tdo something\r\n$
 !
 
+# err_exit #
+tst $LINENO <<"!"
+L value of $? after PS1.get
+
+d 15
+w PS1.get() {; true; }; false
+u PS1.get\(\) \{; true; \}; false
+w echo "Exit status is: $?"
+u Exit status is: 1
+!
+
 # ======
 exit $((Errors<125?Errors:125))

--- a/src/cmd/ksh93/tests/pty.sh
+++ b/src/cmd/ksh93/tests/pty.sh
@@ -719,8 +719,6 @@ w echo "Exit status is: $?"
 u Exit status is: 1
 w LINES.set() { return 13; }
 u LINES.set\(\) \{ return 13; \}
-w true
-u true
 w echo "Exit status is: $?"
 u Exit status is: 0
 !

--- a/src/cmd/ksh93/tests/pty.sh
+++ b/src/cmd/ksh93/tests/pty.sh
@@ -710,13 +710,19 @@ r \tdo something\r\n$
 
 # err_exit #
 tst $LINENO <<"!"
-L value of $? after PS1.get()
+L value of $? after the shell uses a variable with a discipline function
 
 d 15
-w PS1.get() {; true; }; false
-u PS1.get\(\) \{; true; \}; false
+w PS1.get() { true; }; false
+u PS1.get\(\) \{ true; \}; false
 w echo "Exit status is: $?"
 u Exit status is: 1
+w LINES.set() { return 13; }
+u LINES.set\(\) \{ return 13; \}
+w true
+u true
+w echo "Exit status is: $?"
+u Exit status is: 0
 !
 
 # ======

--- a/src/cmd/ksh93/tests/return.sh
+++ b/src/cmd/ksh93/tests/return.sh
@@ -237,5 +237,8 @@ foo && err_exit "'exit' within 'for' with redirection does not preserve exit sta
 foo() ( false; { exit; } 2>&1 )
 foo && err_exit "'exit' within { block; } with redirection does not preserve exit status"
 
+foo() { false; (exit); }
+foo && err_exit "'exit' within subshell does not preserve exit status"
+
 # ======
 exit $((Errors<125?Errors:125))


### PR DESCRIPTION
src/cmd/ksh93/sh/io.c: `io_prompt()`:
\- The exit status from the last command run (`$?`) was replaced with the exit status from `PS1.get()` in interactive shells. Reproducer:
```sh
$ PS1.get() {; true; }
$ false
$ echo $?
0
$ false; echo $? # Running 'echo $?' before the next prompt works around the bug
1
```
To fix this bug, the value of `$?` is saved before setting the prompt.

src/cmd/ksh93/tests/pty.sh:
\- Add a regression test for `$?` after displaying a prompt.