### PR TITLE
Fix many GCC `-Wimplicit-fallthrough` warnings

### DIFF
--- a/src/cmd/INIT/mamake.c
+++ b/src/cmd/INIT/mamake.c
@@ -864,7 +864,7 @@ substitute(Buf_t* buf, register char* s)
 				}
 				if (c != '-')
 					break;
-				/*FALLTHROUGH*/
+				/* FALLTHROUGH */
 			case 0:
 			case '=':
 			case '}':
@@ -2118,7 +2118,7 @@ main(int argc, char** argv)
 			continue;
 		case 'N':
 			state.never = 1;
-			/*FALLTHROUGH*/
+			/* FALLTHROUGH */
 		case 'n':
 			append(state.opt, " -n");
 			state.exec = 0;
@@ -2223,7 +2223,7 @@ main(int argc, char** argv)
 				continue;
 			case 'N':
 				state.never = 1;
-				/*FALLTHROUGH*/
+				/* FALLTHROUGH */
 			case 'n':
 				append(state.opt, " -n");
 				state.exec = 0;
@@ -2278,6 +2278,7 @@ main(int argc, char** argv)
 				break;
 			default:
 				report(2, "unknown option", s, (unsigned long)0);
+				/* FALLTHROUGH */
 			case '?':
 				usage();
 				break;

--- a/src/cmd/INIT/proto.c
+++ b/src/cmd/INIT/proto.c
@@ -1013,7 +1013,7 @@ ppfsm __PARAM__((int op, register char* s), (op, s)) __OTORP__(int op; register 
 				case 023:
 					for (c = 0; c <= 255; c++)
 						rp[c] = n;
- 
+					/* FALLTHROUGH */
 
 				case 002:
 					_pp_fsmtab[(0+28)][fp->state+1] = n < 0 ? ~n : n;
@@ -2899,7 +2899,7 @@ lex __PARAM__((register Proto_t* proto, register long flags), (proto, flags)) __
 	if ((n = ip - bp - 1) > 0)
 	{
 		ip = bp;
-		do switch( n) { default : memcopy( op, ip, n); op += n; ip += n; break; case 7 : * op++ = * ip++; case 6 : * op++ = * ip++; case 5 : * op++ = * ip++; case 4 : * op++ = * ip++; case 3 : * op++ = * ip++; case 2 : * op++ = * ip++; case 1 : * op++ = * ip++; case 0 : break; } while (0);
+		do switch( n) { default : memcopy( op, ip, n); op += n; ip += n; break; case 7 : * op++ = * ip++; /* FALLTHROUGH */ case 6 : * op++ = * ip++; /* FALLTHROUGH */ case 5 : * op++ = * ip++; /* FALLTHROUGH */ case 4 : * op++ = * ip++; /* FALLTHROUGH */ case 3 : * op++ = * ip++; /* FALLTHROUGH */ case 2 : * op++ = * ip++; /* FALLTHROUGH */ case 1 : * op++ = * ip++; /* FALLTHROUGH */ case 0 : break; } while (0);
 		ip++;
 	}
 	state = ~state;
@@ -3534,11 +3534,11 @@ lex __PARAM__((register Proto_t* proto, register long flags), (proto, flags)) __
 							break;
 						case ((( ((( ((( ((( ((( (( 'i')-('a'-1)))<<5)+(( 'n')-('a'-1))))<<5)+(( 'c')-('a'-1))))<<5)+(( 'l')-('a'-1))))<<5)+(( 'u')-('a'-1))))<<5)+(( 'd')-('a'-1))):
 							if (*ip == 'e') ip++;
- 
+ 							/* FALLTHROUGH */
 						case ((( ((( ((( ((( ((( (( 'd')-('a'-1)))<<5)+(( 'e')-('a'-1))))<<5)+(( 'f')-('a'-1))))<<5)+(( 'i')-('a'-1))))<<5)+(( 'n')-('a'-1))))<<5)+(( 'e')-('a'-1))):
 						case ((( ((( ((( ((( ((( (( 'p')-('a'-1)))<<5)+(( 'r')-('a'-1))))<<5)+(( 'a')-('a'-1))))<<5)+(( 'g')-('a'-1))))<<5)+(( 'm')-('a'-1))))<<5)+(( 'a')-('a'-1))):
 							if (*ip < 'a' || *ip > 'z') break;
- 
+							/* FALLTHROUGH */
 						default:
 							flags |= (1L<<12)|(1L<<15);
 							im = bp - 1;
@@ -4260,7 +4260,7 @@ if !defined(va_start)\n\
 				call = 0;
 				break;
 			}
- 
+			/* FALLTHROUGH */
 		case (0401+0):
  fsm_id:
 
@@ -5161,7 +5161,7 @@ main __PARAM__((int argc, char** argv), (argc, argv)) __OTORP__(int argc; char**
 				continue;
 			default:
 				proto_error(((char*)0), 2, file, "unknown option");
- 
+				/* FALLTHROUGH */
 			case '?':
 				b = "Usage: proto [-dfhinprstvzP+S] [-C directory] [-e package] [-l file]\n             [-o \"name='value' ...\"] [-L file] file ...\n";
 				write(2, b, sstrlen( b));

--- a/src/cmd/INIT/proto.c
+++ b/src/cmd/INIT/proto.c
@@ -2110,7 +2110,7 @@ astlicense __PARAM__((char* p, int size, char* file, char* options, int cc1, int
 							break;
 						case -1:
 							c = 12;
- 
+							/* FALLTHROUGH */
 						default:
 							notice.type = c;
 							notice.item[1].data = lic[lic[c].quote].data;

--- a/src/cmd/INIT/ratz.c
+++ b/src/cmd/INIT/ratz.c
@@ -2983,6 +2983,7 @@ int flush;
             strm->adler = state->check = REVERSE(hold);
             INITBITS();
             state->mode = DICT;
+	    /* FALLTHROUGH */
         case DICT:
             if (state->havedict == 0) {
                 RESTORE();
@@ -2990,8 +2991,10 @@ int flush;
             }
             strm->adler = state->check = adler32(0L, Z_NULL, 0);
             state->mode = TYPE;
+	    /* FALLTHROUGH */
         case TYPE:
             if (flush == Z_BLOCK) goto inf_leave;
+	    /* FALLTHROUGH */
         case TYPEDO:
             if (state->last) {
                 BYTEBITS();
@@ -3037,6 +3040,7 @@ int flush;
                     state->length));
             INITBITS();
             state->mode = COPY;
+	    /* FALLTHROUGH */
         case COPY:
             copy = state->length;
             if (copy) {
@@ -3072,6 +3076,7 @@ int flush;
             Tracev((stderr, "inflate:       table sizes ok\n"));
             state->have = 0;
             state->mode = LENLENS;
+	    /* FALLTHROUGH */
         case LENLENS:
             while (state->have < state->ncode) {
                 NEEDBITS(3);
@@ -3093,6 +3098,7 @@ int flush;
             Tracev((stderr, "inflate:       code lengths ok\n"));
             state->have = 0;
             state->mode = CODELENS;
+	    /* FALLTHROUGH */
         case CODELENS:
             while (state->have < state->nlen + state->ndist) {
                 for (;;) {
@@ -3167,6 +3173,7 @@ int flush;
             }
             Tracev((stderr, "inflate:       codes ok\n"));
             state->mode = LEN;
+	    /* FALLTHROUGH */
         case LEN:
             if (have >= 6 && left >= 258) {
                 RESTORE();
@@ -3210,6 +3217,7 @@ int flush;
             }
             state->extra = (unsigned)(this.op) & 15;
             state->mode = LENEXT;
+	    /* FALLTHROUGH */
         case LENEXT:
             if (state->extra) {
                 NEEDBITS(state->extra);
@@ -3218,6 +3226,7 @@ int flush;
             }
             Tracevv((stderr, "inflate:         length %u\n", state->length));
             state->mode = DIST;
+	    /* FALLTHROUGH */
         case DIST:
             for (;;) {
                 this = state->distcode[BITS(state->distbits)];
@@ -3243,6 +3252,7 @@ int flush;
             state->offset = (unsigned)this.val;
             state->extra = (unsigned)(this.op) & 15;
             state->mode = DISTEXT;
+	    /* FALLTHROUGH */
         case DISTEXT:
             if (state->extra) {
                 NEEDBITS(state->extra);
@@ -3263,6 +3273,7 @@ int flush;
             }
             Tracevv((stderr, "inflate:         distance %u\n", state->offset));
             state->mode = MATCH;
+	    /* FALLTHROUGH */
         case MATCH:
             if (left == 0) goto inf_leave;
             copy = out - left;
@@ -3318,6 +3329,7 @@ int flush;
             }
 #ifdef GUNZIP
             state->mode = LENGTH;
+	    /* FALLTHROUGH */
         case LENGTH:
             if (state->wrap && state->flags) {
                 NEEDBITS(32);
@@ -3331,6 +3343,7 @@ int flush;
             }
 #endif
             state->mode = DONE;
+	    /* FALLTHROUGH */
         case DONE:
             ret = Z_STREAM_END;
             goto inf_leave;
@@ -4861,7 +4874,7 @@ char**	argv;
 				return 0;
 			default:
 				fprintf(stderr, "%s: -%c: unknown option\n", state.id, c);
-				/*FALLTHROUGH*/
+				/* FALLTHROUGH */
 			case '?':
 				usage();
 				break;
@@ -5233,7 +5246,7 @@ char**	argv;
 						break;
 					}
 					c = 1;
-					/*FALLTHROUGH*/
+					/* FALLTHROUGH */
 				case 1:
 					for (e = (s = buf) + sizeof(header); s < e; s++)
 						*s = a2x[*(unsigned char*)s];

--- a/src/cmd/INIT/release.c
+++ b/src/cmd/INIT/release.c
@@ -308,7 +308,7 @@ main(int argc, char** argv)
 				return 0;
 			default:
 				fprintf(stderr, "release: -%c: unknown option\n", i);
-				/*FALLTHROUGH*/
+				/* FALLTHROUGH */
 			case '?':
 				usage();
 				break;

--- a/src/cmd/builtin/pty.c
+++ b/src/cmd/builtin/pty.c
@@ -1037,6 +1037,7 @@ b_pty(int argc, char** argv, Shbltin_t* context)
 			continue;
 		case 'l':
 			log = opt_info.arg;
+			/* FALLTHROUGH */
 		case 'm':
 			messages = opt_info.arg;
 			continue;

--- a/src/cmd/ksh93/bltins/getopts.c
+++ b/src/cmd/ksh93/bltins/getopts.c
@@ -128,7 +128,7 @@ int	b_getopts(int argc,char *argv[],Shbltin_t *context)
 		if(mode==0)
 			errormsg(SH_DICT,ERROR_usage(2), "%s", opt_info.arg);
 		opt_info.option[1] = '?';
-		/* FALL THRU */
+		/* FALLTHROUGH */
 	    case ':':
 		key[0] = opt_info.option[1];
 		if(strmatch(opt_info.arg,"*unknown*"))

--- a/src/cmd/ksh93/bltins/hist.c
+++ b/src/cmd/ksh93/bltins/hist.c
@@ -89,6 +89,7 @@ int	b_hist(int argc,char *argv[], Shbltin_t *context)
 			range[++indx] = flag;
 			break;
 		}
+		/* FALLTHROUGH */
 	    case ':':
 		errormsg(SH_DICT,2, "%s", opt_info.arg);
 		break;

--- a/src/cmd/ksh93/bltins/misc.c
+++ b/src/cmd/ksh93/bltins/misc.c
@@ -527,7 +527,6 @@ int	b_times(int argc, char *argv[], Shbltin_t *context)
 	    case ':':
 		errormsg(SH_DICT, 2, "%s", opt_info.arg);
 		errormsg(SH_DICT, ERROR_usage(2), "%s", optusage((char*)0));
-		break;
 	    default:
 		errormsg(SH_DICT, ERROR_usage(0), "%s", opt_info.arg);
 		return(2);

--- a/src/cmd/ksh93/bltins/misc.c
+++ b/src/cmd/ksh93/bltins/misc.c
@@ -527,6 +527,7 @@ int	b_times(int argc, char *argv[], Shbltin_t *context)
 	    case ':':
 		errormsg(SH_DICT, 2, "%s", opt_info.arg);
 		errormsg(SH_DICT, ERROR_usage(2), "%s", optusage((char*)0));
+		break;
 	    default:
 		errormsg(SH_DICT, ERROR_usage(0), "%s", opt_info.arg);
 		return(2);

--- a/src/cmd/ksh93/bltins/print.c
+++ b/src/cmd/ksh93/bltins/print.c
@@ -716,7 +716,7 @@ static int extend(Sfio_t* sp, void* v, Sffmt_t* fe)
 			break;
 		case 'q':
 			format = 's';
-			/* FALL THROUGH */
+			/* FALLTHROUGH */
 		case 's':
 		case 'H':
 		case 'B':
@@ -798,6 +798,7 @@ static int extend(Sfio_t* sp, void* v, Sffmt_t* fe)
 						fe->flags |=SFFMT_ALTER;
 				}
 			}
+			/* FALLTHROUGH */
 		case 'b':
 		case 's':
 		case 'B':
@@ -837,12 +838,14 @@ static int extend(Sfio_t* sp, void* v, Sffmt_t* fe)
 		case 'u':
 		case 'U':
 			longmax = LDBL_ULLONG_MAX;
+			/* FALLTHROUGH */
 		case '.':
 			if(fe->size==2 && strchr("bcsqHPRQTZ",*fe->form))
 			{
 				value->ll = ((unsigned char*)argp)[0];
 				break;
 			}
+			/* FALLTHROUGH */
 		case 'd':
 		case 'D':
 		case 'i':
@@ -1096,6 +1099,7 @@ static int fmtvecho(const char *string, struct printf *pp)
 					c <<= 3;
 					c |= (*cp-'0');
 				}
