### PR TITLE
Fix integer truncation in `put_enum`

### DIFF
--- a/src/cmd/ksh93/bltins/enum.c
+++ b/src/cmd/ksh93/bltins/enum.c
@@ -121,7 +121,8 @@ static void put_enum(Namval_t* np,const char *val,int flags,Namfun_t *fp)
 {
 	struct Enum 		*ep = (struct Enum*)fp;
 	register const char	*v;
-	unsigned short		i=0, n;
+	unsigned short		i=0;
+	int			n;
 	if(!val)
 	{
 		nv_putv(np, val, flags,fp);


### PR DESCRIPTION
This bugfix comes from https://github.com/att/ast/pull/711. Eric Scrivner provided the following explanation for the fix:

> Coverity identified an issue with integer truncation in `put_enum`.  The
> function was truncating the return values of `strcasecmp` and `strcmp` from an
> `int` to an `unsigned short` when assigning them to the local variable `n`.
> Since either of these methods can return a value that is not in the set
> `{0, 1, -1}` the later check if `n == 0` could spuriously evaluate to true. For
> example, in the case where either function returned `-65536`.

> The fix is simply to change `n` from an `unsigned short` to an `int` to avoid
> the possibility of truncation. Since the only purpose of `n` is the store the
> return values of these checks, this does not have any side effects.