### PR TITLE
Overlapping buffers in hist_word

### DIFF
--- a/src/cmd/ksh93/edit/history.c
+++ b/src/cmd/ksh93/edit/history.c
@@ -1115,7 +1115,8 @@ char *hist_word(char *string,int size,int word)
 	}
 	*cp = 0;
 	if(s1 != string)
-		strcpy(string,s1);
+		/* We can't use strcpy() because the two buffers may overlap. */
+		memmove(string,s1,strlen(s1)+1);
 	return(string);
 }
 


### PR DESCRIPTION
While experimenting with #233, a memory segmentation fault occurred. A search of other emacs issues found a potential matching issue as described in https://github.com/att/ast/pull/791. Also, a duplicate PR of https://github.com/att/ast/pull/1489 was submitted. This commit back ports that fix.

src/cmd/ksh93/edit/history.c: hist_word():
- Switch from using strcpy to memmove as the two strings could overlap.