### PR TITLE
tests/pty.sh: Add a regression test for a ksh93r crash (re: 129614b9)

### DIFF
--- a/src/cmd/ksh93/tests/pty.sh
+++ b/src/cmd/ksh93/tests/pty.sh
@@ -733,5 +733,22 @@ w echo "Exit status is: $?"
 u Exit status is: 1
 !
 
+((SHOPT_ESH)) && ((SHOPT_VSH)) && tst $LINENO <<"!"
+L crash after switching from emacs to vi mode
+
+# In ksh93r using the vi 'r' command after switching from emacs mode could
+# trigger a memory fault: https://bugzilla.opensuse.org/show_bug.cgi?id=179917
+
+d 15
+w exec $SHELL -o emacs
+u emacs
+w set -o vi
+u set -o vi
+c \Erri
+w echo Success
+u echo
+r ^Success\r?\n$
+!
+
 # ======
 exit $((Errors<125?Errors:125))


### PR DESCRIPTION
In ksh93r a crash can occur after switching from emacs mode to vi mode (OpenSUSE bug report: https://bugzilla.opensuse.org/show_bug.cgi?id=179917):
```sh
$ ENV=/./dev/null ksh2006 -o emacs
$ echo ${.sh.version}
Version M 1993-12-28 r
$ set -o vi
$ <Esc>+<r>+<r>  # This triggers the memory fault
```
Commit 129614b9 added the OpenSUSE patch for this crash. This commit adds a regression test for it, although I'll note I couldn't get the crash to occur in ksh93u+ or ksh93v- at all (even without OpenSUSE's patch).