+				/* FALLTHROUGH */
 			default:
 				cp--;
 		}

--- a/src/cmd/ksh93/bltins/read.c
+++ b/src/cmd/ksh93/bltins/read.c
@@ -599,6 +599,7 @@ int sh_readline(register Shell_t *shp,char **names, volatile int fd, int flags,s
 
 		    case S_ERR:
 			cp++;
+			/* FALLTHROUGH */
 		    case S_EOF:
 			/* check for end of buffer */
 			if(val && *val)
@@ -660,7 +661,7 @@ int sh_readline(register Shell_t *shp,char **names, volatile int fd, int flags,s
 #endif /* SHOPT_MULTIBYTE */
 			if(c!=S_DELIM)
 				break;
-			/* FALL THRU */
+			/* FALLTHROUGH */
 
 		    case S_DELIM:
 			if(!del)
@@ -671,7 +672,7 @@ int sh_readline(register Shell_t *shp,char **names, volatile int fd, int flags,s
 				while((c=shp->ifstable[*cp++])==S_SPACE);
 				break;
 			}
-			/* FALL THRU */
+			/* FALLTHROUGH */
 
 		    case 0:
 			if(val==0 || was_escape)

--- a/src/cmd/ksh93/bltins/test.c
+++ b/src/cmd/ksh93/bltins/test.c
@@ -166,7 +166,7 @@ int b_test(int argc, char *argv[],Shbltin_t *context)
 			if(!not)
 				break;
 			argv++;
-			/* fall through */
+			/* FALLTHROUGH */
 		case 4:
 		{
 			register int op = sh_lookup(cp=argv[2],shtab_testops);
@@ -434,6 +434,7 @@ int test_unop(Shell_t *shp,register int op,register const char *arg)
 		return(*arg == 0);
 	    case 's':
 		sfsync(sfstdout);
+		/* FALLTHROUGH */
 	    case 'O':
 	    case 'G':
 		if(*arg==0 || test_stat(arg,&statb)<0)

--- a/src/cmd/ksh93/bltins/trap.c
+++ b/src/cmd/ksh93/bltins/trap.c
@@ -211,6 +211,7 @@ int	b_kill(int argc,char *argv[],Shbltin_t *context)
 			goto endopts;
 		case 'L':
 			usemenu = -1;
+			/* FALLTHROUGH */
 		case 'l':
 			flag |= L_FLAG;
 			break;

--- a/src/cmd/ksh93/bltins/typeset.c
+++ b/src/cmd/ksh93/bltins/typeset.c
@@ -256,6 +256,7 @@ int    b_typeset(int argc,register char *argv[],Shbltin_t *context)
 					tdata.argnum = (int)opt_info.num;
 					break;
 				}
+				/* FALLTHROUGH */
 			case 'F':
 			case 'X':
 				if(!opt_info.arg || (tdata.argnum = opt_info.num) <0)
@@ -1230,6 +1231,7 @@ static int unall(int argc, char **argv, register Dt_t *troot, Shell_t* shp)
 			break;
 		case 'n':
 			nflag = NV_NOREF;
+			/* FALLTHROUGH */
 		case 'v':
 			troot = shp->var_tree;
 			break;

--- a/src/cmd/ksh93/bltins/whence.c
+++ b/src/cmd/ksh93/bltins/whence.c
@@ -109,7 +109,7 @@ int	b_whence(int argc,char *argv[],Shbltin_t *context)
 	{
 	    case 'a':
 		flags |= A_FLAG;
-		/* FALL THRU */
+		/* FALLTHROUGH */
 	    case 'v':
 		flags |= V_FLAG;
 		break;

--- a/src/cmd/ksh93/edit/completion.c
+++ b/src/cmd/ksh93/edit/completion.c
@@ -190,7 +190,7 @@ static char *find_begin(char outbuff[], char *last, int endchar, int *type)
 		    case '~':
 			if(*cp=='(')
 				break;
-			/* fall through */
+			/* FALLTHROUGH */
 		    default:
 			if(c && c==endchar)
 				return(xp);

--- a/src/cmd/ksh93/edit/edit.c
+++ b/src/cmd/ksh93/edit/edit.c
@@ -692,7 +692,7 @@ void	ed_setup(register Edit_t *ep, int fd, int reedit)
 			case '\r':
 				if(pp == (ep->e_prompt+2)) /* quote char */
 					myquote = *(pp-1);
-				/*FALLTHROUGH*/
+				/* FALLTHROUGH */
 
 			case '\n':
 				/* start again */

--- a/src/cmd/ksh93/edit/emacs.c
+++ b/src/cmd/ksh93/edit/emacs.c
@@ -566,6 +566,7 @@ update:
 		case KILLCHAR :
 			cur = 0;
 			oadjust = -1;
+			/* FALLTHROUGH */
 		case cntl('K') :
 			if(oadjust >= 0)
 			{
@@ -983,6 +984,7 @@ static int escape(register Emacs_t* ep,register genchar *out,int count)
 			if(ch=='\n')
 				ed_ungetchar(ep->ed,'\n');
 #endif /* SHOPT_EDPREDICT */
+			/* FALLTHROUGH */
 		/* file name expansion */
 		case ESC :
 #if SHOPT_EDPREDICT
@@ -1001,6 +1003,7 @@ static int escape(register Emacs_t* ep,register genchar *out,int count)
 			}
 #endif /* SHOPT_EDPREDICT */
 			i = '\\';	/* filename completion */
+			/* FALLTHROUGH */
 		case '*':		/* filename expansion */
 		case '=':	/* escape = - list all matching file names */
 			ep->mark = cur;
@@ -1144,6 +1147,7 @@ static int escape(register Emacs_t* ep,register genchar *out,int count)
 				ed_ungetchar(ep->ed,i);
 			}
 			i = '_';
+			/* FALLTHROUGH */
 
 		default:
 			/* look for user defined macro definitions */

--- a/src/cmd/ksh93/edit/hexpand.c
+++ b/src/cmd/ksh93/edit/hexpand.c
@@ -250,6 +250,7 @@ int hist_expand(const char *ln, char **xp)
 			if(!isdigit(*(cp+1)))
 				goto string_event;
 			cp++;
+			/* FALLTHROUGH */
 		case '0': /* reference by number */
 		case '1':
 		case '2':
@@ -273,6 +274,7 @@ int hist_expand(const char *ln, char **xp)
 		case '?':
 			cp++;
 			flag |= HIST_QUESTION;
+			/* FALLTHROUGH */
 		string_event:
 		default:
 			/* read until end of string or word designator/modifier */
@@ -376,6 +378,7 @@ getline:
 					sfseek(wm, 0, SEEK_SET);
 					goto skip;
 				}
+				/* FALLTHROUGH */
 			default:
 			skip2:
 				cp--;

--- a/src/cmd/ksh93/edit/vi.c
+++ b/src/cmd/ksh93/edit/vi.c
@@ -838,6 +838,7 @@ static int cntlmode(Vi_t *vp)
 			case BAD:
 				/*** no match ***/
 					ed_ringbell();
+				/* FALLTHROUGH */
 
 			default:
 				if( vp->u_column == INVALID )
@@ -958,6 +959,7 @@ static int cntlmode(Vi_t *vp)
 			if(vp->repeat_set==0)
 				goto vcommand;
 #endif /* KSHELL */
+			/* FALLTHROUGH */
 
 		case 'G':		/** goto command repeat **/
 			if(vp->repeat_set==0)
@@ -1016,11 +1018,13 @@ static int cntlmode(Vi_t *vp)
 				}
 				refresh(vp,INPUT);
 			}
+			/* FALLTHROUGH */
 
 		case '\n':		/** send to shell **/
 #if SHOPT_EDPREDICT
 			if(!vp->ed->hlist)
