### PR TITLE
Fix compile when using tcc >0.9.27

### DIFF
--- a/src/cmd/INIT/iffe.sh
+++ b/src/cmd/INIT/iffe.sh
@@ -36,7 +36,7 @@ version=2021-03-21 # update in USAGE too #
 compile() # $cc ...
 {
 	# tcc can't combine -l* and -c
-	case "`$1 --version 2> /dev/null`" in
+	case "`$1 -version 2> /dev/null`" in
 	tcc*)	if echo "$@" | grep ' -c' | grep -q ' -l'
 		then	for arg
 			do	shift

--- a/src/cmd/INIT/iffe.sh
+++ b/src/cmd/INIT/iffe.sh
@@ -31,10 +31,24 @@ AIX)	unset LIBPATH ;;
 esac
 
 command=iffe
-version=2021-02-03 # update in USAGE too #
+version=2021-03-21 # update in USAGE too #
 
 compile() # $cc ...
 {
+	# tcc can't combine -l* and -c
+	case "`$1 --version 2> /dev/null`" in
+	tcc*)	if echo "$@" | grep ' -c' | grep -q ' -l'
+		then	for arg
+			do	shift
+				case $arg in
+				-l*) : ;;
+				*) set -- "$@" "$arg"
+				esac
+			done
+		fi
+		;;
+	esac
+
 	"$@" 2>$tmp.err
 	_compile_status=$?
 	if	test -s $tmp.err
@@ -753,7 +767,7 @@ set=
 case `(getopts '[-][123:xyz]' opt --xyz; echo 0$opt) 2>/dev/null` in
 0123)	USAGE=$'
 [-?
-@(#)$Id: iffe (ksh 93u+m) 2021-02-03 $
+@(#)$Id: iffe (ksh 93u+m) 2021-03-21 $
 ]
 [-author?Glenn Fowler <gsf@research.att.com>]
 [-author?Phong Vo <kpv@research.att.com>]

--- a/src/cmd/INIT/iffe.sh
+++ b/src/cmd/INIT/iffe.sh
@@ -35,20 +35,6 @@ version=2021-03-21 # update in USAGE too #
 
 compile() # $cc ...
 {
-	# tcc can't combine -l* and -c
-	case "`$1 -version 2> /dev/null`" in
-	tcc*)	if echo "$@" | grep ' -c' | grep -q ' -l'
-		then	for arg
-			do	shift
-				case $arg in
-				-l*) : ;;
-				*) set -- "$@" "$arg"
-				esac
-			done
-		fi
-		;;
-	esac
-
 	"$@" 2>$tmp.err
 	_compile_status=$?
 	if	test -s $tmp.err

--- a/src/cmd/INIT/iffe.sh
+++ b/src/cmd/INIT/iffe.sh
@@ -31,7 +31,7 @@ AIX)	unset LIBPATH ;;
 esac
 
 command=iffe
