### PR TITLE
Fix FreeBSD timezone name determination again

### DIFF
--- a/src/cmd/ksh93/tests/builtins.sh
+++ b/src/cmd/ksh93/tests/builtins.sh
@@ -844,6 +844,7 @@ unset foo
 [[ $(printf '%(%k)T') == $(printf '%(%_H)T') ]] || err_exit 'date format %k is not the same as %_H'
 [[ $(printf '%(%f)T') == $(printf '%(%Y.%m.%d-%H:%M:%S)T') ]] || err_exit 'date format %f is not the same as %Y.%m.%d-%H:%M:%S'
 [[ $(printf '%(%q)T') == $(printf '%(%Qz)T') ]] && err_exit 'date format %q is the same as %Qz'
+[[ $(printf '%(%Z)T') == $(date '+%Z') ]] || err_exit "date format %Z is incorrect (expected $(date '+%Z'), got $(printf '%(%Z)T'))"
 
 # Test manually specified blank and zero padding with 'printf  %T'
 (

--- a/src/lib/libast/tm/tminit.c
+++ b/src/lib/libast/tm/tminit.c
@@ -248,10 +248,6 @@ tmlocal(void)
 			environ[0] = e;
 	}
 #endif
-#if _dat_tzname
-	local.standard = strdup(tzname[0]);
-	local.daylight = strdup(tzname[1]);
-#endif
 	tmlocale();
 
 	/*
@@ -296,10 +292,8 @@ tmlocal(void)
 		 * POSIX
 		 */
 
-		if (!local.standard)
-			local.standard = strdup(tzname[0]);
-		if (!local.daylight)
-			local.daylight = strdup(tzname[1]);
+		local.standard = strdup(tzname[0]);
+		local.daylight = strdup(tzname[1]);
 	}
 	else
 #endif


### PR DESCRIPTION
src/lib/libast/tm/tminit.c:
- Commit 9f43f8d1, in addition to backporting fixes from ksh93v-, also backported this bug (see #6):  
```sh
$ printf '%(%Z)T\n' now
PPT  # Should be PDT
```
This pull request reapplies the ksh2020 bugfix to fix the `%Z` time format again.

src/cmd/ksh93/tests/builtins.sh:
- Add a regression test so this bug (hopefully) isn't backported from  ksh93v- again.