-			return(ENTER);
+				return(ENTER);
+			/* FALLTHROUGH */
 		case '\t':		/** bring choice to edit **/
 			if(vp->ed->hlist)
 			{
@@ -1047,6 +1051,7 @@ static int cntlmode(Vi_t *vp)
 				if(c=='[')
 					continue;
 			}
+			/* FALLTHROUGH */
 		default:
 		ringbell:
 			ed_ringbell();
@@ -1523,6 +1528,7 @@ static void getline(register Vi_t* vp,register int mode)
 			if( cur_virt != INVALID )
 				continue;
 			vp->addnl = 0;
+			/* FALLTHROUGH */
 
 		case '\n':		/** newline or return **/
 			if( mode != SEARCH )
@@ -1556,7 +1562,7 @@ static void getline(register Vi_t* vp,register int mode)
 				}
 				vp->ed->e_tabcount = 0;
 			}
-			/* FALL THRU*/
+			/* FALLTHROUGH */
 		default:
 			if( mode == REPLACE )
 			{
@@ -1614,7 +1620,7 @@ static int mvcursor(register Vi_t* vp,register int motion)
 		tcur_virt = vp->repeat-1;
 		if(tcur_virt <= last_virt)
 			break;
-		/* fall through */
+		/* FALLTHROUGH */
 
 	case '$':		/** End of line **/
 		tcur_virt = last_virt;
@@ -1752,6 +1758,7 @@ static int mvcursor(register Vi_t* vp,register int motion)
 	case 'f':		/** find new char forward **/
 		bound = last_virt;
 		incr = 1;
+		/* FALLTHROUGH */
 
 	case 'T':		/** find up to new char backward **/
 	case 'F':		/** find new char backward **/
@@ -2448,10 +2455,12 @@ addin:
 		if(vp->ed->e_tabcount!=1)
 			return(BAD);
 		c = '=';
+		/* FALLTHROUGH */
 	case '*':		/** do file name expansion in place **/
 	case '\\':		/** do file name completion in place **/
 		if( cur_virt == INVALID )
 			return(BAD);
+		/* FALLTHROUGH */
 	case '=':		/** list file name expansions **/
 		save_v(vp);
 		i = last_virt;
@@ -2532,10 +2541,12 @@ addin:
 			while(i = *p++);
 			return(APPEND);
 		}
+		/* FALLTHROUGH */
 
 	case 'A':		/** append to end of line **/
 		cur_virt = last_virt;
 		sync_cursor(vp);
+		/* FALLTHROUGH */
 
 	case 'a':		/** append **/
 		if( fold(mode) == 'A' )
@@ -2555,6 +2566,7 @@ addin:
 	case 'I':		/** insert at beginning of line **/
 		cur_virt = first_virt;
 		sync_cursor(vp);
+		/* FALLTHROUGH */
 
 	case 'i':		/** insert **/
 		if( fold(mode) == 'I' )
@@ -2631,6 +2643,7 @@ deleol:
 				vp->ocur_virt = INVALID;
 			--cur_virt;
 		}
+		/* FALLTHROUGH */
 
 	case 'p':		/** print **/
 		if( p[0] == '\0' )

--- a/src/cmd/ksh93/sh/args.c
+++ b/src/cmd/ksh93/sh/args.c
@@ -216,13 +216,13 @@ int sh_argopts(int argc,register char *argv[], void *context)
 				ap->kiafile = opt_info.arg;
 				n = 'n';
 			}
-			/*FALLTHROUGH*/
 #endif /* SHOPT_KIA */
 #if SHOPT_REGRESS
 			goto skip;
 		    case 'I':
 			continue;
 #endif /* SHOPT_REGRESS */
+			/* FALLTHROUGH */
 		    skip:
 		    default:
 			if(cp=strchr(optksh,n))

--- a/src/cmd/ksh93/sh/fcin.c
+++ b/src/cmd/ksh93/sh/fcin.c
@@ -157,7 +157,7 @@ int _fcmbget(short *len)
 	{
 	    case -1:
 		*len = 1;
-		/* fall through */
+		/* FALLTHROUGH */
 	    case 0:
 	    case 1:
 		c=fcget();

--- a/src/cmd/ksh93/sh/lex.c
+++ b/src/cmd/ksh93/sh/lex.c
@@ -470,7 +470,7 @@ int sh_lex(Lex_t* lp)
 					return(lp->token=EOFSYM);
 				n = S_NLTOK;
 				shp->inlineno--;
-				/* FALL THRU */
+				/* FALLTHROUGH */
 			case S_NLTOK:
 				/* check for here-document */
 				if(lp->heredoc)
@@ -491,7 +491,7 @@ int sh_lex(Lex_t* lp)
 				}
 				lp->lex.reservok = !lp->lex.intest;
 				lp->lex.skipword = 0;
-				/* FALL THRU */
+				/* FALLTHROUGH */
 			case S_NL:
 				/* skip over new-lines */
 				lp->lex.last_quote = 0;
@@ -502,6 +502,7 @@ int sh_lex(Lex_t* lp)
 					lp->comp_assign = 0;
 					return(lp->token='\n');
 				}
+				/* FALLTHROUGH */
 			case S_BLNK:
 				if(lp->lex.incase<=TEST_RE)
 					continue;
@@ -686,7 +687,7 @@ int sh_lex(Lex_t* lp)
 			case S_NAME:
 				if(!lp->lex.skipword)
 					lp->lex.reservok *= 2;
-				/* FALL THRU */
+				/* FALLTHROUGH */
 			case S_TILDE:
 				if(c=='~' && mode==ST_NESTED)
 				{
@@ -697,6 +698,7 @@ int sh_lex(Lex_t* lp)
 					}
 					continue;
 				}
+				/* FALLTHROUGH */
 			case S_RES:
 				if(!lp->lexd.dolparen)
 					lp->lexd.first = fcseek(0)-LEN;
@@ -808,7 +810,7 @@ int sh_lex(Lex_t* lp)
 				wordflags |=(ARG_MAC|ARG_EXP);
 				if(mode==ST_QUOTE)
 					ingrave = !ingrave;
-				/* FALL THRU */
+				/* FALLTHROUGH */
 			case S_QUOTE:
 				if(oldmode(lp)==ST_NONE && lp->lexd.arith)	/*  in ((...)) */
 				{
@@ -914,10 +916,11 @@ int sh_lex(Lex_t* lp)
 					setchar(lp,c);
 					continue;
 				}
-				/* FALL THRU */
+				/* FALLTHROUGH */
 			case S_ALP:
 				if(c=='.' && endchar(lp)=='$')
 					goto err;
+				/* FALLTHROUGH */
 			case S_SPC2:
 			case S_DIG:
 				wordflags |= ARG_MAC;
@@ -938,9 +941,11 @@ int sh_lex(Lex_t* lp)
 					case '!':
 						if(n!=S_ALP)
 							goto dolerr;
+						/* FALLTHROUGH */
 					case '#':
 						if(c=='#')
 							n = S_ALP;
+						/* FALLTHROUGH */
 					case RBRACE:
 						if(n==S_ALP)
 						{
@@ -1150,7 +1155,7 @@ int sh_lex(Lex_t* lp)
 				continue;
 			case S_EQ:
 				assignment = lp->assignok;
-				/* FALL THRU */
+				/* FALLTHROUGH */
 			case S_COLON:
 				if(assignment)
 				{
@@ -1254,7 +1259,7 @@ int sh_lex(Lex_t* lp)
 			}
 			case S_PAT:
 				wordflags |= ARG_EXP;
-				/* FALL THRU */
+				/* FALLTHROUGH */
 			case S_EPAT:
 			epat:
 				if(fcgetc(n)==LPAREN && c!='[')
@@ -1419,7 +1424,7 @@ breakloop:
 		case TEST_SEQ:
 			if(lp->lexd.warn && state[1]==0)
 				errormsg(SH_DICT,ERROR_warn(0),e_lexobsolete3,shp->inlineno);
-			/* FALL THRU */
+			/* FALLTHROUGH */
 		default:
 			if(lp->lex.testop2)
 			{
@@ -1434,7 +1439,7 @@ breakloop:
 				lp->token = TESTBINOP;	
 				return(lp->token);	
 			}
-
+			/* FALLTHROUGH */
 		case TEST_OR: case TEST_AND:
 		case 0:
 			return(lp->token=0);
@@ -1629,6 +1634,7 @@ static int comsub(register Lex_t *lp, int endtok)
 				lp->lastline = line;
 				lp->lasttok = endtok;
 				sh_syntax(lp);
+				break;
 			    case IOSEEKSYM:
 				if(fcgetc(c)!='#' && c>0)
 					fcseek(-LEN);
@@ -1649,7 +1655,7 @@ static int comsub(register Lex_t *lp, int endtok)
 					goto rbrace;
 				if(c>0)
 					fcseek(-LEN);
-				/* fall through */
+				/* FALLTHROUGH */
 			    default:
 				lp->lex.reservok = 1;
 			}

--- a/src/cmd/ksh93/sh/lex.c
+++ b/src/cmd/ksh93/sh/lex.c
@@ -1634,7 +1634,6 @@ static int comsub(register Lex_t *lp, int endtok)
 				lp->lastline = line;
 				lp->lasttok = endtok;
 				sh_syntax(lp);
-				break;
 			    case IOSEEKSYM:
 				if(fcgetc(c)!='#' && c>0)
 					fcseek(-LEN);

--- a/src/cmd/ksh93/sh/macro.c
+++ b/src/cmd/ksh93/sh/macro.c
@@ -390,7 +390,7 @@ void sh_machere(Shell_t *shp,Sfio_t *infile, Sfio_t *outfile, char *string)
 			    case S_EOF:
 				if((c=fcfill()) > 0)
 					goto again;
-				/* FALL THRU */
+				/* FALLTHROUGH */
 			    default:
 			    regular:
 				sfputc(outfile,'$');
@@ -464,6 +464,7 @@ static void copyto(register Mac_t *mp,int endch, int newquote)
 				    case -1:	/* illegal multi-byte char */
 				    case 0:
 					len = 1;
+					/* FALLTHROUGH */
 				    case 1:
 					n = state[*(unsigned char*)cp++];
 					break;
@@ -643,6 +644,7 @@ static void copyto(register Mac_t *mp,int endch, int newquote)
 					goto pattern;
 				continue;
 			}