-version=2021-03-21 # update in USAGE too #
+version=2021-02-03 # update in USAGE too #
 
 compile() # $cc ...
 {
@@ -753,7 +753,7 @@ set=
 case `(getopts '[-][123:xyz]' opt --xyz; echo 0$opt) 2>/dev/null` in
 0123)	USAGE=$'
 [-?
-@(#)$Id: iffe (ksh 93u+m) 2021-03-21 $
+@(#)$Id: iffe (ksh 93u+m) 2021-02-03 $
 ]
 [-author?Glenn Fowler <gsf@research.att.com>]
 [-author?Phong Vo <kpv@research.att.com>]

--- a/src/cmd/builtin/Mamfile
+++ b/src/cmd/builtin/Mamfile
@@ -37,7 +37,7 @@ make install
 					meta FEATURE/pty features/%>FEATURE/% features/pty pty
 					make features/pty
 					done features/pty
-					exec - iffe ${IFFEFLAGS} -v -c "${CC} ${mam_cc_FLAGS} ${KSH_RELFLAGS} ${CCFLAGS} ${LDFLAGS} -lm" ref ${mam_cc_L+-L${INSTALLROOT}/lib} -I${PACKAGE_ast_INCLUDE} -I${INSTALLROOT}/include ${mam_libast} ${mam_libcmd} : run features/pty
+					exec - iffe ${IFFEFLAGS} -v -c "${CC} ${mam_cc_FLAGS} ${KSH_RELFLAGS} ${CCFLAGS} ${LDFLAGS}" ref ${mam_cc_L+-L${INSTALLROOT}/lib} -I${PACKAGE_ast_INCLUDE} -I${INSTALLROOT}/include ${mam_libast} ${mam_libcmd} : run features/pty
 				done FEATURE/pty generated
 				make ${PACKAGE_ast_INCLUDE}/ast_time.h implicit
 				done ${PACKAGE_ast_INCLUDE}/ast_time.h

--- a/src/cmd/builtin/features/pty
+++ b/src/cmd/builtin/features/pty
@@ -13,7 +13,7 @@ lib	openpty,_getpty,ptsname -lutil
 lib	grantpt,unlockpt,posix_openpt stdlib.h
 lib	cfmakeraw termios.h
 
-tst - output{
+tst - -lm output{
 	#include	<fcntl.h>
 	#if _lib_ptsname
 	#include	<stdlib.h>

--- a/src/lib/libast/comp/atexit.c
+++ b/src/lib/libast/comp/atexit.c
@@ -34,11 +34,7 @@ NoN(atexit)
 
 #else
 
-#if _lib_onexit || _lib_on_exit
-
-#if !_lib_onexit
-#define onexit		on_exit
-#endif
+#if _lib_onexit
 
 extern int		onexit(void(*)(void));
 

--- a/src/lib/libast/features/lib
+++ b/src/lib/libast/features/lib
@@ -28,7 +28,7 @@ lib	getopt,getsubopt,getopt_long,getopt_long_only
 lib	glob,index,iswblank,iswctype,killpg,link,localeconv,madvise
 lib	mbtowc,mbrtowc,memalign,memchr,memcpy,memdup,memmove,memset
 lib	mkdir,mkfifo,mktemp,mktime
-lib	mount,on_exit,onexit,opendir,pathconf
+lib	mount,onexit,opendir,pathconf
 lib	readlink,remove,rename,rewinddir,rindex,rmdir,setlocale
 lib	setpgid,setpgrp,setpgrp2,setreuid,setsid,setuid,sigaction
 lib	sigprocmask,sigsetmask,sigunblock,sigvec,socketpair

--- a/src/lib/libast/include/ast.h
+++ b/src/lib/libast/include/ast.h
@@ -79,6 +79,19 @@ struct _sfio_s;
 #endif
 
 /*
+ * tcc on FreeBSD: Avoid using nonexistent math
+ * builtins by pretending to be an ancient gcc.
+ */
+#if __TINYC__ && __GNUC__ >= 3 && __FreeBSD__
+#undef __GNUC__
+#undef __GNUC_MINOR__
+#undef __GNUC_PATCHLEVEL__
+#define __GNUC__ 2
+#define __GNUC_MINOR__ 95
+#define __GNUC_PATCHLEVEL__ 3
+#endif
+
+/*
  * exit() support -- this matches shell exit codes
  */
 

--- a/src/lib/libast/vmalloc/malloc.c
+++ b/src/lib/libast/vmalloc/malloc.c
@@ -1040,11 +1040,7 @@ extern Void_t*	F1(_ast_valloc, size_t,n) { return valloc(n); }
 
 #if !_UWIN
 
-#if !_malloc_hook
-
 #include	<malloc.h>
-
-#endif
 
 typedef struct mallinfo Mallinfo_t;
 typedef struct mstats Mstats_t;

--- a/src/lib/libast/vmalloc/vmexit.c
+++ b/src/lib/libast/vmalloc/vmexit.c
@@ -93,7 +93,7 @@ int	type;
 	return type;
 }
 
-#endif	/* _lib_onexit || _lib_on_exit */
+#endif	/* _lib_onexit */
 
 #endif /*!PACKAGE_ast*/
 

--- a/src/lib/libdll/Mamfile
+++ b/src/lib/libdll/Mamfile
@@ -154,7 +154,7 @@ make install
 							done features/dll
 							bind -ldl dontcare
 							bind -last
-							exec - iffe ${IFFEFLAGS} -v -c "${CC} ${mam_cc_FLAGS} ${KSH_RELFLAGS} ${CCFLAGS} ${LDFLAGS} -lm" ref ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -I${PACKAGE_ast_INCLUDE} -I${INSTALLROOT}/include ${mam_libdl} ${mam_libast} : run features/dll
+							exec - iffe ${IFFEFLAGS} -v -c "${CC} ${mam_cc_FLAGS} ${KSH_RELFLAGS} ${CCFLAGS} ${LDFLAGS}" ref ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -I${PACKAGE_ast_INCLUDE} -I${INSTALLROOT}/include ${mam_libdl} ${mam_libast} : run features/dll
 						done FEATURE/dll generated
 						exec - cmp 2>/dev/null -s FEATURE/dll dlldefs.h || { rm -f dlldefs.h; silent test -d . || mkdir .; cp FEATURE/dll dlldefs.h; }
 					done dlldefs.h generated

--- a/src/lib/libdll/features/dll
+++ b/src/lib/libdll/features/dll
@@ -74,7 +74,7 @@ tst	run{
 	esac
 	echo "#define _DLL_NEXT_PATH	\"$lib\""
 }end
-tst	- output{
+tst	- -lm output{
 	#include <math.h>
 	#if defined(__MVS__) && !defined(__SUSV3)
 	#define __SUSV3		1


### PR DESCRIPTION
This allows ksh to be compiled with versions of `tcc` that define `__dso_handle` in `libtcc1.a` (see `tcc` commit [dd60b20c](https://repo.or.cz/tinycc.git/commit/dd60b20c6e0d01df8e332b0234125abaa964d324)), although only on Linux. The two problems that remain are the following:

1) Older versions of `tcc` still fail to compile ksh, although now they fail after reaching the libdll feature test. I'm not sure if fixing that is feasible; even if I hack out the failing libdll feature test ksh fails to link with a `__dso_handle` error.
2) `tcc` fails to build ksh on FreeBSD. For some reason `tcc` imitates GCC on FreeBSD but not on Linux. As a result the FreeBSD `math.h` header tries to define macros that call GCC/Clang builtins. This results in undefined symbol errors since `tcc` doesn't have those builtins.

src/cmd/INIT/iffe.sh: compile():
- `tcc` forbids combining the -c compiler flag with -l* linker flags. Strip all -l* flags when -c was passed to the compiler. This is only done when `tcc` is the compiler to prevent build failures on some platforms (such as illumos).

src/lib/libast/comp/atexit.c,
src/lib/libast/features/lib,
src/lib/libast/vmalloc/vmexit.c:
- From what I've been able to gather the only OSes with support for `on_exit` are Linux and SunOS 4. However, `on_exit` takes two arguments, so the macro that defines it as taking one argument is incorrect. Since Solaris (SunOS 5) no longer has this call and the macro breaks on Linux, the clean fix is to remove it (`atexit` is used instead).

Progresses: https://github.com/ksh93/ksh/issues/232