### PR TITLE
Linux bugfixes for globcasedetect

### DIFF
--- a/src/cmd/ksh93/features/options
+++ b/src/cmd/ksh93/features/options
@@ -62,17 +62,8 @@ tst	note{ can we probe file system case insensitivity }end output{
 	static char *o = "SHOPT_GLOBCASEDET";
 	int main(int argc,char *argv[])
 	{
-		char *dir;
 		int r;
-		/* Prioritize /boot/EFI and /boot since those could
-		   be VFAT boot partitions. */
-		if(access("/boot/EFI", R_OK) == 0)
-			dir = "/boot/EFI";
-		else if(access("/boot", R_OK) == 0)
-			dir = "/boot";
-		else
-			dir = "/";
-		r = pathicase(dir);
+		r = pathicase("/");
 		r = (r > -1 || errno != ENOSYS);
 		printf("#ifndef %s\n#   define %s\t%d\n#endif\n", o, o, r);
 		return !r;

--- a/src/cmd/ksh93/features/options
+++ b/src/cmd/ksh93/features/options
@@ -62,8 +62,17 @@ tst	note{ can we probe file system case insensitivity }end output{
 	static char *o = "SHOPT_GLOBCASEDET";
 	int main(int argc,char *argv[])
 	{
+		char *dir;
 		int r;
-		r = pathicase("/");
+		/* Prioritize /boot/EFI and /boot since those could
+		   be VFAT boot partitions. */
+		if(access("/boot/EFI", R_OK) == 0)
+			dir = "/boot/EFI";
+		else if(access("/boot", R_OK) == 0)
+			dir = "/boot";
+		else
+			dir = "/";
+		r = pathicase(dir);
 		r = (r > -1 || errno != ENOSYS);
 		printf("#ifndef %s\n#   define %s\t%d\n#endif\n", o, o, r);
 		return !r;

--- a/src/lib/libast/features/lib
+++ b/src/lib/libast/features/lib
@@ -4,7 +4,7 @@ cmd	universe
 
 hdr	dirent,direntry,filio,fmtmsg,fnmatch,jioctl,libgen,limits
 hdr	locale,ndir,nl_types,process,spawn,syslog,utime,vfork
-hdr	linux/fs,sys/ioctl
+hdr	linux/fs,linux/msdos_fs,sys/ioctl
 hdr	wchar note{ <wchar.h> and isw*() really work }end execute{
 	#include <wchar.h>
 	int

--- a/src/lib/libast/path/pathicase.c
+++ b/src/lib/libast/path/pathicase.c
@@ -17,9 +17,21 @@
 #include <ast.h>
 #include <error.h>
 
-#if _hdr_linux_fs && _hdr_sys_ioctl
+#if _hdr_linux_fs
 #include <linux/fs.h>
+#endif
+#if _hdr_linux_msdos_fs
+#include <linux/msdos_fs.h>
+#endif
+#if _hdr_sys_ioctl
 #include <sys/ioctl.h>
+#endif
+
+#if _hdr_sys_ioctl && _hdr_linux_fs && defined(FS_IOC_GETFLAGS) && defined(FS_CASEFOLD_FL)
+#define _linux_casefold	1
+#endif
+#if _hdr_sys_ioctl && _hdr_linux_msdos_fs && defined(FAT_IOCTL_GET_ATTRIBUTES)
+#define _linux_fatfs	1
 #endif
 
 /*
@@ -40,14 +52,22 @@ pathicase(const char *path)
 	/* Cygwin */
 	long r = pathconf(path, _PC_CASE_INSENSITIVE);
 	return r < 0L ? -1 : r > 0L;
-#elif _hdr_linux_fs && _hdr_sys_ioctl && defined(FS_IOC_GETFLAGS) && defined(FS_CASEFOLD_FL)
-	/* Linux 5.2+ */
+#elif _linux_fatfs
 	int attr = 0, fd, r;
-	if ((fd = open(path, O_RDONLY|O_NONBLOCK)) < 0)
+	if((fd = open(path, O_RDONLY|O_NONBLOCK)) < 0)
 		return -1;
-	r = ioctl(fd, FS_IOC_GETFLAGS, &attr);
+	r = ioctl(fd, FAT_IOCTL_GET_ATTRIBUTES, &attr);
+#	if _linux_casefold
+	if(r < 0 && errno == ENOTTY)
+	{
+		/* Linux 5.2+ */
+		r = ioctl(fd, FS_IOC_GETFLAGS, &attr);
+		close(fd);
+		return r < 0 ? -1 : (attr & FS_CASEFOLD_FL) != 0;
+	}
+#	endif /* _linux_casefold */
 	close(fd);
-	return r < 0 ? -1 : attr & FS_CASEFOLD_FL != 0;
+	return r < 0 ? (errno != ENOTTY ? -1 : 0) : 1;
 #elif _WINIX || __APPLE__
 	/* Windows or Mac without pathconf probe: assume case insensitive */
 	return 1;

--- a/src/lib/libast/path/pathicase.c
+++ b/src/lib/libast/path/pathicase.c
@@ -53,19 +53,20 @@ pathicase(const char *path)
 	long r = pathconf(path, _PC_CASE_INSENSITIVE);
 	return r < 0L ? -1 : r > 0L;
 #elif _linux_fatfs
+	/* Linux */
 	int attr = 0, fd, r;
-	if((fd = open(path, O_RDONLY|O_NONBLOCK)) < 0)
+	if ((fd = open(path, O_RDONLY|O_NONBLOCK)) < 0)
 		return -1;
 	r = ioctl(fd, FAT_IOCTL_GET_ATTRIBUTES, &attr);
-#	if _linux_casefold
-	if(r < 0 && errno == ENOTTY)
+#   if _linux_casefold
+	/* Linux 5.2+ */
+	if (r < 0 && errno == ENOTTY)	/* if it's not VFAT/FAT32...*/
 	{
-		/* Linux 5.2+ */
 		r = ioctl(fd, FS_IOC_GETFLAGS, &attr);
 		close(fd);
 		return r < 0 ? -1 : (attr & FS_CASEFOLD_FL) != 0;
 	}
-#	endif /* _linux_casefold */
+#   endif /* _linux_casefold */
 	close(fd);
 	return r < 0 ? (errno != ENOTTY ? -1 : 0) : 1;
 #elif _WINIX || __APPLE__


### PR DESCRIPTION
src/lib/libast/features/lib,
src/lib/libast/path/pathicase.c:
* FAT32/VFAT file systems on Linux don't support `FS_CASEFOLD_FL`, which caused case-insensitive globbing to break. This was fixed by checking for FAT attributes with ioctl, then checking for `FS_CASEFOLD_FL` if that fails. Reproducer using a UEFI boot partition:  
```sh
$ set --globcasedetect
$ echo /boot/eF*
/boot/eF*
```
* The check for `FS_CASEFOLD_FL` didn't work correctly; I still wasn't able to get `--globcasedetect` to work on a case-insensitive ext4 folder. Fix that by adding missing parentheses (with this change it's now working fine on my system).

src/cmd/ksh93/features/options:
* Prefer `/boot/EFI` and `/boot` over `/` since those could be FAT partitions. This should allow ksh to detect `SHOPT_GLOBCASEDET` support on Linux kernels older than 5.2.