+			/* FALLTHROUGH */
 		    case S_EOF:
 			if(c)
 			{
@@ -667,6 +669,7 @@ static void copyto(register Mac_t *mp,int endch, int newquote)
 		    case S_QUOTE:
 			if(mp->lit || mp->arith)
 				break;
+			/* FALLTHROUGH */
 		    case S_LIT:
 			if(mp->arith)
 			{
@@ -729,6 +732,7 @@ static void copyto(register Mac_t *mp,int endch, int newquote)
 				cp = first = fcseek(0);
 				break;
 			}
+			/* FALLTHROUGH */
 		    case S_PAT:
 			if(mp->pattern && !(mp->quote || mp->lit))
 			{
@@ -1102,7 +1106,7 @@ retry1:
 		/* This code handles ${#} */
 		c = mode;
 		mode = type = 0;
-		/* FALL THRU */
+		/* FALLTHROUGH */
 	    case S_SPC1:
 		if(type==M_BRACE)
 		{
@@ -1129,7 +1133,7 @@ retry1:
 				goto retry1;
 			}
 		}
-		/* FALL THRU */
+		/* FALLTHROUGH */
 	    case S_SPC2:
 		var = 0;
 		*id = c;

--- a/src/cmd/ksh93/sh/name.c
+++ b/src/cmd/ksh93/sh/name.c
@@ -769,10 +769,12 @@ Namval_t *nv_create(const char *name,  Dt_t *root, int flags, Namfun_t *dp)
 				sp = (char*)name+c;
 				c = '.';
 			}
+			/* FALLTHROUGH */
 		skip:
 		    case '+':
 		    case '=':
 			*sp = 0;
+			/* FALLTHROUGH */
 		    case 0:
 			isref = 0;
 			dp->last = cp;

--- a/src/cmd/ksh93/sh/parse.c
+++ b/src/cmd/ksh93/sh/parse.c
@@ -501,7 +501,7 @@ static Shnode_t	*sh_cmd(Lex_t *lexp, register int sym, int flag)
 	{
 	    case COOPSYM:		/* set up a cooperating process */
 		type |= (FPIN|FPOU|FPCL|FCOOP);
-		/* FALL THRU */		
+		/* FALLTHROUGH */
 	    case '&':
 		if(left)
 		{
@@ -510,7 +510,7 @@ static Shnode_t	*sh_cmd(Lex_t *lexp, register int sym, int flag)
 				left = left->par.partre;
 			left = makeparent(lexp,TFORK|type, left);
 		}
-		/* FALL THRU */		
+		/* FALLTHROUGH */
 	    case ';':
 		if(!left)
 			sh_syntax(lexp);
@@ -520,6 +520,7 @@ static Shnode_t	*sh_cmd(Lex_t *lexp, register int sym, int flag)
 	    case EOFSYM:
 		if(sym==NL)
 			break;
+		/* FALLTHROUGH */
 	    default:
 		if(sym && sym!=lexp->token)
 		{
@@ -1304,7 +1305,7 @@ static Shnode_t	*item(Lex_t *lexp,int flag)
 	    default:
 		if(io==0)
 			return(0);
-
+		/* FALLTHROUGH */
 	    case ';':
 		if(io==0)
 		{
@@ -1314,6 +1315,7 @@ static Shnode_t	*item(Lex_t *lexp,int flag)
 				sh_syntax(lexp);
 			showme =  FSHOWME;
 		}
+		/* FALLTHROUGH */
 	    /* simple command */
 	    case 0:
 		t = (Shnode_t*)simple(lexp,flag,io);

--- a/src/cmd/ksh93/sh/path.c
+++ b/src/cmd/ksh93/sh/path.c
@@ -1205,6 +1205,7 @@ pid_t path_spawn(Shell_t *shp,const char *opath,register char **argv, char **env
 			((struct checkpt*)shp->jmplist)->mode = SH_JMPEXIT;
 		}
 		exscript(shp,path,argv,envp);
+		break;
 	    case EACCES:
 	    {
 		struct stat statb;
@@ -1218,11 +1219,12 @@ pid_t path_spawn(Shell_t *shp,const char *opath,register char **argv, char **env
 #endif
 		}
 	    }
-		/* FALL THROUGH */
 #ifdef ENAMETOOLONG
+	    /* FALLTHROUGH */
 	    case ENAMETOOLONG:
 #endif /* ENAMETOOLONG */
 #if !SHOPT_SUID_EXEC
+	    /* FALLTHROUGH */
 	    case EPERM:
 #endif
 		shp->path_err = errno;
@@ -1242,6 +1244,7 @@ pid_t path_spawn(Shell_t *shp,const char *opath,register char **argv, char **env
 				errormsg(SH_DICT,ERROR_system(ERROR_NOEXEC),"command -x: could not execute %s",path);
 			return(pid);
 		}
+		/* FALLTHROUGH */
 	    default:
 		errormsg(SH_DICT,ERROR_system(ERROR_NOEXEC),e_exec,path);
 	}

--- a/src/cmd/ksh93/sh/path.c
+++ b/src/cmd/ksh93/sh/path.c
@@ -1205,7 +1205,6 @@ pid_t path_spawn(Shell_t *shp,const char *opath,register char **argv, char **env
 			((struct checkpt*)shp->jmplist)->mode = SH_JMPEXIT;
 		}
 		exscript(shp,path,argv,envp);
-		break;
 	    case EACCES:
 	    {
 		struct stat statb;

--- a/src/cmd/ksh93/sh/streval.c
+++ b/src/cmd/ksh93/sh/streval.c
@@ -238,6 +238,7 @@ Sfdouble_t	arith_exec(Arith_t *ep)
 			continue;
 		    case A_ASSIGNOP1:
 			node.emode |= ARITH_ASSIGNOP;
+			/* FALLTHROUGH */
 		    case A_PUSHV:
 			cp = roundptr(ep,cp,Sfdouble_t*);
 			dp = *((Sfdouble_t**)cp);
@@ -282,6 +283,7 @@ Sfdouble_t	arith_exec(Arith_t *ep)
 			continue;
 		    case A_ASSIGNOP:
 			node.nosub = lastsub;
+			/* FALLTHROUGH */
 		    case A_STORE:
 			cp = roundptr(ep,cp,Sfdouble_t*);
 			dp = *((Sfdouble_t**)cp);
@@ -532,7 +534,7 @@ static int gettok(register struct vars *vp)
 				op = A_DIG;
 			else
 				op = A_REG;
-			/*FALL THRU*/
+			/* FALLTHROUGH */
 		    case A_DIG: case A_REG: case A_LIT:
 		    keep:
 			ungetchr(vp);
@@ -551,10 +553,10 @@ static int gettok(register struct vars *vp)
 				op -= 2;
 				break;
 			}
-			/* FALL THRU */
+			/* FALLTHROUGH */
 		    case A_NOT:	case A_COLON:
 			c = '=';
-			/* FALL THRU */
+			/* FALLTHROUGH */
 		    case A_ASSIGN:
 		    case A_TIMES:
 		    case A_PLUS:	case A_MINUS:
@@ -608,7 +610,7 @@ again:
 	    case A_PLUSPLUS:
 		c = A_LVALUE;
 		op = A_INCR|T_NOFLOAT;
-		/* FALL THRU */
+		/* FALLTHROUGH */
 	    case A_TILDE:
 		op |= T_NOFLOAT;
 	    common:
@@ -762,6 +764,7 @@ again:
 		case A_MINUSMINUS:
 			wasop=0;
 			op |= T_NOFLOAT;
+			/* FALLTHROUGH */
 		case A_ASSIGN:
 			if(!lvalue.value)
 				ERROR(vp,e_notlvalue);
@@ -827,7 +830,7 @@ again:
 		case A_AND:	case A_OR:	case A_XOR:	case A_LSHIFT:
 		case A_RSHIFT:	case A_MOD:
 			op |= T_NOFLOAT;
-			/* FALL THRU */
+			/* FALLTHROUGH */
 		case A_PLUS:	case A_MINUS:	case A_TIMES:	case A_DIV:
 		case A_EQ:	case A_NEQ:	case A_LT:	case A_LE:
 		case A_GT:	case A_GE:	case A_POW:

--- a/src/cmd/ksh93/sh/subshell.c
+++ b/src/cmd/ksh93/sh/subshell.c
@@ -932,12 +932,14 @@ Sfio_t *sh_subshell(Shell_t *shp,Shnode_t *t, volatile int flags, int comsub)
 				shp->toomany = 1;
 				errno = saveerrno;
 				errormsg(SH_DICT,ERROR_system(1),e_redirect);
+				break;
 			case 2:
 				/* reinit PWD as it will be wrong */
 				shp->pwd = NULL;
 				path_pwd(shp,0);
 				errno = saveerrno;
 				errormsg(SH_DICT,ERROR_system(1),"Failed to restore PWD upon exiting subshell");
+				break;
 			default:
 				errormsg(SH_DICT,ERROR_system(1),"Subshell error %d",fatalerror);
 		}

--- a/src/cmd/ksh93/sh/subshell.c
+++ b/src/cmd/ksh93/sh/subshell.c
@@ -932,14 +932,12 @@ Sfio_t *sh_subshell(Shell_t *shp,Shnode_t *t, volatile int flags, int comsub)
 				shp->toomany = 1;
 				errno = saveerrno;
 				errormsg(SH_DICT,ERROR_system(1),e_redirect);
-				break;
 			case 2:
 				/* reinit PWD as it will be wrong */
 				shp->pwd = NULL;
 				path_pwd(shp,0);
 				errno = saveerrno;
 				errormsg(SH_DICT,ERROR_system(1),"Failed to restore PWD upon exiting subshell");
-				break;
 			default:
 				errormsg(SH_DICT,ERROR_system(1),"Subshell error %d",fatalerror);
 		}

--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -572,7 +572,7 @@ static void out_pattern(Sfio_t *iop, register const char *cp, int n)
 		    case '\\':
 			if (!(c = *++cp))
 				c = '\\';
-			/*FALLTHROUGH*/
+			/* FALLTHROUGH */
 		    case ' ':
 		    case '<': case '>': case ';':
 		    case '$': case '`': case '\t':
@@ -1558,6 +1558,7 @@ int sh_exec(register const Shnode_t *t, int flags)
 				break;
 			}
 		    }
+		    /* FALLTHROUGH */
 		    case TFORK:
 		    {
 			register pid_t parent;
@@ -1821,6 +1822,7 @@ int sh_exec(register const Shnode_t *t, int flags)
 				sh_done(shp,0);
 			}
 		    }
