### PR TITLE
Fix locale test failures on OpenBSD

### DIFF
--- a/src/cmd/ksh93/tests/variables.sh
+++ b/src/cmd/ksh93/tests/variables.sh
@@ -750,9 +750,8 @@ Errors=$?  # ensure error count survives subshell
 	do	nameref r=$v
 		unset $v
 		[[ $r ]] && err_exit "unset $v failed -- expected '', got '$r'"
-		# Test disabled: some system libraries do not verify the locale, so no diagnostic is printed.
-		#d=$($SHELL -c "$v=$x" 2>&1)
-		#[[ $d ]] || err_exit "$v=$x failed -- expected locale diagnostic"
+		d=$($SHELL -c "$v=$x" 2>&1)
+		[[ $d ]] || err_exit "$v=$x failed -- expected locale diagnostic"
 		{ g=$( r=$x; print -- $r ); } 2>/dev/null
 		[[ $g == '' ]] || err_exit "$v=$x failed -- expected '', got '$g'"
 		{ g=$( r=C; r=$x; print -- $r ); } 2>/dev/null

--- a/src/cmd/ksh93/tests/variables.sh
+++ b/src/cmd/ksh93/tests/variables.sh
@@ -736,26 +736,15 @@ unset r v x
 )
 Errors=$?  # ensure error count survives subshell
 (
-	errmsg=$({ LANG=bad_LOCALE; } 2>&1)
-
 	# $x must be an unknown locale.
-	case "$(uname)" in
-	OpenBSD)
-		# "x" acts as a known alias of "C", but "x.x" is unknown (see
-		# https://man.openbsd.org/setlocale). For worse, "locale -a" doesn't
-		# list "x", so "locale -a | grep -q '^x$'" doesn't work.
-		x=x.x ;;
-	*)
-		# Most systems agree that "x" is an unknown locale.
-		# The error output from locale(1) is redirected because it will complain
-		# about C.UTF-8 on Linux (which is a ksh-specific locale).
-		if locale -a 2> /dev/null | grep -q '^x$'
-		then	# Someone added "x" using localedef(1)?
-			warning "skipping test: 'x' is a known locale"
-			exit $Errors
-		else	x=x
-		fi ;;
-	esac
+	for x in x x.b@d xx_XX xx_XX.b@d
+	do	errmsg=$({ LANG=$x; } 2>&1)
+		[[ -n $errmsg ]] && break
+	done
+	if	[[ -z $errmsg ]]
+	then	warning "C library does not seem to verify locales: skipping LC_* tests"
+		exit $Errors
+	fi
 
 	for v in LC_ALL LC_CTYPE LC_MESSAGES LC_COLLATE LC_NUMERIC
 	do	nameref r=$v


### PR DESCRIPTION
On OpenBSD `x` functions as an alias for the `C` locale, which causes regression tests that assume `x` is an invalid locale to fail. Additionally, the regression tests didn't account for if `x` is manually added by the user as a valid locale. The fixes for both of these problems were backported from ksh2020: https://github.com/att/ast/pull/495. To avoid regression test failures on OpenBSD, an invalid `x.x` locale is now used instead of `x`. To fix the other problem, `locale -a` is used to look for an `x` locale that would cause the regression tests to fail.