+		    /* FALLTHROUGH */
 
 		    case TSETIO:
 		    {
@@ -3596,8 +3598,10 @@ static pid_t sh_ntfork(Shell_t *shp,const Shnode_t *t,char *argv[],int *jobid,in
 		{
 		    case ENOENT:
 			errormsg(SH_DICT,ERROR_system(ERROR_NOENT),e_found+4);
+			break;
 		    default:
 			errormsg(SH_DICT,ERROR_system(ERROR_NOEXEC),e_exec+4);
+			break;
 		}
 		job_unlock();
 	}

--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -3598,10 +3598,8 @@ static pid_t sh_ntfork(Shell_t *shp,const Shnode_t *t,char *argv[],int *jobid,in
 		{
 		    case ENOENT:
 			errormsg(SH_DICT,ERROR_system(ERROR_NOENT),e_found+4);
-			break;
 		    default:
 			errormsg(SH_DICT,ERROR_system(ERROR_NOEXEC),e_exec+4);
-			break;
 		}
 		job_unlock();
 	}

--- a/src/lib/libast/aso/asolock.c
+++ b/src/lib/libast/aso/asolock.c
@@ -44,7 +44,7 @@ asolock(unsigned int volatile* lock, unsigned int key, int type)
 		case ASO_LOCK:
 			if (*lock == key)
 				return 0;
-			/*FALLTHROUGH*/
+			/* FALLTHROUGH */
 		case ASO_SPINLOCK:
 			for (k = 0; asocasint(lock, 0, key) != 0; ASOLOOP(k));
 			return 0;

--- a/src/lib/libast/astsa/strmatch.c
+++ b/src/lib/libast/astsa/strmatch.c
@@ -115,7 +115,7 @@ gobble(Match_t* mp, register char* s, register int sub, int* g, int clear)
 		case '\\':
 			if (mbgetchar(s))
 				break;
-			/*FALLTHROUGH*/
+			/* FALLTHROUGH */
 		case 0:
 			return 0;
 		case '[':
@@ -295,7 +295,7 @@ onematch(Match_t* mp, int g, char* s, char* p, char* e, char* r, int flags)
 						if (n <= g && mp->current.beg[n])
 							pc = *mp->current.beg[n];
 					}
-					/*FALLTHROUGH*/
+					/* FALLTHROUGH */
 				default:
 					if (icase && isupper(pc))
 						pc = tolower(pc);
@@ -321,7 +321,7 @@ onematch(Match_t* mp, int g, char* s, char* p, char* e, char* r, int flags)
 		case 0:
 			if (!(flags & STR_MAXIMAL))
 				sc = 0;
-			/*FALLTHROUGH*/
+			/* FALLTHROUGH */
 		case '|':
 		case '&':
 		case ')':
@@ -502,7 +502,7 @@ onematch(Match_t* mp, int g, char* s, char* p, char* e, char* r, int flags)
 					break;
 				}
 			}
-			/*FALLTHROUGH*/
+			/* FALLTHROUGH */
 		default:
 			if (icase && isupper(pc))
 				pc = tolower(pc);

--- a/src/lib/libast/comp/getopt.c
+++ b/src/lib/libast/comp/getopt.c
@@ -56,7 +56,7 @@ getopt(int argc, char* const* argv, const char* optstring)
 	{
 	case ':':
 		n = '?';
-		/*FALLTHROUGH*/
+		/* FALLTHROUGH */
 	case '?':
 		if (opterr && (!optstring || *optstring != ':'))
 		{

--- a/src/lib/libast/disc/sfdcmore.c
+++ b/src/lib/libast/disc/sfdcmore.c
@@ -190,11 +190,11 @@ Sfdisc_t*	dp;
 		{
 		case '\t':
 			more->col = ((more->col + 8) & ~7) - 1;
-			/*FALLTHROUGH*/
+			/* FALLTHROUGH */
 		default:
 			if (++more->col <= more->cols || s < e && *s == '\n')
 				continue;
-			/*FALLTHROUGH*/
+			/* FALLTHROUGH */
 		case '\n':
 			more->col = 1;
 			if (++more->row < more->rows)

--- a/src/lib/libast/misc/fastfind.c
+++ b/src/lib/libast/misc/fastfind.c
@@ -1013,7 +1013,7 @@ findwrite(register Find_t* fp, const char* path, size_t len, const char* type)
 		else
 			u = 0;
 		sfputu(fp->fp, u);
-		/*FALLTHROUGH...*/
+		/* FALLTHROUGH */
 	case FF_dir:
 		d = n - fp->encode.prefix;
 		sfputl(fp->fp, d);

--- a/src/lib/libast/misc/fts.c
+++ b/src/lib/libast/misc/fts.c
@@ -856,7 +856,7 @@ fts_read(register FTS* fts)
 					t = f;
 					f = f->fts_link;
 				}
-			/*FALLTHROUGH*/
+			/* FALLTHROUGH */
 
 		case 0:
 
@@ -864,7 +864,7 @@ fts_read(register FTS* fts)
 				order(fts);
 			if (!(f = fts->todo))
 				return 0;
-			/*FALLTHROUGH*/
+			/* FALLTHROUGH */
 
 		case FTS_todo:
 
@@ -914,7 +914,7 @@ fts_read(register FTS* fts)
 				return 0;
 			memcpy(fts->base, f->name, fts->baselen + 1);
 			fts->name = fts->cd ? fts->path : fts->base;
-			/*FALLTHROUGH*/
+			/* FALLTHROUGH */
 
 		case FTS_preorder:
 
@@ -956,7 +956,7 @@ fts_read(register FTS* fts)
 				fts->state = FTS_preorder_return;
 				goto note;
 			}
-			/*FALLTHROUGH*/
+			/* FALLTHROUGH */
 
 		case FTS_preorder_resume:
 
@@ -997,7 +997,7 @@ fts_read(register FTS* fts)
 			if (fts->endbase[-1] != '/')
 				*fts->endbase++ = '/';
 			fts->current = f;
-			/*FALLTHROUGH*/
+			/* FALLTHROUGH */
 
 		case FTS_readdir:
 
@@ -1147,7 +1147,7 @@ fts_read(register FTS* fts)
 				fts->state = FTS_children_return;
 				goto note;
 			}
-			/*FALLTHROUGH*/
+			/* FALLTHROUGH */
 
 		case FTS_children_resume:
 
@@ -1158,7 +1158,7 @@ fts_read(register FTS* fts)
 				fts->todo = fts->top;
 				fts->top = 0;
 			}
-			/*FALLTHROUGH*/
+			/* FALLTHROUGH */
 
 		case FTS_popstack:
 
@@ -1168,7 +1168,7 @@ fts_read(register FTS* fts)
 
 			fts->nd = 0;
 			f = fts->current;
-			/*FALLTHROUGH*/
+			/* FALLTHROUGH */
 
 		case FTS_popstack_resume:
 

--- a/src/lib/libast/misc/glob.c
+++ b/src/lib/libast/misc/glob.c
@@ -380,6 +380,7 @@ again:
 		case '(':
 			if (!(gp->gl_flags & GLOB_AUGMENTED))
 				continue;
+			/* FALLTHROUGH */
 		case '*':
 		case '?':
 			meta = MATCH_META;

--- a/src/lib/libast/misc/magic.c
+++ b/src/lib/libast/misc/magic.c
@@ -550,7 +550,7 @@ ckmagic(register Magic_t* mp, const char* file, char* buf, char* end, struct sta
 		case '|':
 			if (mp->keep[level] > 1)
 				goto checknest;
-			/*FALLTHROUGH*/
+			/* FALLTHROUGH */
 		default:
 			if (!mp->keep[level])
 			{
@@ -678,7 +678,7 @@ ckmagic(register Magic_t* mp, const char* file, char* buf, char* end, struct sta
 		case 'e':
 			if (!(p = getdata(mp, num, 0)))
 				goto next;
-			/*FALLTHROUGH*/
+			/* FALLTHROUGH */
 		case 'E':
 			if (!ep->value.sub)
 				goto next;
@@ -714,7 +714,7 @@ ckmagic(register Magic_t* mp, const char* file, char* buf, char* end, struct sta
 		case 'm':
 			if (!(p = getdata(mp, num, 0)))
 				goto next;
-			/*FALLTHROUGH*/
+			/* FALLTHROUGH */
 		case 'M':
 		case 'S':
 		checkstr:
@@ -1356,7 +1356,7 @@ cklang(register Magic_t* mp, const char* file, char* buf, char* end, struct stat
 						mp->mime = "application/x-cc";
 						break;
 					}
-					/*FALLTHROUGH*/
+					/* FALLTHROUGH */
 				case 'y':
 				case 'Y':
 					t1 = "yacc ";
@@ -1462,13 +1462,16 @@ cklang(register Magic_t* mp, const char* file, char* buf, char* end, struct stat
 			case 4:
 				if (b < e && (*b++ & 0xc0) != 0x80)
 					break;
+				/* FALLTHROUGH */
 			case 3:
 				if (b < e && (*b++ & 0xc0) != 0x80)
 					break;
+				/* FALLTHROUGH */
 			case 2:
 				if (b < e && (*b++ & 0xc0) != 0x80)
 					break;
 				n = 1;
+				/* FALLTHROUGH */
 			case 0:
 				if (b >= e)
 				{
@@ -1803,7 +1806,7 @@ load(register Magic_t* mp, char* file, register Sfio_t* fp)
 					ep->nest = '1';
 				}
 			}
-			/*FALLTHROUGH*/
+			/* FALLTHROUGH */
 		case '+':
 		case '&':
 		case '|':
@@ -1812,7 +1815,7 @@ load(register Magic_t* mp, char* file, register Sfio_t* fp)
 		default:
 			if ((mp->flags & MAGIC_VERBOSE) && !isalpha(*p) && mp->disc->errorf)
 				(*mp->disc->errorf)(mp, mp->disc, 1, "`%c': invalid line continuation operator", *p);
-			/*FALLTHROUGH*/
+			/* FALLTHROUGH */
 		case '*':
 		case '0': case '1': case '2': case '3': case '4':
 		case '5': case '6': case '7': case '8': case '9':

--- a/src/lib/libast/misc/optget.c
+++ b/src/lib/libast/misc/optget.c
@@ -2516,7 +2516,7 @@ opthelp(const char* oopts, const char* what)
 		for (q = o; q < e; q++)
 			if (!(q->flags & OPT_ignore) && !streq(q->catalog, o->catalog))
 				o = q;
-		/*FALLTHROUGH*/
+		/* FALLTHROUGH */
 	case STYLE_posix:
 		sfputc(mp, '\f');
 		break;

--- a/src/lib/libast/misc/procopen.c
+++ b/src/lib/libast/misc/procopen.c
@@ -869,7 +869,7 @@ sfsync(sfstderr);
 				proc->wfd = poi[1];
 				close(poi[0]);
 #endif
-				/*FALLTHROUGH*/
+				/* FALLTHROUGH */
 			case 1:
 				proc->rfd = pio[0];
 				close(pio[1]);

--- a/src/lib/libast/misc/recstr.c
+++ b/src/lib/libast/misc/recstr.c
@@ -69,7 +69,7 @@ recstr(register const char* s, char** e)
 	case 'f':
 	case 'F':
 		while (*++s == ' ' || *s == '\t' || *s == ',');
-		/*FALLTHROUGH*/
+		/* FALLTHROUGH */
 	case '+':
 	case '0': case '1': case '2': case '3': case '4':
 	case '5': case '6': case '7': case '8': case '9':

--- a/src/lib/libast/path/pathcanon.c
+++ b/src/lib/libast/path/pathcanon.c
@@ -87,7 +87,7 @@ pathcanon_20100601(char* path, size_t size, int flags)
 			break;
 		case 0:
 			s--;
-			/*FALLTHROUGH*/
+			/* FALLTHROUGH */
 		case '/':
 			while (*s == '/') s++;
 			switch (dots)

--- a/src/lib/libast/port/astlicense.c
+++ b/src/lib/libast/port/astlicense.c
@@ -753,7 +753,7 @@ astlicense(char* p, int size, char* file, char* options, int cc1, int cc2, int c
 							break;
 						case -1:
 							c = SPECIAL;
-							/*FALLTHROUGH*/
+							/* FALLTHROUGH */
 						default:
 							notice.type = c;
 							notice.item[CLASS].data = lic[lic[c].quote].data;

--- a/src/lib/libast/port/astquery.c
+++ b/src/lib/libast/port/astquery.c
@@ -89,7 +89,7 @@ astquery(int quit, const char* format, ...)
 		{
 		case EOF:
 			n = c;
-			/*FALLTHROUGH*/
+			/* FALLTHROUGH */
 		case '\n':
 			switch (n)
 			{

--- a/src/lib/libast/port/mc.c
+++ b/src/lib/libast/port/mc.c
@@ -171,7 +171,7 @@ mcfind(const char* locale, const char* catalog, int category, int nls, char* pat
 						p += sizeof(lc_messages) - 1;
 						goto case_C;
 					}
-					/*FALLTHROUGH*/
+					/* FALLTHROUGH */
 				default:
 					if (s < e)
 						*s++ = c;

--- a/src/lib/libast/regex/regcomp.c
+++ b/src/lib/libast/regex/regcomp.c
@@ -775,7 +775,7 @@ magic(register Cenv_t* env, register int c, int escaped)
 					env->token.len += ep - sp;
 					return n;
 				}
-				/*FALLTHROUGH*/
+				/* FALLTHROUGH */
 			case T_BACK+8:
 			case T_BACK+9:
 				if (env->type == SRE || c == T_BACK && !(env->flags & (REG_LENIENT|REG_REGEXP)))
@@ -2102,7 +2102,7 @@ grp(Cenv_t* env, int parno)
 					env->error = REG_BADRPT;
 					return 0;
 				}
-				/*FALLTHROUGH*/
+				/* FALLTHROUGH */
 			case 0:
 			case T_CLOSE:
 				x = 0;
@@ -2177,7 +2177,7 @@ grp(Cenv_t* env, int parno)
 			case 'X':
 				if (typ >= 0 || env->type == ERE && (env->flags & REG_CLASS_ESCAPE))
 					break; /* PCRE_EXTRA */
-				/*FALLTHROUGH*/
+				/* FALLTHROUGH */
 			case 'A':
 				env->flags &= ~(REG_AUGMENTED|REG_EXTENDED|REG_LITERAL|REG_REGEXP|REG_SHELL|REG_LEFT|REG_RIGHT);
 				env->flags |= REG_AUGMENTED|REG_EXTENDED;
@@ -2291,7 +2291,7 @@ grp(Cenv_t* env, int parno)
 				return 0;
 			case 'D':
 				x = REX_NEST_delimiter;
-				/*FALLTHROUGH*/
+				/* FALLTHROUGH */
 			delimiter:
 				if ((i = chr(env, &esc)) < 0)
 					goto invalid;
@@ -2317,7 +2317,7 @@ grp(Cenv_t* env, int parno)
 				continue;
 			case 'Q':
 				x = REX_NEST_quote;
-				/*FALLTHROUGH*/
+				/* FALLTHROUGH */
 			quote:
 				if ((i = chr(env, &esc)) < 0)
 					goto invalid;
@@ -2512,7 +2512,7 @@ grp(Cenv_t* env, int parno)
 			env->paren[c]->re.group.back = 1;
 			return rep(env, node(env, REX_BACK, c, 0, 0), 0, 0);
 		}
-		/*FALLTHROUGH*/
+		/* FALLTHROUGH */
 	default:
 		env->error = REG_BADRPT;
 		return 0;
@@ -3182,7 +3182,7 @@ special(Cenv_t* env, regex_t* p)
 			e = e->re.group.expr.rex;
 			if (e->type != REX_DOT)
 				return 0;
-			/*FALLTHROUGH*/
+			/* FALLTHROUGH */
 		case REX_DOT:
 			if (e->lo == 0 && e->hi == RE_DUP_INF)
 				break;

--- a/src/lib/libast/regex/regnexec.c
+++ b/src/lib/libast/regex/regnexec.c
@@ -770,7 +770,7 @@ nestmatch(register unsigned char* s, register unsigned char* e, const unsigned s
 					if (!--n)
 						return s;
 				}
-				/*FALLTHROUGH*/
+				/* FALLTHROUGH */
 			case REX_NEST_open:
 				if (c == co)
 				{
@@ -1444,7 +1444,7 @@ DEBUG_TEST(0x0200,(sfprintf(sfstdout,"AHA#%04d 0x%04x parse %s=>%s `%-.*s'\n", _
 							break;
 						case GOOD:
 							r = GOOD;
-							/*FALLTHROUGH*/
+							/* FALLTHROUGH */
 						default:
 							continue;
 						}

--- a/src/lib/libast/sfio/_sfputl.c
+++ b/src/lib/libast/sfio/_sfputl.c
@@ -66,12 +66,19 @@ Sflong_t	v;	/* the value to be written */
 	{	switch(n)
 		{
 		case 8 : *ps++ = *s++;
+			 /* FALLTHROUGH */
 		case 7 : *ps++ = *s++;
+			 /* FALLTHROUGH */
 		case 6 : *ps++ = *s++;
+			 /* FALLTHROUGH */
 		case 5 : *ps++ = *s++;
+			 /* FALLTHROUGH */
 		case 4 : *ps++ = *s++;
+			 /* FALLTHROUGH */
 		case 3 : *ps++ = *s++;
+			 /* FALLTHROUGH */
 		case 2 : *ps++ = *s++;
+			 /* FALLTHROUGH */
 		case 1 : *ps++ = *s++;
 		}
 		f->next = ps;

--- a/src/lib/libast/sfio/_sfputm.c
+++ b/src/lib/libast/sfio/_sfputm.c
@@ -62,12 +62,19 @@ Sfulong_t	m;	/* the max value of the range */
 	{	switch(n)
 		{
 		case 8 : *ps++ = *s++;
+			 /* FALLTHROUGH */
 		case 7 : *ps++ = *s++;
+			 /* FALLTHROUGH */
 		case 6 : *ps++ = *s++;
+			 /* FALLTHROUGH */
 		case 5 : *ps++ = *s++;
+			 /* FALLTHROUGH */
 		case 4 : *ps++ = *s++;
+			 /* FALLTHROUGH */
 		case 3 : *ps++ = *s++;
+			 /* FALLTHROUGH */
 		case 2 : *ps++ = *s++;
+			 /* FALLTHROUGH */
 		case 1 : *ps++ = *s++;
 		}
 		f->next = ps;

--- a/src/lib/libast/sfio/_sfputu.c
+++ b/src/lib/libast/sfio/_sfputu.c
@@ -59,12 +59,19 @@ Sfulong_t	v;	/* the unsigned value to be written */
 	{	switch(n)
 		{
 		case 8 : *ps++ = *s++;
+			 /* FALLTHROUGH */
 		case 7 : *ps++ = *s++;
+			 /* FALLTHROUGH */
 		case 6 : *ps++ = *s++;
+			 /* FALLTHROUGH */
 		case 5 : *ps++ = *s++;
+			 /* FALLTHROUGH */
 		case 4 : *ps++ = *s++;
+			 /* FALLTHROUGH */
 		case 3 : *ps++ = *s++;
+			 /* FALLTHROUGH */
 		case 2 : *ps++ = *s++;
+			 /* FALLTHROUGH */
 		case 1 : *ps++ = *s++;
 		}
 		f->next = ps;

--- a/src/lib/libast/sfio/sfhdr.h
+++ b/src/lib/libast/sfio/sfhdr.h
@@ -1132,24 +1132,36 @@ typedef struct _sftab_
 #define MEMCPY(to,fr,n) \
 	switch(n) \
 	{ default : memcpy((Void_t*)to,(Void_t*)fr,n); to += n; fr += n; break; \
-	  case  7 : *to++ = *fr++; \
-	  case  6 : *to++ = *fr++; \
-	  case  5 : *to++ = *fr++; \
-	  case  4 : *to++ = *fr++; \
-	  case  3 : *to++ = *fr++; \
-	  case  2 : *to++ = *fr++; \
-	  case  1 : *to++ = *fr++; \
+	  case  7 : *to++ = *fr++;	\
+		/* FALLTHROUGH */	\
+	  case  6 : *to++ = *fr++;	\
+		/* FALLTHROUGH */	\
+	  case  5 : *to++ = *fr++;	\
+		/* FALLTHROUGH */	\
+	  case  4 : *to++ = *fr++;	\
+		/* FALLTHROUGH */	\
+	  case  3 : *to++ = *fr++;	\
+		/* FALLTHROUGH */	\
+	  case  2 : *to++ = *fr++;	\
+		/* FALLTHROUGH */	\
+	  case  1 : *to++ = *fr++;	\
 	}
 #define MEMSET(s,c,n) \
 	switch(n) \
 	{ default : memset((Void_t*)s,(int)c,n); s += n; break; \
-	  case  7 : *s++ = c; \
-	  case  6 : *s++ = c; \
-	  case  5 : *s++ = c; \
-	  case  4 : *s++ = c; \
-	  case  3 : *s++ = c; \
-	  case  2 : *s++ = c; \
-	  case  1 : *s++ = c; \
+	  case  7 : *s++ = c;		\
+		    /* FALLTHROUGH */	\
+	  case  6 : *s++ = c;		\
+		    /* FALLTHROUGH */	\
+	  case  5 : *s++ = c;		\
+		    /* FALLTHROUGH */	\
+	  case  4 : *s++ = c;		\
+		    /* FALLTHROUGH */	\
+	  case  3 : *s++ = c;		\
+		    /* FALLTHROUGH */	\
+	  case  2 : *s++ = c;		\
+		    /* FALLTHROUGH */	\
+	  case  1 : *s++ = c;		\
 	}
 
 _BEGIN_EXTERNS_

--- a/src/lib/libast/sfio/sfmode.c
+++ b/src/lib/libast/sfio/sfmode.c
@@ -537,7 +537,7 @@ reg int		local;	/* a local call */
 
 			break;
 		}
-		/* fall thru */
+		/* FALLTHROUGH */
 
 	case SF_READ: /* switching to SF_WRITE */
 		if(wanted != SF_WRITE)

--- a/src/lib/libast/sfio/sfpurge.c
+++ b/src/lib/libast/sfio/sfpurge.c
@@ -78,7 +78,7 @@ Sfio_t*	f;
 
 		/* 2-way pipe, must clear read buffer */
 		(void)_sfmode(f,SF_READ,1);
-		/* fall through */
+		/* FALLTHROUGH */
 	case SF_READ:
 		if(f->extent >= 0 && f->endb > f->next)
 		{	f->here -= f->endb-f->next;

--- a/src/lib/libast/sfio/sfrd.c
+++ b/src/lib/libast/sfio/sfrd.c
@@ -303,7 +303,7 @@ Sfdisc_t*	disc;
 		case SF_EDISC :
 			if(!local && !(f->flags&SF_STRING))
 				goto do_continue;
-			/* else fall thru */
+			/* FALLTHROUGH */
 		case SF_ESTACK :
 			SFMTXRETURN(f, -1);
 		}

--- a/src/lib/libast/sfio/sftable.c
+++ b/src/lib/libast/sfio/sftable.c
@@ -178,7 +178,8 @@ int		type;	/* >0: scanf, =0: printf, -1: internal	*/
 			}
 			else if(*form != '*')
 				goto loop_flags;
-			else	form += 1; /* drop thru below */
+			else	form += 1;
+			/* FALLTHROUGH */
 
 		case '*' :
 			form = sffmtint(form,&n);

--- a/src/lib/libast/sfio/sfvprintf.c
+++ b/src/lib/libast/sfio/sfvprintf.c
@@ -367,8 +367,9 @@ loop_fmt :
 			}
 			else if(*form != '*')
 				goto loop_flags;
-		do_star:
-			form += 1; /* fall thru for '*' */
+		do_star: /* for '*' */
+			form += 1;
+			/* FALLTHROUGH */
 		case '*' :
 			form = (*_Sffmtintf)(form,&n);
 			if(*form == '$')
@@ -674,6 +675,7 @@ loop_fmt :
 
 		case 'S':
 			flags = (flags & ~(SFFMT_TYPES|SFFMT_LDOUBLE)) | SFFMT_LONG;
+			/* FALLTHROUGH */
 		case 's':
 #if _has_multibyte && defined(mbwidth)
 			wc = (flags & SFFMT_LDOUBLE) && mbwide();
@@ -833,6 +835,7 @@ loop_fmt :
 
 		case 'C':
 			flags = (flags & ~(SFFMT_TYPES|SFFMT_LDOUBLE)) | SFFMT_LONG;
+			/* FALLTHROUGH */
 		case 'c':
 #if _has_multibyte && defined(mbwidth)
 			wc = (flags & SFFMT_LDOUBLE) && mbwide();
@@ -959,6 +962,7 @@ loop_fmt :
 			goto int_arg;
 		case 'X':
 			ssp = "0123456789ABCDEF";
+			/* FALLTHROUGH */
 		case 'x':
 			base = 16; n_s = 15; n = 4;
 			flags &= ~(SFFMT_SIGN|SFFMT_BLANK);
@@ -974,6 +978,7 @@ loop_fmt :
 			goto d_format;
 		case 'u':
 			flags &= ~(SFFMT_SIGN|SFFMT_BLANK);
+			/* FALLTHROUGH */
 		case 'd':
 		d_format:
 #if _PACKAGE_ast

--- a/src/lib/libast/sfio/sfwr.c
+++ b/src/lib/libast/sfio/sfwr.c
@@ -238,7 +238,7 @@ Sfdisc_t*	disc;
 		case SF_EDISC :
 			if(!local && !(f->flags&SF_STRING))
 				goto do_continue;
-			/* else fall thru */
+			/* FALLTHROUGH */
 		case SF_ESTACK :
 			SFMTXRETURN(f, (ssize_t)(-1));
 		}

--- a/src/lib/libast/string/fmtip6.c
+++ b/src/lib/libast/string/fmtip6.c
@@ -115,7 +115,7 @@ fmtip6(const unsigned char* addr, int bits)
 		case 14:
 			if (!a[14] && a[15] <= 15)
 				break;
-			/*FALLTHROUGH*/
+			/* FALLTHROUGH */
 		case 12:
 			s = dec(s, "::", a[12]);
 			s = dec(s, ".", a[13]);

--- a/src/lib/libast/string/fmtmatch.c
+++ b/src/lib/libast/string/fmtmatch.c
@@ -266,7 +266,7 @@ fmtmatch(const char* as)
 		case '$':
 			if (e = !*s)
 				break;
-			/*FALLTHROUGH*/
+			/* FALLTHROUGH */
 		default:
 			*t++ = c;
 			continue;

--- a/src/lib/libast/string/fmtre.c
+++ b/src/lib/libast/string/fmtre.c
@@ -129,7 +129,7 @@ fmtre(const char* as)
 				end = 0;
 				break;
 			}
-			/*FALLTHROUGH*/
+			/* FALLTHROUGH */
 		case '?':
 		case '+':
 		case '@':
@@ -210,7 +210,7 @@ fmtre(const char* as)
 		logical:
 			if (!*s || *s == ')')
 				return 0;
-			/*FALLTHROUGH*/
+			/* FALLTHROUGH */
 		default:
 			*t++ = c;
 			continue;

--- a/src/lib/libast/string/strelapsed.c
+++ b/src/lib/libast/string/strelapsed.c
@@ -105,7 +105,7 @@ strelapsed(register const char* s, char** e, int n)
 			break;
 		case '-':
 			p = 1;
-			/*FALLTHROUGH*/
+			/* FALLTHROUGH */
 		case 'd':
 			v *= 24 * 60 * 60;
 			break;

--- a/src/lib/libast/string/strperm.c
+++ b/src/lib/libast/string/strperm.c
@@ -86,13 +86,13 @@ strperm(const char* aexpr, char** e, register int perm)
 					c = '=';
 				}
 				expr--;
-				/*FALLTHROUGH*/
+				/* FALLTHROUGH */
 			case '=':
 				if (who)
 					perm &= ~who;
 				else
 					perm = 0;
-				/*FALLTHROUGH*/
+				/* FALLTHROUGH */
 			case '+':
 			case '|':
 			case '-':
@@ -112,7 +112,7 @@ strperm(const char* aexpr, char** e, register int perm)
 					case 'X':
 						if (!S_ISDIR(perm) && !(perm & (S_IXUSR|S_IXGRP|S_IXOTH)))
 							continue;
-						/*FALLTHROUGH*/
+						/* FALLTHROUGH */
 					case 'x':
 						typ |= S_IXUSR|S_IXGRP|S_IXOTH;
 						continue;
@@ -165,7 +165,7 @@ strperm(const char* aexpr, char** e, register int perm)
 								perm &= ~who;
 							else
 								perm = 0;
-							/*FALLTHROUGH*/
+							/* FALLTHROUGH */
 						case '+':
 						case '|':
 							perm |= typ;
@@ -230,7 +230,7 @@ strperm(const char* aexpr, char** e, register int perm)
 						}
 						if (c)
 							break;
-						/*FALLTHROUGH*/
+						/* FALLTHROUGH */
 					default:
 						if (c < '0' || c > '7')
 						{

--- a/src/lib/libast/string/tok.c
+++ b/src/lib/libast/string/tok.c
@@ -156,12 +156,12 @@ tokread(char* u)
 				else if (!p->flg)
 					p->flg = FLG_NEWLINE;
 			}
-			/*FALLTHROUGH*/
+			/* FALLTHROUGH */
 		case ' ':
 		case '\t':
 			if (q)
 				break;
-			/*FALLTHROUGH*/
+			/* FALLTHROUGH */
 		case 0:
 			if (s == --r)
 			{

--- a/src/lib/libast/string/wc2utf8.c
+++ b/src/lib/libast/string/wc2utf8.c
@@ -62,11 +62,15 @@ wc2utf8(register char* s, register uint32_t w)
 			*s++ = ops[i].prefix | (w >> ops[i].shift);
 			switch (ops[i].shift)
 			{
-			case 30:	*s++ = 0x80 | ((w >> 24) & 0x3f);
-			case 24:	*s++ = 0x80 | ((w >> 18) & 0x3f);
-			case 18:	*s++ = 0x80 | ((w >> 12) & 0x3f);
-			case 12:	*s++ = 0x80 | ((w >>  6) & 0x3f);
-			case  6:	*s++ = 0x80 | (w & 0x3f);
+			case 30: *s++ = 0x80 | ((w >> 24) & 0x3f);
+				 /* FALLTHROUGH */
+			case 24: *s++ = 0x80 | ((w >> 18) & 0x3f);
+				 /* FALLTHROUGH */
+			case 18: *s++ = 0x80 | ((w >> 12) & 0x3f);
+				 /* FALLTHROUGH */
+			case 12: *s++ = 0x80 | ((w >>  6) & 0x3f);
+				 /* FALLTHROUGH */
+			case  6: *s++ = 0x80 | (w & 0x3f);
 			}
 			return s - b;
 		}

--- a/src/lib/libast/tm/tmlocale.c
+++ b/src/lib/libast/tm/tmlocale.c
@@ -217,7 +217,7 @@ word2posix(register char* f, register char* w, int alternate)
 			{
 			case 1:
 				p = '-';
-				/*FALLTHROUGH*/
+				/* FALLTHROUGH */
 			case 2:
 				c = 'd';
 				break;
@@ -234,7 +234,7 @@ word2posix(register char* f, register char* w, int alternate)
 			{
 			case 1:
 				p = '-';
-				/*FALLTHROUGH*/
+				/* FALLTHROUGH */
 			default:
 				c = 'I';
 				break;
@@ -245,7 +245,7 @@ word2posix(register char* f, register char* w, int alternate)
 			{
 			case 1:
 				p = '-';
-				/*FALLTHROUGH*/
+				/* FALLTHROUGH */
 			default:
 				c = 'H';
 				break;
@@ -256,7 +256,7 @@ word2posix(register char* f, register char* w, int alternate)
 			{
 			case 1:
 				p = '-';
-				/*FALLTHROUGH*/
+				/* FALLTHROUGH */
 			case 2:
 				c = 'm';
 				break;
@@ -273,7 +273,7 @@ word2posix(register char* f, register char* w, int alternate)
 			{
 			case 1:
 				p = '-';
-				/*FALLTHROUGH*/
+				/* FALLTHROUGH */
 			default:
 				c = 'M';
 				break;
@@ -284,7 +284,7 @@ word2posix(register char* f, register char* w, int alternate)
 			{
 			case 1:
 				p = '-';
-				/*FALLTHROUGH*/
+				/* FALLTHROUGH */
 			default:
 				c = 'S';
 				break;
@@ -295,7 +295,7 @@ word2posix(register char* f, register char* w, int alternate)
 			{
 			case 1:
 				p = '-';
-				/*FALLTHROUGH*/
+				/* FALLTHROUGH */
 			case 2:
 				c = 'y';
 				break;

--- a/src/lib/libast/tm/tmxdate.c
+++ b/src/lib/libast/tm/tmxdate.c
@@ -325,7 +325,7 @@ tmxdate(register const char* s, char** e, Time_t now)
 				case 'm':
 					if (!m)
 						m = 1;
-					/*FALLTHROUGH*/
+					/* FALLTHROUGH */
 				case 'M':
 					switch (*(s + 1))
 					{
@@ -403,7 +403,7 @@ tmxdate(register const char* s, char** e, Time_t now)
 				case 'S':
 				case 's':
 					m = 2;
-					/*FALLTHROUGH*/
+					/* FALLTHROUGH */
 				case ' ':
 				case '_':
 				case '\n':
@@ -1243,7 +1243,7 @@ tmxdate(register const char* s, char** e, Time_t now)
 							set |= state & (EXACT|LAST|NEXT|THIS);
 							continue;
 						}
-						/*FALLTHROUGH*/
+						/* FALLTHROUGH */
 					case TM_FINAL:
 						state |= HOLD|THIS|FINAL;
 						set &= ~(EXACT|LAST|NEXT|THIS);
@@ -1264,7 +1264,7 @@ tmxdate(register const char* s, char** e, Time_t now)
 					case TM_ORDINAL:
 						j += TM_ORDINALS - TM_ORDINAL;
 						message((-1, "AHA#%d j=%d", __LINE__, j));
-						/*FALLTHROUGH*/
+						/* FALLTHROUGH */
 					case TM_ORDINALS:
 						n = j - TM_ORDINALS + 1;
 						message((-1, "AHA#%d n=%d", __LINE__, n));
@@ -1300,7 +1300,7 @@ tmxdate(register const char* s, char** e, Time_t now)
 						continue;
 					case TM_DAY_ABBREV:
 						j += TM_DAY - TM_DAY_ABBREV;
-						/*FALLTHROUGH*/
+						/* FALLTHROUGH */
 					case TM_DAY:
 					case TM_PARTS:
 					case TM_HOURS:
@@ -1330,7 +1330,7 @@ tmxdate(register const char* s, char** e, Time_t now)
 								set &= ~(EXACT|LAST|NEXT|THIS);
 								set |= state & (EXACT|LAST|NEXT|THIS);
 							}
-						/*FALLTHROUGH*/
+						/* FALLTHROUGH */
 					case TM_DAYS:
 						message((-1, "AHA#%d n=%d j=%d f=%d state=" FFMT, __LINE__, n, j, f, FLAGS(state)));
 						if (n == -1)
@@ -1494,7 +1494,7 @@ tmxdate(register const char* s, char** e, Time_t now)
 						continue;
 					case TM_MONTH_ABBREV:
 						j += TM_MONTH - TM_MONTH_ABBREV;
-						/*FALLTHROUGH*/
+						/* FALLTHROUGH */
 					case TM_MONTH:
 						if (state & MONTH)
 							goto done;

--- a/src/lib/libast/tm/tmxfmt.c
+++ b/src/lib/libast/tm/tmxfmt.c
@@ -177,7 +177,7 @@ tmxfmt(char* buf, size_t len, const char* format, Time_t t)
 					pad = c;
 					continue;
 				}
-				/*FALLTHROUGH*/
+				/* FALLTHROUGH */
 			case '1':
 			case '2':
 			case '3':
@@ -191,7 +191,7 @@ tmxfmt(char* buf, size_t len, const char* format, Time_t t)
 				{
 				case 0:
 					parts++;
-					/*FALLTHROUGH*/
+					/* FALLTHROUGH */
 				case 1:
 					width = width * 10 + (c - '0');
 					break;

--- a/src/lib/libast/tm/tmxscan.c
+++ b/src/lib/libast/tm/tmxscan.c
@@ -253,7 +253,7 @@ scan(register const char* s, char** e, const char* format, char** f, Time_t t, l
 			case 'd':
 				if (pedantic && !isdigit(*s))
 					goto next;
-				/*FALLTHROUGH*/
+				/* FALLTHROUGH */
 			case 'e':
 				NUMBER(2, 1, 31);
 				set.mday = n;
@@ -301,7 +301,7 @@ scan(register const char* s, char** e, const char* format, char** f, Time_t t, l
 						s++;
 					continue;
 				}
-				/*FALLTHROUGH*/
+				/* FALLTHROUGH */
 			case 't':
 				while (isspace(*s))
 					s++;
@@ -384,6 +384,7 @@ scan(register const char* s, char** e, const char* format, char** f, Time_t t, l
 					u = 0;
 				if (d == 'q')
 					continue;
+				/* FALLTHROUGH */
 			case 'z':
 				if ((zp = tmzone(s, &u, u, &m)))
 				{

--- a/src/lib/libast/tm/tmzone.c
+++ b/src/lib/libast/tm/tmzone.c
@@ -92,10 +92,10 @@ tmzone(register const char* name, char** end, const char* type, int* dst)
 		{
 		case 'C':
 			d += 15;
-			/*FALLTHROUGH*/
+			/* FALLTHROUGH */
 		case 'B':
 			d += 15;
-			/*FALLTHROUGH*/
+			/* FALLTHROUGH */
 		case 'A':
 			d += 15;
 			e++;

--- a/src/lib/libcmd/cp.c
+++ b/src/lib/libcmd/cp.c
@@ -361,7 +361,7 @@ visit(State_t* state, register FTSENT* ent)
 			error(2, "%s: cannot search directory", ent->fts_path);
 			fts_set(NiL, ent, FTS_SKIP);
 
-			/*FALLTHROUGH*/
+			/* FALLTHROUGH */
 		case FTS_D:
 			if (state->directory)
 				memcpy(state->path + state->postsiz, base, len);
@@ -520,7 +520,7 @@ visit(State_t* state, register FTSENT* ent)
 				sfprintf(state->tmp, "%s.%s%d%s", state->path, state->suffix, v + 1, state->suffix);
 				goto backup;
 			}
-			/*FALLTHROUGH*/
+			/* FALLTHROUGH */
 		case BAK_simple:
 			sfprintf(state->tmp, "%s%s", state->path, state->suffix);
 		backup:
@@ -564,7 +564,7 @@ visit(State_t* state, register FTSENT* ent)
 			else
 				break;
 		}
-		/*FALLTHROUGH*/
+		/* FALLTHROUGH */
 	case CP:
 		if (S_ISLNK(ent->fts_statp->st_mode))
 		{

--- a/src/lib/libcmd/cut.c
+++ b/src/lib/libcmd/cut.c
@@ -165,7 +165,7 @@ cutinit(int mode, char* str, Delim_t* wdelim, Delim_t* ldelim, size_t reclen)
 		case '\t':
 			while(*cp==' ' || *cp=='\t')
 				cp++;
-			/*FALLTHROUGH*/
+			/* FALLTHROUGH */
 		case 0:
 		case ',':
 			if(range)

--- a/src/lib/libcmd/head.c
+++ b/src/lib/libcmd/head.c
@@ -87,7 +87,7 @@ b_head(int argc, register char** argv, Shbltin_t* context)
 		{
 		case 'c':
 			delim = -1;
-			/*FALLTHROUGH*/
+			/* FALLTHROUGH */
 		case 'n':
 			if (opt_info.offset && argv[opt_info.index][opt_info.offset] == 'c')
 			{

--- a/src/lib/libcmd/join.c
+++ b/src/lib/libcmd/join.c
@@ -348,7 +348,7 @@ getrec(Join_t* jp, int index, int discard)
 						cp = tp;
 						break;
 					}
-					/*FALLTHROUGH*/
+					/* FALLTHROUGH */
 				default:
 					goto next;
 				}
@@ -866,7 +866,7 @@ b_join(int argc, char** argv, Shbltin_t* context)
 				jp->file[0].field = (int)(opt_info.num-1);
 				n = '2';
 			}
-			/*FALLTHROUGH*/
+			/* FALLTHROUGH */
  		case '1':
 		case '2':
 			if (opt_info.num <=0)
@@ -875,7 +875,7 @@ b_join(int argc, char** argv, Shbltin_t* context)
 			continue;
 		case 'v':
 			jp->outmode &= ~C_COMMON;
-			/*FALLTHROUGH*/
+			/* FALLTHROUGH */
 		case 'a':
 			if (opt_info.num!=1 && opt_info.num!=2)
 				error(2,"%s: file number must be 1 or 2", opt_info.name);

--- a/src/lib/libcmd/rm.c
+++ b/src/lib/libcmd/rm.c
@@ -198,7 +198,7 @@ rm(State_t* state, register FTSENT* ent)
 		}
 		else if (ent->fts_info == FTS_D)
 			break;
-		/*FALLTHROUGH*/
+		/* FALLTHROUGH */
 	case FTS_DP:
 		if (isempty(ent) || state->directory)
 		{
@@ -223,7 +223,7 @@ rm(State_t* state, register FTSENT* ent)
 							fts_set(NiL, ent, FTS_AGAIN);
 							break;
 						}
-						/*FALLTHROUGH*/
+						/* FALLTHROUGH */
 					default:
 						nonempty(ent);
 						if (!state->force)

--- a/src/lib/libcmd/stty.c
+++ b/src/lib/libcmd/stty.c
@@ -936,7 +936,7 @@ b_stty(int argc, char** argv, Shbltin_t* context)
 				}
 				continue;
 			}
-			/*FALLTHROUGH*/
+			/* FALLTHROUGH */
 		case ':':
 			if (!opt_info.offset)
 				error(2, "%s", opt_info.arg);

--- a/src/lib/libcmd/tail.c
+++ b/src/lib/libcmd/tail.c
@@ -462,7 +462,7 @@ b_tail(int argc, char** argv, Shbltin_t* context)
 				t = opt_info.arg;
 				goto suffix;
 			}
-			/*FALLTHROUGH*/
+			/* FALLTHROUGH */
 		case 'n':
 			flags |= COUNT;
 			if (s = opt_info.arg)


### PR DESCRIPTION
This pull request adds `/* FALLTHROUGH */` comments to fix many GCC warnings when compiling with `-Wimplicit-fallthrough` (some usage of `break` was also added, see below). Additionally, the existing fallthrough comments have been changed for consistency.

src/cmd/ksh93/bltins/misc.c,
src/cmd/ksh93/sh/lex.c,
src/cmd/ksh93/sh/path.c,
src/cmd/ksh93/sh/subshell.c,
src/cmd/ksh93/sh/xec.c:
- Some breaks were placed after `errormsg`, `sh_syntax` and `exscript` calls to fix additional fallthrough warnings (those functions don't return, which makes `break` better than a fallthrough comment). In these scenarios ksh2020 used `__builtin_unreachable()`, which could be a better option since that allows the GCC and Clang to optimize the code more effectively. Such a change is outside of this commit's scope, but it could be a future change worth considering.