### PR TITLE
Introduce usage of `__builtin_unreachable` and `noreturn`

### DIFF
--- a/src/cmd/ksh93/bltins/alarm.c
+++ b/src/cmd/ksh93/bltins/alarm.c
@@ -256,19 +256,25 @@ int	b_alarm(int argc,char *argv[],Shbltin_t *context)
 		break;
 	    case '?':
 		errormsg(SH_DICT,ERROR_usage(2), "%s", opt_info.arg);
-		break;
+		UNREACHABLE();
 	}
 	argc -= opt_info.index;
 	argv += opt_info.index;
 	if(error_info.errors)
+	{
 		errormsg(SH_DICT,ERROR_usage(2),optusage((char*)0));
+		UNREACHABLE();
+	}
 	if(argc==0)
 	{
 		print_alarms(shp->st.timetrap);
 		return(0);
 	}
 	if(argc!=2)
+	{
 		errormsg(SH_DICT,ERROR_usage(2),optusage((char*)0));
+		UNREACHABLE();
+	}
 	np = nv_open(argv[0],shp->var_tree,NV_NOARRAY|NV_VARNAME|NV_NOASSIGN);
 	if(!nv_isnull(np))
 		nv_unset(np);

--- a/src/cmd/ksh93/bltins/cd_pwd.c
+++ b/src/cmd/ksh93/bltins/cd_pwd.c
@@ -60,7 +60,10 @@ int	b_cd(int argc, char *argv[],Shbltin_t *context)
 	char *oldpwd;
 	Namval_t *opwdnod, *pwdnod;
 	if(sh_isoption(SH_RESTRICTED))
+	{
 		errormsg(SH_DICT,ERROR_exit(1),e_restricted+4);
+		UNREACHABLE();
+	}
 	while((rval = optget(argv,sh_optcd))) switch(rval)
 	{
 		case 'L':
@@ -74,13 +77,16 @@ int	b_cd(int argc, char *argv[],Shbltin_t *context)
 			break;
 		case '?':
 			errormsg(SH_DICT,ERROR_usage(2), "%s", opt_info.arg);
-			break;
+			UNREACHABLE();
 	}
 	argv += opt_info.index;
 	argc -= opt_info.index;
 	dir =  argv[0];
 	if(error_info.errors>0 || argc >2)
+	{
 		errormsg(SH_DICT,ERROR_usage(2),"%s",optusage((char*)0));
+		UNREACHABLE();
+	}
 	oldpwd = path_pwd(shp,0);
 	opwdnod = (shp->subshell?sh_assignok(OLDPWDNOD,1):OLDPWDNOD); 
 	pwdnod = (shp->subshell?sh_assignok(PWDNOD,1):PWDNOD); 
@@ -91,7 +97,10 @@ int	b_cd(int argc, char *argv[],Shbltin_t *context)
 	else if(*dir == '-' && dir[1]==0)
 		dir = nv_getval(opwdnod);
 	if(!dir || *dir==0)
+	{
 		errormsg(SH_DICT,ERROR_exit(1),argc==2?e_subst+4:e_direct);
+		UNREACHABLE();
+	}
 	/*
 	 * If sh_subshell() in subshell.c cannot use fchdir(2) to restore the PWD using a saved file descriptor,
 	 * we must fork any virtual subshell now to avoid the possibility of ending up in the wrong PWD on exit.
@@ -186,6 +195,7 @@ int	b_cd(int argc, char *argv[],Shbltin_t *context)
 		if(saverrno)
 			errno = saverrno;
 		errormsg(SH_DICT,ERROR_system(1),"%s:",dir);
+		UNREACHABLE();
 	}
 success:
 	if(dir == nv_getval(opwdnod) || argc==2)
@@ -197,6 +207,7 @@ success:
 		{
 			dir = stakptr(PATH_OFFSET);
 			errormsg(SH_DICT,ERROR_system(1),"%s:",dir);
+			UNREACHABLE();
 		}
 		stakseek(dir-stakptr(0));
 	}
@@ -240,12 +251,18 @@ int	b_pwd(int argc, char *argv[],Shbltin_t *context)
 			break;
 		case '?':
 			errormsg(SH_DICT,ERROR_usage(2), "%s", opt_info.arg);
-			break;
+			UNREACHABLE();
 	}
 	if(error_info.errors)
+	{
 		errormsg(SH_DICT,ERROR_usage(2),"%s",optusage((char*)0));
+		UNREACHABLE();
+	}
 	if(*(cp = path_pwd(shp,0)) != '/')
+	{
 		errormsg(SH_DICT,ERROR_system(1), e_pwd);
+		UNREACHABLE();
+	}
 	if(flag)
 	{
 		cp = strcpy(stakseek(strlen(cp)+PATH_MAX),cp);

--- a/src/cmd/ksh93/bltins/cflow.c
+++ b/src/cmd/ksh93/bltins/cflow.c
@@ -61,7 +61,10 @@ int	b_return(register int n, register char *argv[],Shbltin_t *context)
 	}
 done:
 	if(error_info.errors)
+	{
 		errormsg(SH_DICT,ERROR_usage(2),"%s",optusage((char*)0));
+		UNREACHABLE();
+	}
 	pp->mode = (**argv=='e'?SH_JMPEXIT:SH_JMPFUN);
 	argv += opt_info.index;
 	n = (arg = *argv) ? (int)strtol(arg, (char**)0, 10) : shp->savexit;
@@ -98,14 +101,20 @@ int	b_break(register int n, register char *argv[],Shbltin_t *context)
 		return(2);
 	}
 	if(error_info.errors)
+	{
 		errormsg(SH_DICT,ERROR_usage(2),"%s",optusage((char*)0));
+		UNREACHABLE();
+	}
 	argv += opt_info.index;
 	n=1;
 	if(arg= *argv)
 	{
 		n = (int)strtol(arg,&arg,10);
 		if(n<=0 || *arg)
+		{
 			errormsg(SH_DICT,ERROR_exit(1),e_nolabels,*argv);
+			UNREACHABLE();
+		}
 	}
 	if(shp->st.loopcnt)
 	{

--- a/src/cmd/ksh93/bltins/enum.c
+++ b/src/cmd/ksh93/bltins/enum.c
@@ -150,6 +150,7 @@ static void put_enum(Namval_t* np,const char *val,int flags,Namfun_t *fp)
 		i++;
 	}
 	error(ERROR_exit(1), "%s: invalid value %s",nv_name(np),val);
+	UNREACHABLE();
 }
 
 static char* get_enum(register Namval_t* np, Namfun_t *fp)
@@ -196,8 +197,8 @@ int b_enum(int argc, char** argv, Shbltin_t *context)
 			iflag = 'i';
 			continue;
 		case '?':
-			error(ERROR_USAGE|4, "%s", opt_info.arg);
-			break;
+			error(ERROR_usage(2), "%s", opt_info.arg);
+			UNREACHABLE();
 		case ':':
 			error(2, "%s", opt_info.arg);
 			break;
@@ -213,7 +214,10 @@ int b_enum(int argc, char** argv, Shbltin_t *context)
 	while(cp = *argv++)
 	{
 		if(!(np = nv_open(cp, (void*)0, NV_VARNAME|NV_NOADD))  || !(ap=nv_arrayptr(np)) || ap->fun || (sz=ap->nelem&(((1L<<ARRAY_BITS)-1))) < 2)
-			error(ERROR_exit(1), "%s must name an array  containing at least two elements",cp);
+		{
+			error(ERROR_exit(1), "%s must name an array containing at least two elements",cp);
+			UNREACHABLE();
+		}
 		n = staktell();
 		sfprintf(stkstd,"%s.%s%c",NV_CLASS,np->nvname,0);
 		tp = nv_open(stakptr(n), shp->var_tree, NV_VARNAME);

--- a/src/cmd/ksh93/bltins/getopts.c
+++ b/src/cmd/ksh93/bltins/getopts.c
@@ -84,12 +84,15 @@ int	b_getopts(int argc,char *argv[],Shbltin_t *context)
 		break;
 	    case '?':
 		errormsg(SH_DICT,ERROR_usage(2), "%s", opt_info.arg);
-		break;
+		UNREACHABLE();
 	}
 	argv += opt_info.index;
 	argc -= opt_info.index;
 	if(error_info.errors || argc<2)
+	{
 		errormsg(SH_DICT,ERROR_usage(2), "%s", optusage((char*)0));
+		UNREACHABLE();
+	}
 	error_info.context->flags |= ERROR_SILENT;
 	error_info.id = options;
 	options = argv[0];
@@ -126,7 +129,10 @@ int	b_getopts(int argc,char *argv[],Shbltin_t *context)
 	{
 	    case '?':
 		if(mode==0)
+		{
 			errormsg(SH_DICT,ERROR_usage(2), "%s", opt_info.arg);
+			UNREACHABLE();
+		}
 		opt_info.option[1] = '?';
 		/* FALL THRU */
 	    case ':':
@@ -160,7 +166,10 @@ int	b_getopts(int argc,char *argv[],Shbltin_t *context)
 			optget(com,options);
 			opt_info.index = flag;
 			if(!mode && strchr(options,' '))
+			{
 				errormsg(SH_DICT,ERROR_usage(2), "%s", optusage((char*)0));
+				UNREACHABLE();
+			}
 		}
 		opt_info.arg = 0;
 		options = value;

--- a/src/cmd/ksh93/bltins/hist.c
+++ b/src/cmd/ksh93/bltins/hist.c
@@ -57,7 +57,10 @@ int	b_hist(int argc,char *argv[], Shbltin_t *context)
 	Histloc_t location;
 	NOT_USED(argc);
 	if(!sh_histinit((void*)shp))
+	{
 		errormsg(SH_DICT,ERROR_system(1),e_histopen);
+		UNREACHABLE();
+	}
 	hp = shp->gd->hist_ptr;
 	while((flag = optget(argv,sh_opthist))) switch(flag)
 	{
@@ -94,10 +97,13 @@ int	b_hist(int argc,char *argv[], Shbltin_t *context)
 		break;
 	    case '?':
 		errormsg(SH_DICT,ERROR_usage(2), "%s", opt_info.arg);
-		break;
+		UNREACHABLE();
 	}
 	if(error_info.errors)
+	{
 		errormsg(SH_DICT,ERROR_usage(2),"%s",optusage((char*)0));
+		UNREACHABLE();
+	}
 	argv += (opt_info.index-1);
 #if SHOPT_HISTEXPAND
 	if(pflag)
@@ -146,7 +152,10 @@ int	b_hist(int argc,char *argv[], Shbltin_t *context)
 		/* search for last line starting with string */
 		location = hist_find(hp,argv[1],hist_max(hp)-1,0,-1);
 		if((range[++flag] = location.hist_command) < 0)
+		{
 			errormsg(SH_DICT,ERROR_exit(1),e_found,argv[1]);
+			UNREACHABLE();
+		}
 		argv++;
 	}
 	if(flag <0)
@@ -173,9 +182,15 @@ int	b_hist(int argc,char *argv[], Shbltin_t *context)
 		range[1] = flag;
 	/* check for valid ranges */
 	if(range[1]<index2 || range[0]>=flag)
+	{
 		errormsg(SH_DICT,ERROR_exit(1),e_badrange,range[0],range[1]);
+		UNREACHABLE();
+	}
 	if(edit && *edit=='-' && range[0]!=range[1])
+	{
 		errormsg(SH_DICT,ERROR_exit(1),e_eneedsarg);
+		UNREACHABLE();
+	}
 	/* now list commands from range[flag] to range[1-flag] */
 	incr = 1;
 	flag = rflag>0;
@@ -189,9 +204,15 @@ int	b_hist(int argc,char *argv[], Shbltin_t *context)
 	else
 	{
 		if(!(fname=pathtmp(NIL(char*),0,0,NIL(int*))))
+		{
 			errormsg(SH_DICT,ERROR_exit(1),e_create,"");
+			UNREACHABLE();
+		}
 		if((fdo=open(fname,O_CREAT|O_RDWR,S_IRUSR|S_IWUSR)) < 0)
+		{
 			errormsg(SH_DICT,ERROR_system(1),e_create,fname);
+			UNREACHABLE();
+		}
 		outfile= sfnew(NIL(Sfio_t*),shp->outbuff,IOBSIZE,fdo,SF_WRITE);
 		arg = "\n";
 		nflag++;
@@ -218,7 +239,10 @@ int	b_hist(int argc,char *argv[], Shbltin_t *context)
 	{
 		arg = (char*)e_defedit;
 		if(*arg!='/')
+		{
 			errormsg(SH_DICT,ERROR_exit(1),"ed not found set FCEDIT");
+			UNREACHABLE();
+		}
 	}
 	if(*arg != '-')
 	{
@@ -245,7 +269,10 @@ int	b_hist(int argc,char *argv[], Shbltin_t *context)
 		Sfio_t *iop = sfnew(NIL(Sfio_t*),buff,IOBSIZE,fdo,SF_READ);
 		/* read in and run the command */
 		if(shp->hist_depth++ > HIST_RECURSE)
+		{
 			errormsg(SH_DICT,ERROR_exit(1),e_toodeep,"history");
+			UNREACHABLE();
+		}
 		sh_eval(iop,1);
 		shp->hist_depth--;
 	}
@@ -283,7 +310,10 @@ static void hist_subst(const char *command,int fd,char *replace)
 	string[c] = 0;
 	*newp++ =  0;
 	if((sp=sh_substitute(string,replace,newp))==0)
+	{
 		errormsg(SH_DICT,ERROR_exit(1),e_subst,command);
+		UNREACHABLE();
+	}
 	*(newp-1) =  '=';
 	sh_eval(sfopen(NIL(Sfio_t*),sp,"s"),1);
 }

--- a/src/cmd/ksh93/bltins/misc.c
+++ b/src/cmd/ksh93/bltins/misc.c
@@ -113,18 +113,27 @@ int    b_exec(int argc,char *argv[], Shbltin_t *context)
 		return(2);
 	}
 	if(error_info.errors)
+	{
 		errormsg(SH_DICT,ERROR_usage(2),"%s",optusage((char*)0));
+		UNREACHABLE();
+	}
 	if(*argv[0]=='r' && argv[opt_info.index])  /* 'redirect' supports no args */
+	{
 		errormsg(SH_DICT,ERROR_exit(2),"%s: %s",e_badsyntax,argv[opt_info.index]);
+		UNREACHABLE();
+	}
 	argv += opt_info.index;
 	if(!*argv)
 		return(0);
 
 	/* from here on, it's 'exec' with args, so we're replacing the shell */
 	if(sh_isoption(SH_RESTRICTED))
+	{
 		errormsg(SH_DICT,ERROR_exit(1),e_restricted,argv[0]);
+		UNREACHABLE();
+	}
 	else
-        {
+	{
 		register struct argnod *arg=logdata.sh->envlist;
 		register Namval_t* np;
 		register char *cp;
@@ -175,11 +184,14 @@ int    b_let(int argc,char *argv[],Shbltin_t *context)
 		break;
 	    case '?':
 		errormsg(SH_DICT,ERROR_usage(2), "%s", opt_info.arg);
-		break;
+		UNREACHABLE();
 	}
 	argv += opt_info.index;
 	if(error_info.errors || !*argv)
+	{
 		errormsg(SH_DICT,ERROR_usage(2),"%s",optusage((char*)0));
+		UNREACHABLE();
+	}
 	while(arg= *argv++)
 		r = !sh_arith(shp,arg);
 	return(r);
@@ -200,7 +212,10 @@ int    b_eval(int argc,char *argv[], Shbltin_t *context)
 		return(2);
 	}
 	if(error_info.errors)
+	{
 		errormsg(SH_DICT,ERROR_usage(2),"%s",optusage((char*)0));
+		UNREACHABLE();
+	}
 	argv += opt_info.index;
 	if(*argv && **argv)
 	{
@@ -236,9 +251,15 @@ int    b_dot_cmd(register int n,char *argv[],Shbltin_t *context)
 	argv += opt_info.index;
 	script = *argv;
 	if(error_info.errors || !script)
+	{
 		errormsg(SH_DICT,ERROR_usage(2),"%s",optusage((char*)0));
+		UNREACHABLE();
+	}
 	if(shp->dot_depth+1 > DOTMAX)
+	{
 		errormsg(SH_DICT,ERROR_exit(1),e_toodeep,script);
+		UNREACHABLE();
+	}
 	if(!(np=shp->posix_fun))
 	{
 		/* check for KornShell style function first */
@@ -254,7 +275,10 @@ int    b_dot_cmd(register int n,char *argv[],Shbltin_t *context)
 						np = 0;
 				}
 				else
+				{
 					errormsg(SH_DICT,ERROR_exit(1),e_found,script);
+					UNREACHABLE();
+				}
 			}
 		}
 		else
@@ -262,7 +286,10 @@ int    b_dot_cmd(register int n,char *argv[],Shbltin_t *context)
 		if(!np)
 		{
 			if((fd=path_open(shp,script,path_get(shp,script))) < 0)
+			{
 				errormsg(SH_DICT,ERROR_system(1),e_open,script);
+				UNREACHABLE();
+			}
 			filename = path_fullname(shp,stkptr(shp->stk,PATH_OFFSET));
 		}
 	}
@@ -362,11 +389,17 @@ int    b_shift(register int n, register char *argv[], Shbltin_t *context)
 			return(2);
 	}
 	if(error_info.errors)
+	{
 		errormsg(SH_DICT,ERROR_usage(2),"%s",optusage((char*)0));
+		UNREACHABLE();
+	}
 	argv += opt_info.index;
 	n = ((arg= *argv)?(int)sh_arith(shp,arg):1);
 	if(n<0 || shp->st.dolc<n)
+	{
 		errormsg(SH_DICT,ERROR_exit(1),e_number,arg);
+		UNREACHABLE();
+	}
 	else
 	{
 		shp->st.dolv += n;
@@ -385,10 +418,13 @@ int    b_wait(int n,register char *argv[],Shbltin_t *context)
 			break;
 		case '?':
 			errormsg(SH_DICT,ERROR_usage(2), "%s",opt_info.arg);
-			break;
+			UNREACHABLE();
 	}
 	if(error_info.errors)
+	{
 		errormsg(SH_DICT,ERROR_usage(2),"%s",optusage((char*)0));
+		UNREACHABLE();
+	}
 	argv += opt_info.index;
 	job_bwait(argv);
 	return(shp->exitval);
@@ -416,20 +452,26 @@ int    b_bg(register int n,register char *argv[],Shbltin_t *context)
 		break;
 	    case '?':
 		errormsg(SH_DICT,ERROR_usage(2), "%s",opt_info.arg);
-		break;
+		UNREACHABLE();
 	}
 	if(error_info.errors)
+	{
 		errormsg(SH_DICT,ERROR_usage(2),"%s",optusage((char*)0));
+		UNREACHABLE();
+	}
 	argv += opt_info.index;
 	if(!sh_isstate(SH_MONITOR))
 	{
 		errormsg(SH_DICT,ERROR_exit(1),e_no_jctl);
-		return(1);
+		UNREACHABLE();
 	}
 	if(flag=='d' && *argv==0)
 		argv = (char**)0;
 	if(job_walk(sfstdout,job_switch,flag,argv))
+	{
 		errormsg(SH_DICT,ERROR_exit(1),e_no_job);
+		UNREACHABLE();
+	}
 	return(shp->exitval);
 }
 
@@ -453,15 +495,21 @@ int    b_jobs(register int n,char *argv[],Shbltin_t *context)
 		break;
 	    case '?':
 		errormsg(SH_DICT,ERROR_usage(2), "%s",opt_info.arg);
-		break;
+		UNREACHABLE();
 	}
 	argv += opt_info.index;
 	if(error_info.errors)
+	{
 		errormsg(SH_DICT,ERROR_usage(2),"%s",optusage((char*)0));
+		UNREACHABLE();
+	}
 	if(*argv==0)
 		argv = (char**)0;
 	if(job_walk(sfstdout,job_list,flag,argv))
+	{
 		errormsg(SH_DICT,ERROR_exit(1),e_no_job);
+		UNREACHABLE();
+	}
 	job_wait((pid_t)0);
 	return(shp->exitval);
 }
@@ -527,12 +575,16 @@ int	b_times(int argc, char *argv[], Shbltin_t *context)
 	    case ':':
 		errormsg(SH_DICT, 2, "%s", opt_info.arg);
 		errormsg(SH_DICT, ERROR_usage(2), "%s", optusage((char*)0));
+		UNREACHABLE();
 	    default:
 		errormsg(SH_DICT, ERROR_usage(0), "%s", opt_info.arg);
 		return(2);
 	}
 	if (argv[opt_info.index])
+	{
 		errormsg(SH_DICT, ERROR_exit(2), e_toomanyops);
+		UNREACHABLE();
+	}
 	/* Get & print the times */
 	print_cpu_times();
 	return(0);
@@ -555,21 +607,30 @@ int	b_universe(int argc, char *argv[],Shbltin_t *context)
 		break;
 	    case '?':
 		errormsg(SH_DICT,ERROR_usage(2), "%s",opt_info.arg);
-		break;
+		UNREACHABLE();
 	}
 	argv += opt_info.index;
 	argc -= opt_info.index;
 	if(error_info.errors || argc>1)
+	{
 		errormsg(SH_DICT,ERROR_usage(2),"%s",optusage((char*)0));
+		UNREACHABLE();
+	}
 	if(arg = argv[0])
 	{
 		if(!astconf("UNIVERSE",0,arg))
+		{
 			errormsg(SH_DICT,ERROR_exit(1), e_badname,arg);
+			UNREACHABLE();
+		}
 	}
 	else
 	{
 		if(!(arg=astconf("UNIVERSE",0,0)))
+		{
 			errormsg(SH_DICT,ERROR_exit(1),e_nouniverse);
+			UNREACHABLE();
+		}
 		else
 			sfputr(sfstdout,arg,'\n');
 	}

--- a/src/cmd/ksh93/bltins/misc.c
+++ b/src/cmd/ksh93/bltins/misc.c
@@ -166,7 +166,6 @@ int    b_exec(int argc,char *argv[], Shbltin_t *context)
 		sh_sigreset(2);
 		sh_freeup(logdata.sh);
 		path_exec(logdata.sh,pname,argv,NIL(struct argnod*));
-		sh_done(logdata.sh,0);
         }
 	return(1);
 }

--- a/src/cmd/ksh93/bltins/mkservice.c
+++ b/src/cmd/ksh93/bltins/mkservice.c
@@ -421,13 +421,16 @@ int	b_mkservice(int argc, char** argv, Shbltin_t *context)
 			continue;
 		case '?':
 			error(ERROR_usage(2), opt_info.arg);
-			continue;
+			UNREACHABLE();
 		}
 		break;
 	}
 	argv += opt_info.index;
 	if (error_info.errors || !(var = *argv++) || !(path = *argv++) || *argv)
+	{
 		error(ERROR_usage(2), optusage(NiL));
+		UNREACHABLE();
+	}
 	sp = sh_newof(0, Service_t, 1, 0);
 	sp->acceptf = Accept;
 	sp->actionf = Action;
@@ -440,6 +443,7 @@ int	b_mkservice(int argc, char** argv, Shbltin_t *context)
 	{
 		free((void*)sp);
 		error(ERROR_exit(1), "%s: cannot start service", path);
+		UNREACHABLE();
 	}
 	if((sp->fd = fcntl(fd, F_DUPFD, 10))>=10)
 		close(fd);
@@ -472,13 +476,16 @@ int	b_eloop(int argc, char** argv, Shbltin_t *context)
 			continue;
 		case '?':
 			error(ERROR_usage(2), opt_info.arg);
-			continue;
+			UNREACHABLE();
 		}
 		break;
 	}
 	argv += opt_info.index;
 	if (error_info.errors  || *argv)
+	{
 		error(ERROR_usage(2), optusage(NiL));
+		UNREACHABLE();
+	}
 	while(1)
 	{
 		if(waitnotify(-1, timeout, 0)==0)

--- a/src/cmd/ksh93/bltins/print.c
+++ b/src/cmd/ksh93/bltins/print.c
@@ -214,7 +214,10 @@ int    b_print(int argc, char *argv[], Shbltin_t *context)
 		case 's':
 			/* print to history file */
 			if(!sh_histinit((void*)shp))
+			{
 				errormsg(SH_DICT,ERROR_system(1),e_history);
+				UNREACHABLE();
+			}
 			fd = sffileno(shp->gd->hist_ptr->histfp);
 			sh_onstate(SH_HISTORY);
 			sflag++;
@@ -266,13 +269,19 @@ int    b_print(int argc, char *argv[], Shbltin_t *context)
 			break;
 		case '?':
 			errormsg(SH_DICT,ERROR_usage(2), "%s", opt_info.arg);
-			break;
+			UNREACHABLE();
 	}
 	argv += opt_info.index;
 	if(error_info.errors || (argc<0 && !(format = *argv++)))
+	{
 		errormsg(SH_DICT,ERROR_usage(2),"%s",optusage((char*)0));
+		UNREACHABLE();
+	}
 	if(vflag && format)
+	{
 		errormsg(SH_DICT,ERROR_usage(2),"-%c and -f are mutually exclusive",vflag);
+		UNREACHABLE();
+	}
 skip:
 	if(format)
 		format = genformat(format);
@@ -293,6 +302,7 @@ skip2:
 		if(fd==1)
 			return(1);
 		errormsg(SH_DICT,ERROR_system(1),msg);
+		UNREACHABLE();
 	}
 	if(!(outfile=shp->sftable[fd]))
 	{
@@ -545,7 +555,10 @@ static ssize_t fmtbase64(Sfio_t *iop, char *string, int alt)
 	if(!np || nv_isnull(np))
 	{
 		if(sh_isoption(SH_NOUNSET))
+		{
 			errormsg(SH_DICT,ERROR_exit(1),e_notset,string);
+			UNREACHABLE();
+		}
 		return(0);
 	}
 	if(nv_isattr(np,NV_INTEGER))
@@ -755,7 +768,10 @@ static int extend(Sfio_t* sp, void* v, Sffmt_t* fe)
 			break;
 		default:
 			if(!strchr("DdXxoUu",format))
+			{
 				errormsg(SH_DICT,ERROR_exit(1),e_formspec,format);
+				UNREACHABLE();
+			}
 			fe->fmt = 'd';
 			value->ll = 0;
 			break;
@@ -931,7 +947,7 @@ static int extend(Sfio_t* sp, void* v, Sffmt_t* fe)
 			fe->fmt = 'd';
 			fe->size = sizeof(value->ll);
 			errormsg(SH_DICT,ERROR_exit(1),e_formspec,format);
-			break;
+			UNREACHABLE();
 		}
 		if (format == '.')
 			value->i = value->ll;
@@ -977,13 +993,19 @@ static int extend(Sfio_t* sp, void* v, Sffmt_t* fe)
 	case 'P':
 		s = fmtmatch(value->s);
 		if(!s || *s==0)
+		{
 			errormsg(SH_DICT,ERROR_exit(1),e_badregexp,value->s);
+			UNREACHABLE();
+		}
 		value->s = s;
 		break;
 	case 'R':
 		s = fmtre(value->s);
 		if(!s || *s==0)
+		{
 			errormsg(SH_DICT,ERROR_exit(1),e_badregexp,value->s);
+			UNREACHABLE();
+		}
 		value->s = s;
 		break;
 	case 'Q':

--- a/src/cmd/ksh93/bltins/read.c
+++ b/src/cmd/ksh93/bltins/read.c
@@ -109,7 +109,10 @@ int	b_read(int argc,char *argv[], Shbltin_t *context)
 		break;
 	    case 'p':
 		if((fd = shp->cpipe[0])<=0)
+		{
 			errormsg(SH_DICT,ERROR_exit(1),e_query);
+			UNREACHABLE();
+		}
 		break;
 	    case 'n': case 'N':
 		flags &= ((1<<D_FLAG)-1);
@@ -129,7 +132,10 @@ int	b_read(int argc,char *argv[], Shbltin_t *context)
 	    case 'u':
 		fd = (int)opt_info.num;
 		if(opt_info.num<0 || opt_info.num>INT_MAX || (fd>=shp->gd->lim.open_max && !sh_iovalidfd(shp,fd)))
+		{
 			errormsg(SH_DICT,ERROR_exit(1),e_file,opt_info.arg); /* reject invalid file descriptors */
+			UNREACHABLE();
+		}
 		if(sh_inuse(shp,fd))
 			fd = -1;
 		break;
@@ -141,15 +147,21 @@ int	b_read(int argc,char *argv[], Shbltin_t *context)
 		break;
 	    case '?':
 		errormsg(SH_DICT,ERROR_usage(2), "%s", opt_info.arg);
-		break;
+		UNREACHABLE();
 	}
 	argv += opt_info.index;
 	if(error_info.errors)
+	{
 		errormsg(SH_DICT,ERROR_usage(2), "%s", optusage((char*)0));
+		UNREACHABLE();
+	}
 	if(!((r=shp->fdstatus[fd])&IOREAD)  || !(r&(IOSEEK|IONOSEEK)))
 		r = sh_iocheckfd(shp,fd);
 	if(fd<0 || !(r&IOREAD))
+	{
 		errormsg(SH_DICT,ERROR_system(1),e_file+4);
+		UNREACHABLE();
+	}
 	/* look for prompt */
 	if((name = *argv) && (name=strchr(name,'?')) && (r&IOTTY))
 		r = strlen(name++);
@@ -485,7 +497,10 @@ int sh_readline(register Shell_t *shp,char **names, volatile int fd, int flags,s
 	{
 		c = sfvalue(iop)+1;
 		if(!sferror(iop) && sfgetc(iop) >=0)
+		{
 			errormsg(SH_DICT,ERROR_exit(1),e_overlimit,"line length");
+			UNREACHABLE();
+		}
 	}
 	if(timeslot)
 		timerdel(timeslot);

--- a/src/cmd/ksh93/bltins/regress.c
+++ b/src/cmd/ksh93/bltins/regress.c
@@ -270,7 +270,7 @@ int b___regress__(int argc, char** argv, Shbltin_t *context)
 		{
 		case '?':
 			errormsg(SH_DICT, ERROR_usage(2), "%s", opt_info.arg);
-			break;
+			UNREACHABLE();
 		case ':':
 			errormsg(SH_DICT, 2, "%s", opt_info.arg);
 			break;
@@ -332,7 +332,10 @@ int b___regress__(int argc, char** argv, Shbltin_t *context)
 		break;
 	}
 	if (error_info.errors || *(argv + opt_info.index))
+	{
 		errormsg(SH_DICT, ERROR_usage(2), "%s", optusage(NiL));
+		UNREACHABLE();
+	}
 	return 0;
 }
 

--- a/src/cmd/ksh93/bltins/sleep.c
+++ b/src/cmd/ksh93/bltins/sleep.c
@@ -60,10 +60,13 @@ int	b_sleep(register int argc,char *argv[],Shbltin_t *context)
 			break;
 		case '?':
 			errormsg(SH_DICT,ERROR_usage(2), "%s", opt_info.arg);
-			break;
+			UNREACHABLE();
 	}
 	if(error_info.errors)
+	{
 		errormsg(SH_DICT, ERROR_usage(2), "%s", optusage(NULL));
+		UNREACHABLE();
+	}
 	argv += opt_info.index;
 	if(cp = *argv)
 	{
@@ -93,16 +96,25 @@ int	b_sleep(register int argc,char *argv[],Shbltin_t *context)
 					ns = tmxdate(pp, &last, now);
 			}
 			if(*last)
+			{
 				errormsg(SH_DICT,ERROR_exit(1),e_number,*argv);
+				UNREACHABLE();
+			}
 			d = ns - now;
 			d /= TMX_RESOLUTION;
 		}
 skip:
 		if(argv[1])
+		{
 			errormsg(SH_DICT,ERROR_exit(1),e_oneoperand);
+			UNREACHABLE();
+		}
 	}
 	else if(!sflag)
+	{
 		errormsg(SH_DICT,ERROR_exit(1),e_oneoperand);
+		UNREACHABLE();
+	}
 	if(d > .10)
 	{
 		time(&tloc);

--- a/src/cmd/ksh93/bltins/test.c
+++ b/src/cmd/ksh93/bltins/test.c
@@ -141,7 +141,10 @@ int b_test(int argc, char *argv[],Shbltin_t *context)
 	{
 		cp = argv[--argc];
 		if(!c_eq(cp, ']'))
+		{
 			errormsg(SH_DICT,ERROR_exit(2),e_missing,"']'");
+			UNREACHABLE();
+		}
 	}
 	if(argc <= 1)
 	{
@@ -192,6 +195,7 @@ int b_test(int argc, char *argv[],Shbltin_t *context)
 					goto done;
 				}
 				errormsg(SH_DICT,ERROR_exit(2),e_badop,cp);
+				UNREACHABLE();
 			}
 			exitval = (test_binop(tdata.sh,op,argv[1],argv[3])^(argc!=5));
 			goto done;
@@ -218,7 +222,7 @@ int b_test(int argc, char *argv[],Shbltin_t *context)
 					av[2] = 0;
 					optget(av,sh_opttest);
 					errormsg(SH_DICT,ERROR_usage(2), "%s",opt_info.arg);
-					return(2);
+					UNREACHABLE();
 				}
 				break;
 			}
@@ -276,6 +280,7 @@ static int expr(struct test *tp,register int flag)
 		if(flag==0)
 			break;
 		errormsg(SH_DICT,ERROR_exit(2),e_badsyntax);
+		UNREACHABLE();
 	}
 	return(r);
 }
@@ -290,6 +295,7 @@ static char *nxtarg(struct test *tp,int mt)
 			return(0);
 		}
 		errormsg(SH_DICT,ERROR_exit(2),e_argument);
+		UNREACHABLE();
 	}
 	return(tp->av[tp->ap++]);
 }
@@ -308,7 +314,10 @@ static int e3(struct test *tp)
 		op = expr(tp,1);
 		cp = nxtarg(tp,0);
 		if(!cp || !c_eq(cp, ')'))
+		{
 			errormsg(SH_DICT,ERROR_exit(2),e_missing,"')'");
+			UNREACHABLE();
+		}
 		return(op);
 	}
 	cp = nxtarg(tp,1);
@@ -340,6 +349,7 @@ static int e3(struct test *tp)
 			if(op==0 || !strchr(test_opchars+10,op))
 				return(1);
 			errormsg(SH_DICT,ERROR_exit(2),e_argument);
+			UNREACHABLE();
 		}
 		if(strchr(test_opchars,op))
 			return(test_unop(tp->sh,op,cp));
@@ -354,7 +364,10 @@ skip:
 	if(!(op&TEST_BINOP))
 		cp = nxtarg(tp,0);
 	if(!op)
+	{
 		errormsg(SH_DICT,ERROR_exit(2),e_badop,binop);
+		UNREACHABLE();
+	}
 	if(op==TEST_AND || op==TEST_OR)
 		tp->ap--;
 	return(test_binop(tp->sh,op,arg,cp));
@@ -490,8 +503,7 @@ int test_unop(Shell_t *shp,register int op,register const char *arg)
 		static char a[3] = "-?";
 		a[1]= op;
 		errormsg(SH_DICT,ERROR_exit(2),e_badop,a);
-		/* NOTREACHED */
-		return(0);
+		UNREACHABLE();
 	    }
 	}
 }
@@ -552,8 +564,7 @@ int test_binop(Shell_t *shp,register int op,const char *left,const char *right)
 			errormsg(SH_DICT, ERROR_exit(2), op==TEST_END ? e_badop : e_unsupported_op, shtab_testops[i].sh_name);
 		}
 	}
-	/* NOTREACHED */
-	return(0);
+	UNREACHABLE();
 }
 
 /*

--- a/src/cmd/ksh93/bltins/trap.c
+++ b/src/cmd/ksh93/bltins/trap.c
@@ -60,11 +60,13 @@ int	b_trap(int argc,char *argv[],Shbltin_t *context)
 	    case '?':
 		errormsg(SH_DICT,ERROR_usage(0), "%s", opt_info.arg);
 		return(2);
-		break;
 	}
 	argv += opt_info.index;
 	if(error_info.errors)
+	{
 		errormsg(SH_DICT,ERROR_usage(2),"%s", optusage((char*)0));
+		UNREACHABLE();
+	}
 	if(arg = *argv)
 	{
 		char *action = arg;
@@ -91,7 +93,10 @@ int	b_trap(int argc,char *argv[],Shbltin_t *context)
 				}
 			}
 			if(!argv[0])
+			{
 				errormsg(SH_DICT,ERROR_exit(1),e_condition);
+				UNREACHABLE();
+			}
 		}
 		while(arg = *argv++)
 		{
@@ -216,14 +221,17 @@ int	b_kill(int argc,char *argv[],Shbltin_t *context)
 			break;
 		case '?':
 			errormsg(SH_DICT,ERROR_usage(2), "%s", opt_info.arg);
-			break;
+			UNREACHABLE();
 	}
 endopts:
 	argv += opt_info.index;
 	if(*argv && strcmp(*argv,"--")==0 && strcmp(*(argv-1),"--")!=0)
 		argv++;
 	if(error_info.errors || flag==(L_FLAG|S_FLAG) || (!(*argv) && !(flag&L_FLAG)))
+	{
 		errormsg(SH_DICT,ERROR_usage(2),"%s", optusage((char*)0));
+		UNREACHABLE();
+	}
 	/* just in case we send a kill -9 $$ */
 	sfsync(sfstderr);
 	if(flag&L_FLAG)
@@ -240,6 +248,7 @@ endopts:
 				{
 					shp->exitval = 2;
 					errormsg(SH_DICT,ERROR_exit(1),e_nosignal,signame);
+					UNREACHABLE();
 				}
 				sfprintf(sfstdout,"%d\n",sig);
 			}
@@ -249,7 +258,10 @@ endopts:
 	if(flag&S_FLAG)
 	{
 		if((sig=sig_number(shp,signame)) < 0 || sig > shp->gd->sigmax)
+		{
 			errormsg(SH_DICT,ERROR_exit(1),e_nosignal,signame);
+			UNREACHABLE();
+		}
 	}
 	if(job_walk(sfstdout,job_kill,sig,argv))
 		shp->exitval = 1;
@@ -272,16 +284,28 @@ int	b_suspend(int argc,char *argv[],Shbltin_t *context)
 			break;
 		case '?':
 			errormsg(SH_DICT,ERROR_usage(2), "%s", opt_info.arg);
-			break;
+			UNREACHABLE();
 	}
 	if(error_info.errors)	/* no options supported (except AST --man, etc.) */
+	{
 		errormsg(SH_DICT,ERROR_usage(2),"%s", optusage((char*)0));
+		UNREACHABLE();
+	}
 	if(argv[opt_info.index])	/* no operands supported */
+	{
 		errormsg(SH_DICT, ERROR_exit(2), e_toomanyops);
+		UNREACHABLE();
+	}
 	if(sh_isoption(SH_LOGIN_SHELL))
+	{
 		errormsg(SH_DICT, ERROR_exit(1), "cannot suspend a login shell");
+		UNREACHABLE();
+	}
 	if(kill(context->shp->gd->pid, SIGSTOP) != 0)
+	{
 		errormsg(SH_DICT, ERROR_exit(1), "could not signal main shell at PID %d", context->shp->gd->pid);
+		UNREACHABLE();
+	}
 	return(0);
 }
 #endif /* defined(JOBS) && defined(SIGSTOP) */

--- a/src/cmd/ksh93/bltins/typeset.c
+++ b/src/cmd/ksh93/bltins/typeset.c
@@ -107,7 +107,10 @@ int    b_readonly(int argc,char *argv[],Shbltin_t *context)
 			return(2);
 	}
 	if(error_info.errors)
+	{
 		errormsg(SH_DICT,ERROR_usage(2),optusage(NIL(char*)));
+		UNREACHABLE();
+	}
 	argv += (opt_info.index-1);
 	if(*command=='r')
 		flag = (NV_ASSIGN|NV_RDONLY|NV_VARNAME);
@@ -166,7 +169,10 @@ int    b_alias(int argc,register char *argv[],Shbltin_t *context)
 			return(2);
 		}
 		if(error_info.errors)
+		{
 			errormsg(SH_DICT,ERROR_usage(2),"%s",optusage(NIL(char*)));
+			UNREACHABLE();
+		}
 		argv += (opt_info.index-1);
 	}
 	/* 'alias -t', 'hash' */
@@ -222,7 +228,10 @@ int    b_typeset(int argc,register char *argv[],Shbltin_t *context)
 		else if(argv[0][0] == 'n')	/* <n>ameref == typeset -n */
 			new_argv[1] = "-n";
 		else
+		{
 			errormsg(SH_DICT, ERROR_exit(128), "internal error");
+			UNREACHABLE();
+		}
 		for (n = 1; n <= argc; n++)
 			new_argv[n + 1] = argv[n];
 		argc++;
@@ -304,7 +313,10 @@ int    b_typeset(int argc,register char *argv[],Shbltin_t *context)
 				if(tdata.argnum==0)
 					tdata.argnum = (int)opt_info.num;
 				if(tdata.argnum < 0)
+				{
 					errormsg(SH_DICT,ERROR_exit(1), e_badfield, tdata.argnum);
+					UNREACHABLE();
+				}
 				isadjust = 1;
 				if(n=='Z')
 					flag |= NV_ZFILL;
@@ -316,7 +328,10 @@ int    b_typeset(int argc,register char *argv[],Shbltin_t *context)
 				break;
 			case 'M':
 				if((tdata.wctname = opt_info.arg) && !nv_mapchar((Namval_t*)0,tdata.wctname))
+				{
 					errormsg(SH_DICT, ERROR_exit(1),e_unknownmap, tdata.wctname);
+					UNREACHABLE();
+				}
 				if(tdata.wctname && strcmp(tdata.wctname,e_tolower)==0)
 					flag |= NV_UTOL;
 				else
@@ -451,9 +466,15 @@ endargs:
 		flag |= NV_STATICF;
 	}
 	if(error_info.errors)
+	{
 		errormsg(SH_DICT,ERROR_usage(2),"%s", optusage(NIL(char*)));
+		UNREACHABLE();
+	}
 	if(sizeof(char*)<8 && tdata.argnum > SHRT_MAX)
+	{
 		errormsg(SH_DICT,ERROR_exit(2),"option argument cannot be greater than %d",SHRT_MAX);
+		UNREACHABLE();
+	}
 	if(isfloat)
 		flag |= NV_DOUBLE;
 	if(sflag)
@@ -495,7 +516,10 @@ endargs:
 #endif /* SHOPT_NAMESPACE */
 		stkseek(stkp,offset);
 		if(!tdata.tp)
+		{
 			errormsg(SH_DICT,ERROR_exit(1),"%s: unknown type",tdata.prefix);
+			UNREACHABLE();
+		}
 		else if(nv_isnull(tdata.tp))
 			nv_newtype(tdata.tp);
 		tdata.tp->nvenv = tdata.help;
@@ -511,7 +535,10 @@ endargs:
 	if(!tdata.sh->mktype)
 		tdata.help = 0;
 	if(tdata.aflag=='+' && (flag&(NV_ARRAY|NV_IARRAY|NV_COMVAR)) && argv[1])
+	{
 		errormsg(SH_DICT,ERROR_exit(1),e_nounattr);
+		UNREACHABLE();
+	}
 	return(setall(argv,flag,troot,&tdata));
 }
 
@@ -631,7 +658,10 @@ static int     setall(char **argv,register int flag,Dt_t *troot,struct tdata *tp
 				{
 					/* Function names cannot be special builtin */
 					if((np=nv_search(name,shp->bltin_tree,0)) && nv_isattr(np,BLT_SPC))
+					{
 						errormsg(SH_DICT,ERROR_exit(1),e_badfun,name);
+						UNREACHABLE();
+					}
 #if SHOPT_NAMESPACE
 					if(shp->namespace)
 						np = sh_fsearch(shp,name,NV_ADD|HASH_NOSCOPE);
@@ -704,7 +734,10 @@ static int     setall(char **argv,register int flag,Dt_t *troot,struct tdata *tp
 			if(nv_isnull(np) && !nv_isarray(np) && nv_isattr(np,NV_NOFREE))
 				nv_offattr(np,NV_NOFREE);
 			else if(tp->tp && !nv_isattr(np,NV_MINIMAL|NV_EXPORT) && (mp=(Namval_t*)np->nvenv) && (ap=nv_arrayptr(mp)) && (ap->nelem&ARRAY_TREE))
+			{
 				errormsg(SH_DICT,ERROR_exit(1),e_typecompat,nv_name(np));
+				UNREACHABLE();
+			}
 			else if((ap=nv_arrayptr(np)) && nv_aindex(np)>0 && ap->nelem==1 && nv_getval(np)==Empty)
 			{
 				ap->nelem++;
@@ -712,7 +745,10 @@ static int     setall(char **argv,register int flag,Dt_t *troot,struct tdata *tp
 				ap->nelem--;
 			}
 			else if(iarray && ap && ap->fun) 
+			{
 				errormsg(SH_DICT,ERROR_exit(1),"cannot change associative array %s to indexed array",nv_name(np));
+				UNREACHABLE();
+			}
 			else if( (iarray||(flag&NV_ARRAY)) && nv_isvtree(np) && !nv_type(np))
 				_nv_unset(np,NV_EXPORT);
 			if(tp->pflag)
@@ -803,7 +839,10 @@ static int     setall(char **argv,register int flag,Dt_t *troot,struct tdata *tp
 				Namfun_t *fp;
 				char  *cp;
 				if(!tp->wctname)
+				{
 					errormsg(SH_DICT,ERROR_exit(1),e_mapchararg,nv_name(np));
+					UNREACHABLE();
+				}
 				cp = (char*)nv_mapchar(np,0);
 				if(fp=nv_mapchar(np,tp->wctname))
 				{
@@ -827,7 +866,10 @@ static int     setall(char **argv,register int flag,Dt_t *troot,struct tdata *tp
 			if (tp->aflag == '-')
 			{
 				if((flag&NV_EXPORT) && (strchr(name,'.') || nv_isvtree(np)))
+				{
 					errormsg(SH_DICT,ERROR_exit(1),e_badexport,name);
+					UNREACHABLE();
+				}
 #if SHOPT_BSH
 				if(flag&NV_EXPORT)
 					nv_offattr(np,NV_IMPORT);
@@ -848,7 +890,10 @@ static int     setall(char **argv,register int flag,Dt_t *troot,struct tdata *tp
 			else
 			{
 				if((flag&NV_RDONLY) && (curflag&NV_RDONLY))
+				{
 					errormsg(SH_DICT,ERROR_exit(1),e_readonly,nv_name(np));
+					UNREACHABLE();
+				}
 				newflag = curflag & ~flag;
 			}
 			if (tp->aflag && (tp->argnum || (curflag!=newflag)))
@@ -1070,18 +1115,27 @@ int	b_builtin(int argc,char *argv[],Shbltin_t *context)
 		break;
 	    case '?':
 		errormsg(SH_DICT,ERROR_usage(2), "%s", opt_info.arg);
-		break;
+		UNREACHABLE();
 	}
 	argv += opt_info.index;
 	if(error_info.errors)
+	{
 		errormsg(SH_DICT,ERROR_usage(2),"%s", optusage(NIL(char*)));
+		UNREACHABLE();
+	}
 	if(arg || *argv)
 	{
 		if(sh_isoption(SH_RESTRICTED))
+		{
 			errormsg(SH_DICT,ERROR_exit(1),e_restricted,argv[-opt_info.index]);
+			UNREACHABLE();
+		}
 #if SHOPT_PFSH
 		if(sh_isoption(SH_PFSH))
+		{
 			errormsg(SH_DICT,ERROR_exit(1),e_pfsh,argv[-opt_info.index]);
+			UNREACHABLE();
+		}
 #endif
 		if(tdata.sh->subshell && !tdata.sh->subshare)
 			sh_subfork();
@@ -1242,7 +1296,10 @@ static int unall(int argc, char **argv, register Dt_t *troot, Shell_t* shp)
 	}
 	argv += opt_info.index;
 	if(error_info.errors || (*argv==0 &&!all))
+	{
 		errormsg(SH_DICT,ERROR_usage(2),"%s",optusage(NIL(char*)));
+		UNREACHABLE();
+	}
 	if(!troot)
 		return(1);
 	r = 0;

--- a/src/cmd/ksh93/bltins/ulimit.c
+++ b/src/cmd/ksh93/bltins/ulimit.c
@@ -44,7 +44,7 @@
 		NOT_USED(argv);
 		NOT_USED(context);
 		errormsg(SH_DICT,ERROR_exit(2),e_nosupport);
-		return(0);
+		UNREACHABLE();
 	}
 #else
 
@@ -106,7 +106,7 @@ int	b_ulimit(int argc,char *argv[],Shbltin_t *context)
 			break;
 		case '?':
 			errormsg(SH_DICT,ERROR_usage(2), "%s", opt_info.arg);
-			break;
+			UNREACHABLE();
 	}
 	opt_info.disc = 0;
 	/* default to -f */
@@ -121,7 +121,10 @@ int	b_ulimit(int argc,char *argv[],Shbltin_t *context)
 	/* only one option at a time for setting */
 	label = (hit&(hit-1));
 	if(error_info.errors || (limit && label) || argc>opt_info.index+1)
+	{
 		errormsg(SH_DICT,ERROR_usage(2),optusage((char*)0));
+		UNREACHABLE();
+	}
 	if(mode==0)
 		mode = (HARD|SOFT);
 	for(tp = shtab_limits; tp->option && hit; tp++,hit>>=1)
@@ -145,26 +148,41 @@ int	b_ulimit(int argc,char *argv[],Shbltin_t *context)
 				else if((i=strton(limit,&last,NiL,0))==INFINITY || *last)
 				{
 					if((i=sh_strnum(limit,&last,2))==INFINITY || *last)
+					{
 						errormsg(SH_DICT,ERROR_system(1),e_number,limit);
+						UNREACHABLE();
+					}
 					i *= unit;
 				}
 			}
 			if(nosupport)
+			{
 				errormsg(SH_DICT,ERROR_system(1),e_readonly,tp->name);
+				UNREACHABLE();
+			}
 			else
 			{
 #ifdef _lib_getrlimit
 				if(getrlimit(n,&rlp) <0)
+				{
 					errormsg(SH_DICT,ERROR_system(1),e_number,limit);
+					UNREACHABLE();
+				}
 				if(mode&HARD)
 					rlp.rlim_max = i;
 				if(mode&SOFT)
 					rlp.rlim_cur = i;
 				if(setrlimit(n,&rlp) <0)
+				{
 					errormsg(SH_DICT,ERROR_system(1),e_overlimit,limit);
+					UNREACHABLE();
+				}
 #else
 				if((i=vlimit(n,i)) < 0)
+				{
 					errormsg(SH_DICT,ERROR_system(1),e_number,limit);
+					UNREACHABLE();
+				}
 #endif /* _lib_getrlimit */
 			}
 		}
@@ -174,7 +192,10 @@ int	b_ulimit(int argc,char *argv[],Shbltin_t *context)
 			{
 #ifdef  _lib_getrlimit
 				if(getrlimit(n,&rlp) <0)
+				{
 					errormsg(SH_DICT,ERROR_system(1),e_number,limit);
+					UNREACHABLE();
+				}
 				if(mode&HARD)
 					i = rlp.rlim_max;
 				if(mode&SOFT)
@@ -185,7 +206,10 @@ int	b_ulimit(int argc,char *argv[],Shbltin_t *context)
 #   endif /* _lib_ulimit */
 				i = -1;
 				if((i=vlimit(n,i)) < 0)
+				{
 					errormsg(SH_DICT,ERROR_system(1),e_number,limit);
+					UNREACHABLE();
+				}
 #endif /* _lib_getrlimit */
 			}
 			if(label)

--- a/src/cmd/ksh93/bltins/umask.c
+++ b/src/cmd/ksh93/bltins/umask.c
@@ -53,10 +53,13 @@ int	b_umask(int argc,char *argv[],Shbltin_t *context)
 			break;
 		case '?':
 			errormsg(SH_DICT,ERROR_usage(2), "%s",opt_info.arg);
-			break;
+			UNREACHABLE();
 	}
 	if(error_info.errors)
+	{
 		errormsg(SH_DICT,ERROR_usage(2),"%s",optusage((char*)0));
+		UNREACHABLE();
+	}
 	argv += opt_info.index;
 	if(mask = *argv)
 	{
@@ -68,7 +71,10 @@ int	b_umask(int argc,char *argv[],Shbltin_t *context)
 				if (c>='0' && c<='7')	
 					flag = (flag<<3) + (c-'0');	
 				else
+				{
 					errormsg(SH_DICT,ERROR_exit(1),e_number,*argv);
+					UNREACHABLE();
+				}
 			}
 		}
 		else
@@ -80,6 +86,7 @@ int	b_umask(int argc,char *argv[],Shbltin_t *context)
 			{
 				umask(flag);
 				errormsg(SH_DICT,ERROR_exit(1),e_format,mask);
+				UNREACHABLE();
 			}
 			flag = (~c&0777);
 		}

--- a/src/cmd/ksh93/bltins/whence.c
+++ b/src/cmd/ksh93/bltins/whence.c
@@ -58,7 +58,10 @@ int	b_command(register int argc,char *argv[],Shbltin_t *context)
 	{
 	    case 'p':
 		if(sh_isoption(SH_RESTRICTED))
+		{
 			 errormsg(SH_DICT,ERROR_exit(1),e_restricted,"-p");
+			 UNREACHABLE();
+		}
 		sh_onstate(SH_DEFPATH);
 		break;
 	    case 'v':
@@ -79,7 +82,7 @@ int	b_command(register int argc,char *argv[],Shbltin_t *context)
 		if(argc==0)
 			return(0);
 		errormsg(SH_DICT,ERROR_usage(2), "%s", opt_info.arg);
-		break;
+		UNREACHABLE();
 	}
 	if(argc==0)
 	{
@@ -91,7 +94,10 @@ int	b_command(register int argc,char *argv[],Shbltin_t *context)
 	}
 	argv += opt_info.index;
 	if(error_info.errors || !*argv)
+	{
 		errormsg(SH_DICT,ERROR_usage(2),"%s", optusage((char*)0));
+		UNREACHABLE();
+	}
 	return(whence(shp,argv, flags));
 }
 
@@ -128,11 +134,14 @@ int	b_whence(int argc,char *argv[],Shbltin_t *context)
 		break;
 	    case '?':
 		errormsg(SH_DICT,ERROR_usage(2), "%s", opt_info.arg);
-		break;
+		UNREACHABLE();
 	}
 	argv += opt_info.index;
 	if(error_info.errors || !*argv)
+	{
 		errormsg(SH_DICT,ERROR_usage(2),optusage((char*)0));
+		UNREACHABLE();
+	}
 	return(whence(shp, argv, flags));
 }
 

--- a/src/cmd/ksh93/edit/vi.c
+++ b/src/cmd/ksh93/edit/vi.c
@@ -1055,8 +1055,7 @@ static int cntlmode(Vi_t *vp)
 		refresh(vp,CONTROL);
 		vp->repeat = 1;
 	}
-/* NOTREACHED */
-	return(0);
+	UNREACHABLE();
 }
 
 /*{	CURSOR( new_current_physical )

--- a/src/cmd/ksh93/edit/vi.c
+++ b/src/cmd/ksh93/edit/vi.c
@@ -1060,7 +1060,7 @@ static int cntlmode(Vi_t *vp)
 		refresh(vp,CONTROL);
 		vp->repeat = 1;
 	}
-	UNREACHABLE();
+	return(0);
 }
 
 /*{	CURSOR( new_current_physical )

--- a/src/cmd/ksh93/include/fault.h
+++ b/src/cmd/ksh93/include/fault.h
@@ -108,8 +108,8 @@ struct checkpt
 				)
 #define sh_popcontext(shp,bp)	(shp->jmplist=(bp)->prev, errorpop(&((bp)->err)))
 
+extern noreturn void 	sh_done(void*,int);
 extern void 	sh_fault(int);
-extern void 	sh_done(void*,int);
 extern void 	sh_sigclear(int);
 extern void 	sh_sigdone(void);
 extern void	sh_siginit(void*);

--- a/src/cmd/ksh93/include/path.h
+++ b/src/cmd/ksh93/include/path.h
@@ -82,7 +82,7 @@ extern Pathcomp_t 	*path_absolute(Shell_t*, const char*, Pathcomp_t*, int);
 extern char 		*path_basename(const char*);
 extern char 		*path_fullname(Shell_t*,const char*);
 extern int 		path_expand(Shell_t*,const char*, struct argnod**);
-extern void 		path_exec(Shell_t*,const char*,char*[],struct argnod*);
+extern noreturn void 	path_exec(Shell_t*,const char*,char*[],struct argnod*);
 extern pid_t		path_spawn(Shell_t*,const char*,char*[],char*[],Pathcomp_t*,int);
 #if defined(__EXPORT__) && defined(_BLD_DLL) && defined(_BLD_shell)
 #   define extern __EXPORT__

--- a/src/cmd/ksh93/include/path.h
+++ b/src/cmd/ksh93/include/path.h
@@ -82,7 +82,7 @@ extern Pathcomp_t 	*path_absolute(Shell_t*, const char*, Pathcomp_t*, int);
 extern char 		*path_basename(const char*);
 extern char 		*path_fullname(Shell_t*,const char*);
 extern int 		path_expand(Shell_t*,const char*, struct argnod**);
-extern noreturn void 	path_exec(Shell_t*,const char*,char*[],struct argnod*);
+extern void 		path_exec(Shell_t*,const char*,char*[],struct argnod*);
 extern pid_t		path_spawn(Shell_t*,const char*,char*[],char*[],Pathcomp_t*,int);
 #if defined(__EXPORT__) && defined(_BLD_DLL) && defined(_BLD_shell)
 #   define extern __EXPORT__

--- a/src/cmd/ksh93/include/shlex.h
+++ b/src/cmd/ksh93/include/shlex.h
@@ -149,7 +149,7 @@ extern int		sh_lex(Lex_t*);
 extern Shnode_t		*sh_dolparen(Lex_t*);
 extern Lex_t		*sh_lexopen(Lex_t*, Shell_t*, int);
 extern void 		sh_lexskip(Lex_t*,int,int,int);
-extern void 		sh_syntax(Lex_t*);
+extern noreturn void 	sh_syntax(Lex_t*);
 #if SHOPT_KIA
     extern int                  kiaclose(Lex_t *);
     extern unsigned long        kiaentity(Lex_t*, const char*,int,int,int,int,unsigned long,int,int,const char*);

--- a/src/cmd/ksh93/sh/args.c
+++ b/src/cmd/ksh93/sh/args.c
@@ -171,7 +171,10 @@ int sh_argopts(int argc,register char *argv[], void *context)
 			}
 			o &= 0xff;
 			if(sh_isoption(SH_RESTRICTED) && !f && o==SH_RESTRICTED)
+			{
 				errormsg(SH_DICT,ERROR_exit(1), e_restricted, opt_info.arg);
+				UNREACHABLE();
+			}
 			break;
 		    case -5:	/* --posix must be handled explicitly to stop AST optget(3) overriding it */
 			if(opt_info.num)
@@ -270,7 +273,10 @@ int sh_argopts(int argc,register char *argv[], void *context)
 		else
 		{
 			if ((o == SH_RESTRICTED) && sh_isoption(SH_RESTRICTED))
+			{
 				errormsg(SH_DICT,ERROR_exit(1),e_restricted,"r"); /* set -r cannot be unset */
+				UNREACHABLE();
+			}
 			if(o==SH_POSIX && !defaultflag)
 			{
 #if SHOPT_BRACEPAT
@@ -286,7 +292,10 @@ int sh_argopts(int argc,register char *argv[], void *context)
 		}
 	}
 	if(error_info.errors)
+	{
 		errormsg(SH_DICT,ERROR_usage(2),"%s",optusage(NIL(char*)));
+		UNREACHABLE();
+	}
 	/* check for '-' or '+' argument */
 	if((cp=argv[opt_info.index]) && cp[1]==0 && (*cp=='+' || *cp=='-') &&
 		strcmp(argv[opt_info.index-1],"--"))
@@ -325,6 +334,7 @@ int sh_argopts(int argc,register char *argv[], void *context)
 		{
 			errormsg(SH_DICT,2,e_cneedsarg);
 			errormsg(SH_DICT,ERROR_usage(2),optusage(NIL(char*)));
+			UNREACHABLE();
 		}
 		argc--;
 	}
@@ -334,11 +344,20 @@ int sh_argopts(int argc,register char *argv[], void *context)
 	if(ap->kiafile)
 	{
 		if(!argv[0])
+		{
 			errormsg(SH_DICT,ERROR_usage(2),"-R requires scriptname");
+			UNREACHABLE();
+		}
 		if(!(lp->kiafile=sfopen(NIL(Sfio_t*),ap->kiafile,"w+")))
+		{
 			errormsg(SH_DICT,ERROR_system(3),e_create,ap->kiafile);
+			UNREACHABLE();
+		}
 		if(!(lp->kiatmp=sftmp(2*SF_BUFSIZE)))
+		{
 			errormsg(SH_DICT,ERROR_system(3),e_tmpcreate);
+			UNREACHABLE();
+		}
 		sfputr(lp->kiafile,";vdb;CIAO/ksh",'\n');
 		lp->kiabegin = sftell(lp->kiafile);
 		lp->entity_tree = dtopen(&_Nvdisc,Dtbag);
@@ -735,7 +754,10 @@ struct argnod *sh_argprocsub(Shell_t *shp,struct argnod *argp)
 		break;
 	}
 	if(!shp->fifo)
+	{
 		errormsg(SH_DICT, ERROR_SYSTEM|ERROR_PANIC, "process substitution: FIFO creation failed");
+		UNREACHABLE();
+	}
 	chmod(shp->fifo,S_IRUSR|S_IWUSR);	/* mkfifo + chmod works regardless of umask */
 	sfputr(shp->stk,shp->fifo,0);
 #endif /* SHOPT_DEVFD */

--- a/src/cmd/ksh93/sh/arith.c
+++ b/src/cmd/ksh93/sh/arith.c
@@ -421,7 +421,10 @@ static Sfdouble_t arith(const char **ptr, struct lval *lvalue, int type, Sfdoubl
 			else
 				c = *str;
 			if(c=='.' && radix!='.')
+			{
 				errormsg(SH_DICT,ERROR_exit(1),"%s: radix point '.' requires LC_NUMERIC=C",val);
+				UNREACHABLE();
+			}
 			if(c==radix || c=='e' || c == 'E' || lastbase == 16 && (c == 'p' || c == 'P'))
 			{
 				lvalue->isfloat=1;
@@ -542,7 +545,10 @@ Sfdouble_t sh_strnum(register const char *str, char** ptr, int mode)
 				if(!last || *last!='.' || last[1]!='.')
 					d = strval(shp,str,&last,arith,mode);
 				if(!ptr && *last && mode>0)
+				{
 					errormsg(SH_DICT,ERROR_exit(1),e_lexbadchar,*last,str);
+					UNREACHABLE();
+				}
 			}
 		} else if (!d && *str=='-') {
 			d = -0.0;
@@ -564,6 +570,9 @@ void	*sh_arithcomp(Shell_t *shp,register char *str)
 	Arith_t *ep;
 	ep = arith_compile(shp,str,(char**)&ptr,arith,ARITH_COMP|1);
 	if(*ptr)
+	{
 		errormsg(SH_DICT,ERROR_exit(1),e_lexbadchar,*ptr,str);
+		UNREACHABLE();
+	}
 	return((void*)ep);
 }

--- a/src/cmd/ksh93/sh/array.c
+++ b/src/cmd/ksh93/sh/array.c
@@ -229,7 +229,10 @@ static union Value *array_getup(Namval_t *np, Namarr_t *arp, int update)
 	else
 	{
 		if(ap->cur >= ap->maxi)
+		{
 			errormsg(SH_DICT,ERROR_exit(1),e_subscript,nv_name(np));
+			UNREACHABLE();
+		}
 		up = &(ap->val[ap->cur]);
 		nofree = array_isbit(ap->bits,ap->cur,ARRAY_NOFREE);
 	}
@@ -367,7 +370,10 @@ static Namval_t *array_find(Namval_t *np,Namarr_t *arp, int flag)
 		if(!(ap->header.nelem&ARRAY_SCAN) && ap->cur >= ap->maxi)
 			ap = array_grow(np, ap, (int)ap->cur);
 		if(ap->cur>=ap->maxi)
+		{
 			errormsg(SH_DICT,ERROR_exit(1),e_subscript,nv_name(np));
+			UNREACHABLE();
+		}
 		up = &(ap->val[ap->cur]);
 		if((!up->cp||up->cp==Empty) && nv_type(np) && nv_isvtree(np))
 		{
@@ -810,7 +816,10 @@ static struct index_array *array_grow(Namval_t *np, register struct index_array 
 	register int i;
 	register int newsize = arsize(arp,maxi+1);
 	if (maxi >= ARRAY_MAX)
+	{
 		errormsg(SH_DICT,ERROR_exit(1),e_subscript, fmtbase((long)maxi,10,0));
+		UNREACHABLE();
+	}
 	i = (newsize-1)*sizeof(union Value*)+newsize;
 	ap = new_of(struct index_array,i);
 	memset((void*)ap,0,sizeof(*ap)+i);
@@ -895,7 +904,10 @@ int nv_atypeindex(Namval_t *np, const char *tname)
 	{
 		struct index_array *ap = (struct index_array*)nv_arrayptr(np);
 		if(!nv_hasdisc(tp,&ENUM_disc))
+		{
 			errormsg(SH_DICT,ERROR_exit(1),e_notenum,tp->nvname);
+			UNREACHABLE();
+		}
 		if(!ap)
 			ap = array_grow(np,ap,1);
 		ap->xp = sh_calloc(NV_MINSZ,1);
@@ -907,7 +919,7 @@ int nv_atypeindex(Namval_t *np, const char *tname)
 		return(1);
 	}
 	errormsg(SH_DICT,ERROR_exit(1),e_unknowntype, n,tname);
-	return(0);
+	UNREACHABLE();
 }
 
 Namarr_t *nv_arrayptr(register Namval_t *np)
@@ -1187,7 +1199,7 @@ Namval_t *nv_putsub(Namval_t *np,register char *sp,register long mode)
 		if(size >= ARRAY_MAX || (size < 0))
 		{
 			errormsg(SH_DICT,ERROR_exit(1),e_subscript, nv_name(np));
-			return(NIL(Namval_t*));
+			UNREACHABLE();
 		}
 		if(!ap || size>=ap->maxi)
 		{
@@ -1406,6 +1418,7 @@ static int array_fixed_init(Namval_t *np, char *sub, char *cp)
 		{
 			free((void*)ap);
 			errormsg(SH_DICT,ERROR_exit(1),e_subscript, nv_name(np));
+			UNREACHABLE();
 		}
 		cp[-1] = ']';
 	}
@@ -1442,18 +1455,27 @@ static char *array_fixed(Namval_t *np, char *sub, char *cp,int mode)
 	size = (int)sh_arith(&sh,(char*)sub);
 	fp->cur[n] = size;
 	if(size >= fp->max[n] || (size < 0))
+	{
 		errormsg(SH_DICT,ERROR_exit(1),e_subscript, nv_name(np));
+		UNREACHABLE();
+	}
 	*cp++ = ']';
 	sz = fp->curi + fp->cur[n]*fp->incr[n];
 	for(n++,ep=cp;*ep=='['; ep=cp,n++)
 	{
 		if(n >= fp->ndim)
+		{
 			errormsg(SH_DICT,ERROR_exit(1),e_subscript, nv_name(np));
+			UNREACHABLE();
+		}
 		cp = nv_endsubscript(np,ep,0);
 		cp[-1]=0;
 		size = (int)sh_arith(&sh,(char*)ep+1);
 		if(size >= fp->max[n] || (size < 0))
+		{
 			errormsg(SH_DICT,ERROR_exit(1),e_subscript, nv_name(np));
+			UNREACHABLE();
+		}
 		fp->cur[n] = size;
 		cp[-1] = ']';
 		sz += fp->cur[n]*fp->incr[n];
@@ -1793,7 +1815,10 @@ void nv_setvec(register Namval_t *np,int append,register int argc,register char 
 	{
 		ap = (struct index_array*)nv_arrayptr(np);
 		if(ap && is_associative(ap))
+		{
 			errormsg(SH_DICT,ERROR_exit(1),"cannot append indexed array to associative array %s",nv_name(np));
+			UNREACHABLE();
+		}
 	}
 	if(append)
 	{

--- a/src/cmd/ksh93/sh/fault.c
+++ b/src/cmd/ksh93/sh/fault.c
@@ -599,7 +599,7 @@ static void array_notify(Namval_t *np, void *data)
  * This is the exit routine for the shell
  */
 
-void sh_done(void *ptr, register int sig)
+noreturn void sh_done(void *ptr, register int sig)
 {
 	Shell_t	*shp = (Shell_t*)ptr;
 	register char *t;

--- a/src/cmd/ksh93/sh/init.c
+++ b/src/cmd/ksh93/sh/init.c
@@ -221,11 +221,11 @@ static int		rand_shift;
 /*
  * out of memory routine for stak routines
  */
-static char *nomemory(int unused)
+static noreturn char *nomemory(int unused)
 {
 	NOT_USED(unused);
 	errormsg(SH_DICT, ERROR_SYSTEM|ERROR_PANIC, "out of memory");
-	return(NIL(char*));
+	UNREACHABLE();
 }
 
 /*
@@ -371,7 +371,10 @@ static void put_restricted(register Namval_t* np,const char *val,int flags,Namfu
 	Pathcomp_t *pp;
 	char *name = nv_name(np);
 	if(!(flags&NV_RDONLY) && sh_isoption(SH_RESTRICTED))
+	{
 		errormsg(SH_DICT,ERROR_exit(1),e_restricted,nv_name(np));
+		UNREACHABLE();
+	}
 	if(np==PATHNOD	|| (path_scoped=(strcmp(name,PATHNOD->nvname)==0)))		
 	{
 		/* Clear the hash table */
@@ -1195,7 +1198,10 @@ static void put_mode(Namval_t* np, const char* val, int flag, Namfun_t* nfp)
 		else
 			mode = strperm(val, &last,0);
 		if(*last)
+		{
 			errormsg(SH_DICT,ERROR_exit(1),"%s: invalid mode string",val);
+			UNREACHABLE();
+		}
 		nv_putv(np,(char*)&mode,NV_INTEGER,nfp);
 	}
 	else
@@ -1472,7 +1478,10 @@ Shell_t *sh_init(register int argc,register char *argv[], Shinit_f userinit)
 #ifdef SHELLMAGIC
 		/* careful of #! setuid scripts with name beginning with - */
 		if(shp->login_sh && argv[1] && strcmp(argv[0],argv[1])==0)
+		{
 			errormsg(SH_DICT,ERROR_exit(1),e_prohibited);
+			UNREACHABLE();
+		}
 #endif /*SHELLMAGIC*/
 	}
 	else
@@ -1700,7 +1709,10 @@ found:
 		shp->last_table = SH_STATS;
 	}
 	else
+	{
 		errormsg(SH_DICT,ERROR_exit(1),e_notelem,n,name,nv_name(np));
+		UNREACHABLE();
+	}
 	return(nq);
 }
 

--- a/src/cmd/ksh93/sh/io.c
+++ b/src/cmd/ksh93/sh/io.c
@@ -510,6 +510,7 @@ static int outexcept(register Sfio_t *iop,int type,void *data,Sfdisc_t *handle)
 				sfpurge(iop);
 				sfpool(iop,NIL(Sfio_t*),SF_WRITE);
 				errno = save;
+				/* Note: __builtin_unreachable() is avoided here because of https://github.com/att/ast/issues/1336 */
 				errormsg(SH_DICT,ERROR_system(1),e_badwrite,sffileno(iop));
 				active = 0;
 				((struct checkpt*)shp->jmplist)->mode = mode;
@@ -616,6 +617,7 @@ static void io_preserve(Shell_t* shp, register Sfio_t *sp, register int f2)
 		shp->toomany = 1;
 		((struct checkpt*)shp->jmplist)->mode = SH_JMPERREXIT;
 		errormsg(SH_DICT,ERROR_system(1),e_toomany);
+		UNREACHABLE();
 	}
 	if(f2 >= shp->gd->lim.open_max)
 		sh_iovalidfd(shp,f2);
@@ -669,7 +671,10 @@ int sh_iorenumber(Shell_t *shp, register int f1,register int f2)
 		{
 			shp->fdstatus[f2] = (shp->fdstatus[f1]&~IOCLEX);
 			if((f2 = sh_fcntl(f1,F_DUPFD, f2)) < 0)
+			{
 				errormsg(SH_DICT,ERROR_system(1),e_file+4);
+				UNREACHABLE();
+			}
 			else if(f2 <= 2)
 				sh_iostream(shp,f2);
 		}
@@ -872,7 +877,10 @@ int sh_chkopen(register const char *name)
 {
 	register int fd = sh_open(name,O_RDONLY,0);
 	if(fd < 0)
+	{
 		errormsg(SH_DICT,ERROR_system(1),e_open,name);
+		UNREACHABLE();
+	}
 	return(fd);
 }
 
@@ -902,7 +910,10 @@ int	sh_pipe(register int pv[])
 	Shell_t *shp = sh_getinterp();
 	int fd[2];
 	if(pipe(fd)<0 || (pv[0]=fd[0])<0 || (pv[1]=fd[1])<0)
+	{
 		errormsg(SH_DICT,ERROR_system(1),e_pipe);
+		UNREACHABLE();
+	}
 	pv[0] = sh_iomovefd(pv[0]);
 	pv[1] = sh_iomovefd(pv[1]);
 	shp->fdstatus[pv[0]] = IONOSEEK|IOREAD;
@@ -925,7 +936,10 @@ int	sh_pipe(register int pv[])
 	Shell_t *shp = sh_getinterp();
 	int fd[2];
 	if(pipe(fd)<0 || (pv[0]=fd[0])<0 || (pv[1]=fd[1])<0)
+	{
 		errormsg(SH_DICT,ERROR_system(1),e_pipe);
+		UNREACHABLE();
+	}
 	pv[0] = sh_iomovefd(pv[0]);
 	pv[1] = sh_iomovefd(pv[1]);
 	shp->fdstatus[pv[0]] = IONOSEEK|IOREAD;
@@ -1118,7 +1132,10 @@ int	sh_redirect(Shell_t *shp,struct ionod *iop, int flag)
 		if(fn==1)
 		{
 			if(shp->subshare && flag==2)
+			{
 				errormsg(SH_DICT,ERROR_exit(1),"cannot redirect stdout inside shared-state comsub");
+				UNREACHABLE();
+			}
 			if(shp->subshell && (flag==2 || isstring))
 				sh_subfork();
 		}
@@ -1170,13 +1187,19 @@ int	sh_redirect(Shell_t *shp,struct ionod *iop, int flag)
 		{
 			np = nv_open(iop->iovname,shp->var_tree,NV_NOASSIGN|NV_VARNAME);
 			if(nv_isattr(np,NV_RDONLY))
+			{
 				errormsg(SH_DICT,ERROR_exit(1),e_readonly, nv_name(np));
+				UNREACHABLE();
+			}
 			io_op[0] = '}';
 			if((iof&IOLSEEK) || ((iof&IOMOV) && *fname=='-'))
 				fn = nv_getnum(np);
 		}
 		if(fn>=shp->gd->lim.open_max && !sh_iovalidfd(shp,fn))
+		{
 			errormsg(SH_DICT,ERROR_system(1),e_file+4);
+			UNREACHABLE();
+		}
 		if(iof&IOLSEEK)
 		{
 			io_op[2] = '#';
@@ -1272,7 +1295,10 @@ int	sh_redirect(Shell_t *shp,struct ionod *iop, int flag)
 			else if(iof&IORDW)
 			{
 				if(sh_isoption(SH_RESTRICTED))
+				{
 					errormsg(SH_DICT,ERROR_exit(1),e_restricted,fname);
+					UNREACHABLE();
+				}
 				io_op[2] = '>';
 				o_mode = O_RDWR|O_CREAT;
 				if(iof&IOREWRITE)
@@ -1286,7 +1312,10 @@ int	sh_redirect(Shell_t *shp,struct ionod *iop, int flag)
 				fd=sh_chkopen(fname);
 			}
 			else if(sh_isoption(SH_RESTRICTED))
+			{
 				errormsg(SH_DICT,ERROR_exit(1),e_restricted,fname);
+				UNREACHABLE();
+			}
 			else
 			{
 				if(iof&IOAPP)
@@ -1315,6 +1344,7 @@ int	sh_redirect(Shell_t *shp,struct ionod *iop, int flag)
 							{
 								errno = EEXIST;
 								errormsg(SH_DICT,ERROR_system(1),e_exists,fname);
+								UNREACHABLE();
 							}
 						}
 						else
@@ -1325,7 +1355,10 @@ int	sh_redirect(Shell_t *shp,struct ionod *iop, int flag)
 				if(flag!=SH_SHOWME)
 				{
 					if((fd=sh_open(tname?tname:fname,o_mode,RW_ALL)) <0)
+					{
 						errormsg(SH_DICT,ERROR_system(1),((o_mode&O_CREAT)?e_create:e_open),fname);
+						UNREACHABLE();
+					}
 					if(perm>0)
 #if _lib_fchmod
 						fchmod(fd,perm);
@@ -1507,8 +1540,7 @@ int	sh_redirect(Shell_t *shp,struct ionod *iop, int flag)
 	return(indx);
 fail:
 	errormsg(SH_DICT,ERROR_system(1),message,fname);
-	/* NOTREACHED */
-	return(0);
+	UNREACHABLE();
 }
 /*
  * Create a tmp file for the here-document
@@ -1522,7 +1554,10 @@ static int io_heredoc(Shell_t *shp,register struct ionod *iop, const char *name,
 		return(sh_open(e_devnull,O_RDONLY));
 	/* create an unnamed temporary file */
 	if(!(outfile=sftmp(0)))
+	{
 		errormsg(SH_DICT,ERROR_system(1),e_tmpcreate);
+		UNREACHABLE();
+	}
 	if(iop->iofile&IOSTRG)
 	{
 		if(traceon)
@@ -1656,6 +1691,7 @@ void sh_iosave(Shell_t *shp, register int origfd, int oldtop, char *name)
 			shp->toomany=1;
 			((struct checkpt*)shp->jmplist)->mode = SH_JMPERREXIT;
 			errormsg(SH_DICT,ERROR_system(1),e_toomany);
+			UNREACHABLE();
 		}
 	}
 	filemap[shp->topfd].tname = name;
@@ -2643,7 +2679,10 @@ Sfio_t *sh_pathopen(const char *cp)
 		n = path_open(shp,cp,"");
 #endif
 	if(n < 0)
+	{
 		errormsg(SH_DICT,ERROR_system(1),e_open,cp);
+		UNREACHABLE();
+	}
 	return(sh_iostream(shp,n));
 }
 

--- a/src/cmd/ksh93/sh/io.c
+++ b/src/cmd/ksh93/sh/io.c
@@ -510,7 +510,11 @@ static int outexcept(register Sfio_t *iop,int type,void *data,Sfdisc_t *handle)
 				sfpurge(iop);
 				sfpool(iop,NIL(Sfio_t*),SF_WRITE);
 				errno = save;
-				/* Note: __builtin_unreachable() is avoided here because of https://github.com/att/ast/issues/1336 */
+				/*
+				 * Note: UNREACHABLE() is avoided here because this errormsg() call will return.
+				 * The ERROR_system flag causes sh_exit() to be called, but if shp->jmplist->mode
+				 * is 0 (see above), then sh_exit() neither exits nor longjmps. See fault.c.
+				 */
 				errormsg(SH_DICT,ERROR_system(1),e_badwrite,sffileno(iop));
 				active = 0;
 				((struct checkpt*)shp->jmplist)->mode = mode;

--- a/src/cmd/ksh93/sh/jobs.c
+++ b/src/cmd/ksh93/sh/jobs.c
@@ -76,7 +76,10 @@ pid_t	pid_fromstring(char *str)
 	else
 		pid = (pid_t)strtol(str, &last, 10);
 	if(errno==ERANGE || *last)
+	{
 		errormsg(SH_DICT,ERROR_exit(1),"%s: invalid process id",str);
+		UNREACHABLE();
+	}
 	return(pid);
 }
 
@@ -841,7 +844,10 @@ int job_walk(Sfio_t *file,int (*fun)(struct process*,int),int arg,char *joblist[
 	{
 		job_string = jobid;
 		if(*jobid==0)
+		{
 			errormsg(SH_DICT,ERROR_exit(1),e_jobusage,job_string);
+			UNREACHABLE();
+		}
 		if(*jobid == '%')
 			pw = job_bystring(jobid);
 		else
@@ -1152,7 +1158,10 @@ static struct process *job_byname(char *name)
 		if(hist_match(shgd->hist_ptr,pw->p_name,cp,flag)>=0)
 		{
 			if(pz)
+			{
 				errormsg(SH_DICT,ERROR_exit(1),e_jobusage,name-1);
+				UNREACHABLE();
+			}
 			pz = pw;
 		}
 	}

--- a/src/cmd/ksh93/sh/lex.c
+++ b/src/cmd/ksh93/sh/lex.c
@@ -1633,6 +1633,7 @@ static int comsub(register Lex_t *lp, int endtok)
 				lp->lastline = line;
 				lp->lasttok = endtok;
 				sh_syntax(lp);
+				UNREACHABLE();
 			    case IOSEEKSYM:
 				if(fcgetc(c)!='#' && c>0)
 					fcseek(-LEN);

--- a/src/cmd/ksh93/sh/lex.c
+++ b/src/cmd/ksh93/sh/lex.c
@@ -405,6 +405,7 @@ int sh_lex(Lex_t* lp)
 						errno = ENOEXEC;
 						error_info.id = shp->readscript;
 						errormsg(SH_DICT,ERROR_system(ERROR_NOEXEC),e_exec,cp);
+						UNREACHABLE();
 					}
 					else
 					{
@@ -1185,7 +1186,10 @@ int sh_lex(Lex_t* lp)
 					if(n>0 && n==']')
 					{
 						if(mode==ST_NAME)
+						{
 							errormsg(SH_DICT,ERROR_exit(SYNBAD),e_lexsyntax1, shp->inlineno, "[]", "empty subscript");
+							UNREACHABLE();
+						}
 						if(!epatchar || epatchar=='%')
 							continue;
 					}
@@ -1663,7 +1667,10 @@ done:
 	lp->lex = save;
 	lp->assignok = (endchar(lp)==RBRACT?assignok:0);
 	if(lp->heredoc && !inheredoc)
+	{
 		errormsg(SH_DICT,ERROR_exit(SYNBAD),e_lexsyntax5,lp->sh->inlineno,lp->heredoc->ioname);
+		UNREACHABLE();
+	}
 	return(messages);
 }
 
@@ -2089,7 +2096,7 @@ static char	*fmttoken(Lex_t *lp, register int sym, char *tok)
  * print a bad syntax message
  */
 
-void	sh_syntax(Lex_t *lp)
+noreturn void sh_syntax(Lex_t *lp)
 {
 	register Shell_t *shp = lp->sh;
 	register const char *cp = sh_translate(e_unexpected);
@@ -2126,6 +2133,7 @@ void	sh_syntax(Lex_t *lp)
 		errormsg(SH_DICT,ERROR_exit(SYNBAD),e_lexsyntax1,lp->lastline,tokstr,cp);
 	else
 		errormsg(SH_DICT,ERROR_exit(SYNBAD),e_lexsyntax2,tokstr,cp);
+	UNREACHABLE();
 }
 
 static char *stack_shift(Stk_t *stkp, register char *sp,char *dp)

--- a/src/cmd/ksh93/sh/lex.c
+++ b/src/cmd/ksh93/sh/lex.c
@@ -1638,7 +1638,7 @@ static int comsub(register Lex_t *lp, int endtok)
 				lp->lastline = line;
 				lp->lasttok = endtok;
 				sh_syntax(lp);
-				UNREACHABLE();
+				/* UNREACHABLE */
 			    case IOSEEKSYM:
 				if(fcgetc(c)!='#' && c>0)
 					fcseek(-LEN);

--- a/src/cmd/ksh93/sh/macro.c
+++ b/src/cmd/ksh93/sh/macro.c
@@ -98,6 +98,7 @@ typedef struct  _mac_
 #define M_NAMECOUNT	7	/* ${#var*}	*/
 #define M_TYPE		8	/* ${@var}	*/
 
+static noreturn void	mac_error(Namval_t*);
 static int	substring(const char*, const char*, int[], int);
 static void	copyto(Mac_t*, int, int);
 static void	comsubst(Mac_t*, Shnode_t*, int);
@@ -107,7 +108,6 @@ static void	tilde_expand2(Shell_t*,int);
 static char 	*sh_tilde(Shell_t*,const char*);
 static char	*special(Shell_t *,int);
 static void	endfield(Mac_t*,int);
-static void	mac_error(Namval_t*);
 static char	*mac_getstring(char*);
 static int	charlen(const char*,int);
 #if SHOPT_MULTIBYTE
@@ -184,7 +184,10 @@ char *sh_mactrim(Shell_t *shp, char *str, register int mode)
 		if((mode=path_expand(shp,str,&arglist))==1)
 			str = arglist->argval;
 		else if(mode>1)
+		{
 			errormsg(SH_DICT,ERROR_exit(1),e_ambiguous,str);
+			UNREACHABLE();
+		}
 		sh_trim(str);
 	}
 	*mp = savemac;
@@ -709,7 +712,10 @@ static void copyto(register Mac_t *mp,int endch, int newquote)
 					if(first[c-2]=='.')
 						offset = stktell(stkp);
 					if(isastchar(*cp) && cp[1]==']')
+					{
 						errormsg(SH_DICT,ERROR_exit(1),e_badsubscript,*cp);
+						UNREACHABLE();
+					}
 				}
 				first = fcseek(c);
 				mp->pattern = 4;
@@ -1194,7 +1200,10 @@ retry1:
 			d=fcget();
 			fcseek(-1);
 			if(!(d && strchr(":+-?=",d)))
+			{
 				errormsg(SH_DICT,ERROR_exit(1),e_notset,ltos(c));
+				UNREACHABLE();
+			}
 		}
 		break;
 	    case S_ALP:
@@ -1465,7 +1474,10 @@ retry1:
 		{
 			/* The parameter is unset. */
 			if(sh_isoption(SH_NOUNSET) && !isastchar(mode) && (type==M_VNAME || type==M_SIZE))
+			{
 				errormsg(SH_DICT,ERROR_exit(1),e_notset,id);
+				UNREACHABLE();
+			}
 			v = 0;
 			if(type==M_VNAME)
 			{
@@ -1594,7 +1606,10 @@ retry1:
 			int newops = (c=='#' || c == '%' || c=='/');
 			offset = stktell(stkp);
 			if(newops && sh_isoption(SH_NOUNSET) && *id && id!=idbuff  && (!np || nv_isnull(np)))
+			{
 				errormsg(SH_DICT,ERROR_exit(1),e_notset,id);
+				UNREACHABLE();
+			}
 			if(c=='/' ||c==':' || ((!v || (nulflg && *v==0)) ^ (c=='+'||c=='#'||c=='%')))
 			{
 				int newquote = mp->quote;
@@ -1995,6 +2010,7 @@ retry2:
 				errormsg(SH_DICT,ERROR_exit(1),e_nullset,id);
 			else
 				errormsg(SH_DICT,ERROR_exit(1),e_notset,id);
+			UNREACHABLE();
 		}
 		else if(c=='=')
 		{
@@ -2026,6 +2042,7 @@ retry2:
 			nv_close(np);
 		}
 		errormsg(SH_DICT,ERROR_exit(1),e_notset,id);
+		UNREACHABLE();
 	}
 	if(np)
 		nv_close(np);
@@ -2795,6 +2812,7 @@ static char *special(Shell_t *shp,register int c)
 			c_str[0]=(char)c;
 			c_str[1]='\0';
 			errormsg(SH_DICT,ERROR_exit(1),e_notset,c_str);
+			UNREACHABLE();
 		}
 	}
 	return(NIL(char*));
@@ -2803,11 +2821,12 @@ static char *special(Shell_t *shp,register int c)
 /*
  * Handle macro expansion errors
  */
-static void mac_error(Namval_t *np)
+static noreturn void mac_error(Namval_t *np)
 {
 	if(np)
 		nv_close(np);
 	errormsg(SH_DICT,ERROR_exit(1),e_subst,fcfirst());
+	UNREACHABLE();
 }
 
 /*

--- a/src/cmd/ksh93/sh/main.c
+++ b/src/cmd/ksh93/sh/main.c
@@ -356,7 +356,6 @@ int sh_main(int ac, char *av[], Shinit_f userinit)
 	nv_putval(IFSNOD,(char*)e_sptbnl,NV_RDONLY);
 	exfile(shp,iop,fdin);
 	sh_done(shp,0);
-	UNREACHABLE();
 }
 
 /*

--- a/src/cmd/ksh93/sh/main.c
+++ b/src/cmd/ksh93/sh/main.c
@@ -263,7 +263,10 @@ int sh_main(int ac, char *av[], Shinit_f userinit)
 #endif
 					fdin = (int)strtol(name+8, (char**)0, 10);
 					if(fstat(fdin,&statb)<0)
+					{
 						errormsg(SH_DICT,ERROR_system(1),e_open,name);
+						UNREACHABLE();
+					}
 #if !_WINIX
 					/*
 					 * try to undo effect of solaris 2.5+
@@ -317,7 +320,10 @@ int sh_main(int ac, char *av[], Shinit_f userinit)
 							errno = EISDIR;
 						 error_info.id = av[0];
 						if(sp || errno!=ENOENT)
+						{
 							errormsg(SH_DICT,ERROR_system(ERROR_NOEXEC),e_open,name);
+							UNREACHABLE();
+						}
 						/* try sh -c 'name "$@"' */
 						sh_onoption(SH_CFLAG);
 						shp->comdiv = (char*)sh_malloc(strlen(name)+7);
@@ -350,8 +356,7 @@ int sh_main(int ac, char *av[], Shinit_f userinit)
 	nv_putval(IFSNOD,(char*)e_sptbnl,NV_RDONLY);
 	exfile(shp,iop,fdin);
 	sh_done(shp,0);
-	/* NOTREACHED */
-	return(0);
+	UNREACHABLE();
 }
 
 /*

--- a/src/cmd/ksh93/sh/name.c
+++ b/src/cmd/ksh93/sh/name.c
@@ -204,6 +204,7 @@ Namval_t *nv_addnode(Namval_t* np, int remove)
 			nv_delete(sp->nodes[0],root,NV_NOFREE);
 			dtinsert(root,sp->rp);
 			errormsg(SH_DICT,ERROR_exit(1),e_redef,sp->nodes[0]->nvname);
+			UNREACHABLE();
 		}
 	}
 	for(i=0; i < sp->numnodes; i++)
@@ -352,7 +353,10 @@ void nv_setlist(register struct argnod *arg,register int flags, Namval_t *typ)
 					tp->com.comtyp = COMSCAN;
 				}
 				if(nv_isattr(np,NV_RDONLY) && np->nvfun && !(flags&NV_RDONLY))
+				{
 					errormsg(SH_DICT,ERROR_exit(1),e_readonly, nv_name(np));
+					UNREACHABLE();
+				}
 				if(nv_isattr(np,NV_NOFREE) && nv_isnull(np))
 					nv_offattr(np,NV_NOFREE);
 				if(nv_istable(np))
@@ -413,6 +417,7 @@ void nv_setlist(register struct argnod *arg,register int flags, Namval_t *typ)
 					{
 						shp->mktype = 0;
 						errormsg(SH_DICT,ERROR_exit(1),"%s: not a known type name",argv[0]);
+						UNREACHABLE();
 					}
 #endif /* SHOPT_TYPEDEF */
 					if(!(arg->argflag&ARG_APPEND))
@@ -500,7 +505,10 @@ void nv_setlist(register struct argnod *arg,register int flags, Namval_t *typ)
 						if(nv_isarray(np))
 						{
 							if((sub=nv_aimax(np)) < 0  && nv_arrayptr(np))
+							{
 								errormsg(SH_DICT,ERROR_exit(1),e_badappend,nv_name(np));
+								UNREACHABLE();
+							}
 							if(sub>=0)
 								sub++;
 						}
@@ -926,7 +934,10 @@ Namval_t *nv_create(const char *name,  Dt_t *root, int flags, Namfun_t *dp)
 				}
 				shp->first_root = root;
 				if(nv_isref(np) && (c=='[' || c=='.' || !(flags&NV_ASSIGN)))
+				{
 					errormsg(SH_DICT,ERROR_exit(1),e_noref,nv_name(np));
+					UNREACHABLE();
+				}
 				if(sub && c==0)
 				{
 					if(flags&NV_ARRAY)
@@ -1542,6 +1553,7 @@ skip:
 		else if(c=='[')
 			msg = e_noarray;
 		errormsg(SH_DICT,ERROR_exit(1),msg,name);
+		UNREACHABLE();
 	}
 	if(fun.nofree&1)
 		stakseek(offset);
@@ -1576,7 +1588,10 @@ void nv_putval(register Namval_t *np, const char *string, int flags)
 	Namarr_t	*ap;
 #endif /* SHOPT_FIXEDARRAY */
 	if(!(flags&NV_RDONLY) && nv_isattr (np, NV_RDONLY))
+	{
 		errormsg(SH_DICT,ERROR_exit(1),e_readonly, nv_name(np));
+		UNREACHABLE();
+	}
 	/*
 	 * The following could cause the shell to fork if assignment
 	 * would cause a side effect
@@ -2457,7 +2472,10 @@ void	_nv_unset(register Namval_t *np,int flags)
 	Namarr_t	*ap;
 #endif /* SHOPT_FIXEDARRAY */
 	if(!(flags&NV_RDONLY) && nv_isattr (np,NV_RDONLY))
+	{
 		errormsg(SH_DICT,ERROR_exit(1),e_readonly, nv_name(np));
+		UNREACHABLE();
+	}
 	if(is_afunction(np) && np->nvalue.ip)
 	{
 		register struct slnod *slp = (struct slnod*)(np->nvenv);
@@ -2880,7 +2898,10 @@ Sfdouble_t nv_getnum(register Namval_t *np)
 		nv_optimize(np);
 #endif /* SHOPT_OPTIMIZE */
 	if(nv_istable(np))
+	{
 		errormsg(SH_DICT,ERROR_exit(1),e_number,nv_name(np));
+		UNREACHABLE();
+	}
      	if(np->nvfun && np->nvfun->disc)
 	{
 		if(!nv_local)
@@ -2970,7 +2991,10 @@ void nv_newattr (register Namval_t *np, unsigned newatts, int size)
 
 	/* check for restrictions */
 	if(sh_isoption(SH_RESTRICTED) && ((sp=nv_name(np))==nv_name(PATHNOD) || sp==nv_name(SHELLNOD) || sp==nv_name(ENVNOD) || sp==nv_name(FPATHNOD)))
+	{
 		errormsg(SH_DICT,ERROR_exit(1),e_restricted,nv_name(np));
+		UNREACHABLE();
+	}
 	/* handle attributes that do not change data separately */
 	n = np->nvflag;
 	trans = !(n&NV_INTEGER) && (n&(NV_LTOU|NV_UTOL)); /* transcode to lower or upper case */
@@ -3265,11 +3289,17 @@ int nv_rename(register Namval_t *np, int flags)
 	if(!(cp=nv_getval(np)))
 	{
 		if(flags&NV_MOVE)
+		{
 			errormsg(SH_DICT,ERROR_exit(1),e_varname,"");
+			UNREACHABLE();
+		}
 		return(0);
 	}
 	if(lastdot(cp,0) && nv_isattr(np,NV_MINIMAL))
+	{
 		errormsg(SH_DICT,ERROR_exit(1),e_varname,nv_name(np));
+		UNREACHABLE();
+	}
 	arraynr = cp[strlen(cp)-1] == ']';
 	if(nv_isarray(np) && !(mp=nv_opensub(np)))
 		index=nv_aindex(np);
@@ -3391,7 +3421,10 @@ void nv_setref(register Namval_t *np, Dt_t *hp, int flags)
 	if(nv_isref(np))
 		return;
 	if(nv_isarray(np))
+	{
 		errormsg(SH_DICT,ERROR_exit(1),e_badref,nv_name(np));
+		UNREACHABLE();
+	}
 	if(!(cp=nv_getval(np)))
 	{
 		_nv_unset(np,0);
@@ -3399,7 +3432,10 @@ void nv_setref(register Namval_t *np, Dt_t *hp, int flags)
 		return;
 	}
 	if((ep = lastdot(cp,0)) && nv_isattr(np,NV_MINIMAL))
+	{
 		errormsg(SH_DICT,ERROR_exit(1),e_badref,nv_name(np));
+		UNREACHABLE();
+	}
 	if(hp)
 		hpnext = dtvnext(hp);
 	if((nr=nv_open(cp, hp?hp:shp->var_tree, flags|NV_NOSCOPE|NV_NOADD|NV_NOFAIL)))
@@ -3415,10 +3451,16 @@ void nv_setref(register Namval_t *np, Dt_t *hp, int flags)
 	if(nr==np) 
 	{
 		if(shp->namespace && nv_dict(shp->namespace)==hp)
+		{
 			errormsg(SH_DICT,ERROR_exit(1),e_selfref,nv_name(np));
+			UNREACHABLE();
+		}
 		/* bind to earlier scope, or add to global scope */
 		if(!(hp=dtvnext(hp)) || (nq=nv_search((char*)np,hp,NV_ADD|HASH_BUCKET))==np)
+		{
 			errormsg(SH_DICT,ERROR_exit(1),e_selfref,nv_name(np));
+			UNREACHABLE();
+		}
 		if(nv_isarray(nq))
 			nv_putsub(nq,(char*)0,ARRAY_UNDEF);
 	}
@@ -3447,6 +3489,7 @@ void nv_setref(register Namval_t *np, Dt_t *hp, int flags)
 		_nv_unset(np,NV_RDONLY);
 		nv_onattr(np,NV_REF);
 		errormsg(SH_DICT,ERROR_exit(1),e_globalref,nv_name(np));
+		UNREACHABLE();
 	}
 	shp->instance = 1;
 	if(nq && !ep && (ap=nv_arrayptr(nq)) && !(ap->nelem&(ARRAY_UNDEF|ARRAY_SCAN)))

--- a/src/cmd/ksh93/sh/nvdisc.c
+++ b/src/cmd/ksh93/sh/nvdisc.c
@@ -600,7 +600,10 @@ static char *setdisc(register Namval_t* np,register const char *event,Namval_t *
 	{
 		Namval_t *tp = nv_type(np);
 		if(tp && (np = (Namval_t*)vp->bltins[type]) && nv_isattr(np,NV_STATICF))
+		{
 			errormsg(SH_DICT,ERROR_exit(1),e_staticfun,name,tp->nvname);
+			UNREACHABLE();
+		}
 		vp->bltins[type] = action;
 	}
 	else
@@ -1204,7 +1207,10 @@ Namval_t *sh_addbuiltin(const char *path, Shbltin_f bltin, void *extra)
 		if(extra == (void*)1)
 		{
 			if(nv_isattr(np,BLT_SPC))
+			{
 				errormsg(SH_DICT,ERROR_exit(1),"cannot delete: %s%s",name,is_spcbuiltin);
+				UNREACHABLE();
+			}
 			if(np->nvfun && !nv_isattr(np,NV_NOFREE))
 				free((void*)np->nvfun);
 			dtdelete(sh.bltin_tree,np);
@@ -1254,7 +1260,10 @@ Namval_t *sh_addbuiltin(const char *path, Shbltin_f bltin, void *extra)
 		cp=nv_setdisc(nq,cp+1,np,(Namfun_t*)nq);
 		nv_close(nq);
 		if(!cp)
+		{
 			errormsg(SH_DICT,ERROR_exit(1),e_baddisc,name);
+			UNREACHABLE();
+		}
 	}
 	if(extra == (void*)1)
 		return(0);

--- a/src/cmd/ksh93/sh/nvtype.c
+++ b/src/cmd/ksh93/sh/nvtype.c
@@ -411,7 +411,10 @@ static Namfun_t *clone_type(Namval_t* np, Namval_t *mp, int flags, Namfun_t *fp)
 			if(nr)
 			{
 				if(nv_isattr(nq,NV_RDONLY) && (nq->nvalue.cp || nv_isattr(nq,NV_INTEGER)))
+				{
 					errormsg(SH_DICT,ERROR_exit(1),e_readonly, nq->nvname);
+					UNREACHABLE();
+				}
 				if(nv_isref(nq))
 					nq = nv_refnode(nq);
 				if((size = nv_datasize(nr,(size_t*)0)) && size==nv_datasize(nq,(size_t*)0))
@@ -455,7 +458,10 @@ static Namfun_t *clone_type(Namval_t* np, Namval_t *mp, int flags, Namfun_t *fp)
 					nv_delete(nr,sh.last_root,0);
 			}
 			else if(nv_isattr(nq,NV_RDONLY) && !nq->nvalue.cp && !nv_isattr(nq,NV_INTEGER))
+			{
 				errormsg(SH_DICT,ERROR_exit(1),e_required,nq->nvname,nv_name(mp));
+				UNREACHABLE();
+			}
 		}
 	}
 	if(nv_isattr(mp,NV_BINARY))
@@ -515,6 +521,7 @@ found:
 				return(nq);
 		}
 		errormsg(SH_DICT,ERROR_exit(1),e_notelem,n,name,nv_name(np));
+		UNREACHABLE();
 	}
 	return(nq);
 }
@@ -841,6 +848,7 @@ Namval_t *nv_mktype(Namval_t **nodes, int numnodes)
 		cp = nodes[0]->nvname;
 		_nv_unset(nodes[0],NV_RDONLY);
 		errormsg(SH_DICT,ERROR_exit(1),e_badtypedef,cp);
+		UNREACHABLE();
 	}
 	n=strlen(nodes[1]->nvname);
 	for(nnodes=1,i=1; i <numnodes; i++)
@@ -1299,6 +1307,7 @@ int nv_settype(Namval_t* np, Namval_t *tp, int flags)
 		if(tp==tq)
 			return(0);
 		errormsg(SH_DICT,ERROR_exit(1),e_redef,nv_name(np));
+		UNREACHABLE();
 	}
 	if((ap=nv_arrayptr(np)) && ap->nelem>0)
 	{
@@ -1428,7 +1437,10 @@ Namval_t *nv_mkstruct(const char *name, int rsize, Fields_t *fields)
 			tp = nv_open(stakptr(offset), sh.var_tree, NV_VARNAME|NV_NOADD|NV_NOFAIL);
 			stakseek(r);
 			if(!tp)
+			{
 				errormsg(SH_DICT,ERROR_exit(1),e_unknowntype,strlen(fp->type),fp->type);
+				UNREACHABLE();
+			}
 			if(dp = (Namtype_t*)nv_hasdisc(tp,&type_disc))
 			{
 				nnodes += dp->numnodes;

--- a/src/cmd/ksh93/sh/parse.c
+++ b/src/cmd/ksh93/sh/parse.c
@@ -354,7 +354,10 @@ void	*sh_parse(Shell_t *shp, Sfio_t *iop, int flag)
 			fcrestore(&sav_input);
 			lexp->arg = sav_arg;
 			if(version > SHCOMP_HDR_VERSION)
+			{
 				errormsg(SH_DICT,ERROR_exit(1),e_lexversion);
+				UNREACHABLE();
+			}
 			if(sffileno(iop)==shp->infd || (flag&SH_FUNEVAL))
 				shp->binscript = 1;
 			sfgetc(iop);
@@ -794,7 +797,10 @@ static Shnode_t *funct(Lex_t *lexp)
 			int		c=-1;
 			t->funct.functargs = ac = (struct comnod*)simple(lexp,SH_NOIO|SH_FUNDEF,NIL(struct ionod*));
 			if(ac->comset || (ac->comtyp&COMSCAN))
+			{
 				errormsg(SH_DICT,ERROR_exit(3),e_lexsyntax4,lexp->sh->inlineno);
+				UNREACHABLE();
+			}
 			argv0 = argv = ((struct dolnod*)ac->comarg)->dolval+ARG_SPARE;
 			while(cp= *argv++)
 			{
@@ -803,7 +809,10 @@ static Shnode_t *funct(Lex_t *lexp)
 		                        while(c=mbchar(cp), isaname(c));
 			}
 			if(c)
+			{
 				errormsg(SH_DICT,ERROR_exit(3),e_lexsyntax4,lexp->sh->inlineno);
+				UNREACHABLE();
+			}
 			nargs = argv-argv0;
 			size += sizeof(struct dolnod)+(nargs+ARG_SPARE)*sizeof(char*);
 			if(shp->shcomp && memcmp(".sh.math.",t->funct.functnam,9)==0)
@@ -1271,7 +1280,10 @@ static Shnode_t	*item(Lex_t *lexp,int flag)
 		while(argp)
 		{
 			if(strcmp(argp->argval,lexp->arg->argval)==0)
+			{
 				errormsg(SH_DICT,ERROR_exit(3),e_lexsyntax3,lexp->sh->inlineno,argp->argval);
+				UNREACHABLE();
+			}
 			argp = argp->argnxt.ap;
 		}
 		lexp->arg->argnxt.ap = label_list;

--- a/src/cmd/ksh93/sh/path.c
+++ b/src/cmd/ksh93/sh/path.c
@@ -1000,7 +1000,7 @@ char *path_relative(Shell_t *shp,register const char* file)
 	return((char*)file);
 }
 
-void path_exec(Shell_t *shp,register const char *arg0,register char *argv[],struct argnod *local)
+noreturn void path_exec(Shell_t *shp,register const char *arg0,register char *argv[],struct argnod *local)
 {
 	char **envp;
 	const char *opath;

--- a/src/cmd/ksh93/sh/path.c
+++ b/src/cmd/ksh93/sh/path.c
@@ -1014,7 +1014,7 @@ char *path_relative(Shell_t *shp,register const char* file)
 	return((char*)file);
 }
 
-noreturn void path_exec(Shell_t *shp,register const char *arg0,register char *argv[],struct argnod *local)
+void path_exec(Shell_t *shp,register const char *arg0,register char *argv[],struct argnod *local)
 {
 	char **envp;
 	const char *opath;

--- a/src/cmd/ksh93/sh/shcomp.c
+++ b/src/cmd/ksh93/sh/shcomp.c
@@ -97,14 +97,17 @@ int main(int argc, char *argv[])
 		break;
 	    case '?':
 		errormsg(SH_DICT,ERROR_usage(2),"%s",opt_info.arg);
-		break;
+		UNREACHABLE();
 	}
 	shp = sh_init(argc,argv,(Shinit_f)0);
 	shp->shcomp = 1;
 	argv += opt_info.index;
 	argc -= opt_info.index;
 	if(error_info.errors || argc>2)
+	{
 		errormsg(SH_DICT,ERROR_usage(2),"%s",optusage((char*)0));
+		UNREACHABLE();
+	}
 	if(cp= *argv)
 	{
 		argv++;
@@ -116,7 +119,10 @@ int main(int argc, char *argv[])
 	{
 		struct stat statb;
 		if(!(out = sfopen((Sfio_t*)0,cp,"w")))
+		{
 			errormsg(SH_DICT,ERROR_system(1),"%s: cannot create",cp);
+			UNREACHABLE();
+		}
 		if(fstat(sffileno(out),&statb) >=0)
 			chmod(cp,(statb.st_mode&~S_IFMT)|S_IXUSR|S_IXGRP|S_IXOTH);
 	}
@@ -145,12 +151,18 @@ int main(int argc, char *argv[])
 			if((t->tre.tretyp&(COMMSK|COMSCAN))==0 && t->com.comnamp && strcmp(nv_name((Namval_t*)t->com.comnamp),"alias")==0)
 				sh_exec(t,0);
 			if(!dflag && sh_tdump(out,t) < 0)
+			{
 				errormsg(SH_DICT,ERROR_exit(1),"dump failed");
+				UNREACHABLE();
+			}
 		}
 		else if(sfeof(in))
 			break;
 		if(sferror(in))
+		{
 			errormsg(SH_DICT,ERROR_system(1),"I/O error");
+			UNREACHABLE();
+		}
 		if(t && ((t->tre.tretyp&COMMSK)==TCOM) && (np=t->com.comnamp) && (cp=nv_name(np)))
 		{
 			if(strcmp(cp,"exit")==0)

--- a/src/cmd/ksh93/sh/streval.c
+++ b/src/cmd/ksh93/sh/streval.c
@@ -1021,7 +1021,7 @@ Sfdouble_t strval(Shell_t *shp,const char *s,char **end,Sfdouble_t(*conv)(const 
 	}
 	level=0;
 	errormsg(SH_DICT,ERROR_exit(1),message,ep->name);
-	return(0);
+	UNREACHABLE();
     }
 
 #undef	extern

--- a/src/cmd/ksh93/sh/subshell.c
+++ b/src/cmd/ksh93/sh/subshell.c
@@ -131,7 +131,10 @@ void	sh_subtmpfile(char comsub_flag)
 			close(1);
 		}
 		else if(errno!=EBADF)
+		{
 			errormsg(SH_DICT,ERROR_system(1),e_toomany);
+			UNREACHABLE();
+		}
 		/* popping a discipline forces a /tmp file create */
 		if(comsub_flag != 1)
 			sfdisc(sfstdout,SF_POPDISC);
@@ -149,7 +152,10 @@ void	sh_subtmpfile(char comsub_flag)
 				write(fds[1],sfsetbuf(sfstdout,(Void_t*)sfstdout,0),(size_t)off);
 			sfclose(sfstdout);
 			if((sh_fcntl(fds[1],F_DUPFD, 1)) != 1)
+			{
 				errormsg(SH_DICT,ERROR_system(1),e_file+4);
+				UNREACHABLE();
+			}
 			sh_close(fds[1]);
 		}
 		else
@@ -661,6 +667,7 @@ Sfio_t *sh_subshell(Shell_t *shp,Shnode_t *t, volatile int flags, int comsub)
 			{
 				sfswap(sp->saveout,sfstdout);
 				errormsg(SH_DICT,ERROR_system(1),e_tmpcreate);
+				UNREACHABLE();
 			}
 			sfswap(iop,sfstdout);
 			sfset(sfstdout,SF_READ,0);
@@ -747,6 +754,7 @@ Sfio_t *sh_subshell(Shell_t *shp,Shnode_t *t, volatile int flags, int comsub)
 					shp->toomany = 1;
 					((struct checkpt*)shp->jmplist)->mode = SH_JMPERREXIT;
 					errormsg(SH_DICT,ERROR_system(1),e_toomany);
+					UNREACHABLE();
 				}
 				if(fd >= shp->gd->lim.open_max)
 					sh_iovalidfd(shp,fd);
@@ -932,14 +940,17 @@ Sfio_t *sh_subshell(Shell_t *shp,Shnode_t *t, volatile int flags, int comsub)
 				shp->toomany = 1;
 				errno = saveerrno;
 				errormsg(SH_DICT,ERROR_system(1),e_redirect);
+				UNREACHABLE();
 			case 2:
 				/* reinit PWD as it will be wrong */
 				shp->pwd = NULL;
 				path_pwd(shp,0);
 				errno = saveerrno;
 				errormsg(SH_DICT,ERROR_system(1),"Failed to restore PWD upon exiting subshell");
+				UNREACHABLE();
 			default:
 				errormsg(SH_DICT,ERROR_system(1),"Subshell error %d",fatalerror);
+				UNREACHABLE();
 		}
 	}
 	if(shp->ignsig)

--- a/src/cmd/ksh93/sh/timers.c
+++ b/src/cmd/ksh93/sh/timers.c
@@ -72,7 +72,10 @@ static double setalarm(register double t)
 	tnew.it_interval.tv_sec = 0;
 	tnew.it_interval.tv_usec = 0;
 	if(setitimer(ITIMER_REAL,&tnew,&told) < 0)
+	{
 		errormsg(SH_DICT,ERROR_system(1),e_alarm);
+		UNREACHABLE();
+	}
 	t = told.it_value.tv_sec + 1.e-6*told.it_value.tv_usec;
 #else
 	unsigned seconds = (unsigned)t;

--- a/src/cmd/ksh93/tests/io.sh
+++ b/src/cmd/ksh93/tests/io.sh
@@ -775,4 +775,15 @@ got=$(umask 777; set +x; { cat <(echo ok); } 2>&1)
 [[ $got == ok ]] || err_exit "process substitution failed with umask 777 (got $(printf %q "$got"))"
 
 # ======
+# https://github.com/att/ast/issues/1336
+# Use the /proc psuedo filesystem on Linux as a convenient way to force a write I/O error.
+if [[ $(uname) == Linux ]]
+then
+	actual=$($SHELL -c 'echo > /proc/self/uid_map; echo okay' 2>&1)
+	expect='write.*failed.*okay'
+	[[ "$actual" =~ $expect ]] || err_exit "I/O failure not handled" \
+		"(expected $(printf %q "$expect"), got $(printf %q "$actual"))"
+fi
+
+# ======
 exit $((Errors<125?Errors:125))

--- a/src/lib/libast/comp/waitpid.c
+++ b/src/lib/libast/comp/waitpid.c
@@ -191,7 +191,7 @@ waitpid(pid_t pid, int* status, int flags)
 		zp->next = zombies;
 		zombies = zp;
 	}
-	/*NOTREACHED*/
+	UNREACHABLE();
 }
 
 #endif

--- a/src/lib/libast/dir/readdir.c
+++ b/src/lib/libast/dir/readdir.c
@@ -55,7 +55,7 @@ readdir(register DIR* dirp)
 		dirp->dd_loc += dp->d_reclen;
 		if (dp->d_fileno) return(dp);
 	}
-	/*NOTREACHED*/
+	UNREACHABLE();
 }
 
 #endif

--- a/src/lib/libast/disc/memfatal.c
+++ b/src/lib/libast/disc/memfatal.c
@@ -55,12 +55,12 @@ nomalloc(Vmalloc_t* region, int type, void* obj, Vmdisc_t* disc)
 #ifdef VM_BADADDR
 	case VM_BADADDR:
 		error(ERROR_SYSTEM|3, "invalid pointer %p passed to free or realloc", obj);
-		return(-1);
+		UNREACHABLE();
 #endif
 	case VM_NOMEM:
 		vmstat(region, &st);
 		error(ERROR_SYSTEM|3, "storage allocator out of memory on %lu byte request ( region %lu segments %lu busy %lu:%lu:%lu free %lu:%lu:%lu )", (size_t)obj, st.extent, st.n_seg, st.n_busy, st.s_busy, st.m_busy, st.n_free, st.s_free, st.m_free);
-		return(-1);
+		UNREACHABLE();
 	}
 	return(0);
 }

--- a/src/lib/libast/features/common
+++ b/src/lib/libast/features/common
@@ -659,7 +659,11 @@ tst - note{ does this compiler have __builtin_unreachable() }end output{
 		case 0:
 			__builtin_unreachable();
 		default:
-			printf("#define UNREACHABLE()\t__builtin_unreachable()\n");
+			printf("#if _AST_ksh_release\n");
+			printf("#   define UNREACHABLE()\t__builtin_unreachable()\n");
+			printf("#else\n");
+			printf("#   define UNREACHABLE()\tabort()\n");
+			printf("#endif\n");
 		}
 	}
 	int main(int argc, char *argv[])
@@ -668,5 +672,9 @@ tst - note{ does this compiler have __builtin_unreachable() }end output{
 		return 0;
 	}
 }end fail{
-	echo '#define UNREACHABLE()	0'
+	echo '#if _AST_ksh_release'
+	echo '#   define UNREACHABLE()	0'
+	echo '#else'
+	echo '#   define UNREACHABLE()	abort()'
+	echo '#endif'
 }end

--- a/src/lib/libast/features/common
+++ b/src/lib/libast/features/common
@@ -1,5 +1,5 @@
 iff	AST_COMMON
-hdr	pthread,stdarg,stddef,stdint,inttypes,types,unistd
+hdr	pthread,stdarg,stddef,stdint,stdnoreturn,inttypes,types,unistd
 sys	types
 typ	long.double,size_t,ssize_t
 typ	__va_list stdio.h
@@ -145,6 +145,16 @@ cat{
 	#	define __EXTERN__(T,obj)	extern T obj
 	#	define __DEFINE__(T,obj,val)	T obj = val
 	#endif
+
+	#if !_hdr_stdnoreturn
+	#if defined(__GNUC__) && (__GNUC__ > 2 || (__GNUC__ == 2 && __GNUC_MINOR__ > 4))
+	#define noreturn __attribute__((noreturn))
+	#else
+	#define noreturn
+	#endif /* __GNUC__ */
+	#else
+	#include <stdnoreturn.h>
+	#endif /* _hdr_stdnoreturn */
 }end
 
 if	tst - note{ <stdarg.h>+<wchar.h> works }end compile{
@@ -633,4 +643,30 @@ run{
 	#define __name_h		1
 	#endif
 	!
+}end
+
+tst - note{ does this compiler have __builtin_unreachable() }end output{
+	/*
+	 * To avoid optimizing out the __builtin_unreachable() test call while also avoiding
+	 * executing it, put it in a test function that is called with argc as the argument.
+	 * argc should never be zero on init, but hopefully optimizers aren't that smart.
+	 */
+	#include <stdio.h>
+	void testfn(int a)
+	{
+		switch(a)
+		{
+		case 0:
+			__builtin_unreachable();
+		default:
+			printf("#define UNREACHABLE()\t__builtin_unreachable()\n");
+		}
+	}
+	int main(int argc, char *argv[])
+	{
+		testfn(argc);
+		return 0;
+	}
+}end fail{
+	echo '#define UNREACHABLE()	0'
 }end

--- a/src/lib/libast/misc/stk.c
+++ b/src/lib/libast/misc/stk.c
@@ -120,13 +120,12 @@ static const char Omsg[] = "malloc failed while growing stack\n";
 /*
  * default overflow exception
  */
-static char *overflow(int n)
+static noreturn char *overflow(int n)
 {
 	NoP(n);
 	write(2,Omsg, sizeof(Omsg)-1);
 	exit(2);
-	/* NOTREACHED */
-	return(0);
+	UNREACHABLE();
 }
 
 /*

--- a/src/lib/libcmd/basename.c
+++ b/src/lib/libcmd/basename.c
@@ -122,14 +122,17 @@ b_basename(int argc, register char** argv, Shbltin_t* context)
 			break;
 		case '?':
 			error(ERROR_usage(2), "%s", opt_info.arg);
-			break;
+			UNREACHABLE();
 		}
 		break;
 	}
 	argv += opt_info.index;
 	argc -= opt_info.index;
 	if (error_info.errors || argc < 1 || !all && argc > 2)
+	{
 		error(ERROR_usage(2), "%s", optusage(NiL));
+		UNREACHABLE();
+	}
 	if (!all)
 		namebase(sfstdout, argv[0], argv[1]);
 	else

--- a/src/lib/libcmd/cat.c
+++ b/src/lib/libcmd/cat.c
@@ -463,7 +463,7 @@ b_cat(int argc, char** argv, Shbltin_t* context)
 			break;
 		case '?':
 			error(ERROR_usage(2), "%s", opt_info.arg);
-			break;
+			UNREACHABLE();
 		}
 		if (!n)
 			break;
@@ -474,7 +474,10 @@ b_cat(int argc, char** argv, Shbltin_t* context)
 	}
 	argv += opt_info.index;
 	if (error_info.errors)
+	{
 		error(ERROR_usage(2), "%s", optusage(NiL));
+		UNREACHABLE();
+	}
 	memset(states, 0, sizeof(states));
 	if (flags&V_FLAG)
 	{

--- a/src/lib/libcmd/chgrp.c
+++ b/src/lib/libcmd/chgrp.c
@@ -179,7 +179,10 @@ getids(register char* s, char** e, Key_t* key, int options)
 				if ((m = struid(s)) != NOID)
 					n = m;
 				else if (*z)
+				{
 					error(ERROR_exit(1), "%s: unknown user", s);
+					UNREACHABLE();
+				}
 			}
 			key->uid = n;
 		}
@@ -199,7 +202,10 @@ getids(register char* s, char** e, Key_t* key, int options)
 			if ((m = strgid(s)) != NOID)
 				n = m;
 			else if (*z)
+			{
 				error(ERROR_exit(1), "%s: unknown group", s);
+				UNREACHABLE();
+			}
 		}
 		key->gid = n;
 	}
@@ -241,7 +247,10 @@ b_chgrp(int argc, char** argv, Shbltin_t* context)
 	flags = fts_flags() | FTS_META | FTS_TOP | FTS_NOPOSTORDER | FTS_NOSEEDOTDIR;
 	before = ~0;
 	if (!(sp = sfstropen()))
+	{
 		error(ERROR_SYSTEM|3, "out of space");
+		UNREACHABLE();
+	}
 	sfputr(sp, usage_1, -1);
 	if (error_info.id[2] == 'g')
 		sfputr(sp, usage_grp_1, -1);
@@ -257,14 +266,20 @@ b_chgrp(int argc, char** argv, Shbltin_t* context)
 		sfputr(sp, ERROR_translate(0, 0, 0, "[[owner:]group]"), -1);
 	sfputr(sp, usage_3, -1);
 	if (!(usage = sfstruse(sp)))
+	{
 		error(ERROR_SYSTEM|3, "out of space");
+		UNREACHABLE();
+	}
 	for (;;)
 	{
 		switch (optget(argv, usage))
 		{
 		case 'b':
 			if (stat(opt_info.arg, &st))
+			{
 				error(ERROR_exit(1), "%s: cannot stat", opt_info.arg);
+				UNREACHABLE();
+			}
 			before = st.st_mtime;
 			continue;
 		case 'c':
@@ -282,7 +297,10 @@ b_chgrp(int argc, char** argv, Shbltin_t* context)
 			mapdisc.key = offsetof(Map_t, key);
 			mapdisc.size = sizeof(Key_t);
 			if (!(map = dtopen(&mapdisc, Dtset)))
+			{
 				error(ERROR_exit(1), "out of memory [id map]");
+				UNREACHABLE();
+			}
 			continue;
 		case 'n':
 			options |= OPT_SHOW;
@@ -292,7 +310,10 @@ b_chgrp(int argc, char** argv, Shbltin_t* context)
 			continue;
 		case 'r':
 			if (stat(opt_info.arg, &st))
+			{
 				error(ERROR_exit(1), "%s: cannot stat", opt_info.arg);
+				UNREACHABLE();
+			}
 			uid = st.st_uid;
 			gid = st.st_gid;
 			options |= OPT_UID|OPT_GID;
@@ -325,14 +346,17 @@ b_chgrp(int argc, char** argv, Shbltin_t* context)
 			continue;
 		case '?':
 			error(ERROR_usage(2), "%s", opt_info.arg);
-			break;
+			UNREACHABLE();
 		}
 		break;
 	}
 	argv += opt_info.index;
 	argc -= opt_info.index;
 	if (error_info.errors || argc < 2)
+	{
 		error(ERROR_usage(2), "%s", optusage(NiL));
+		UNREACHABLE();
+	}
 	s = *argv;
 	if (options & OPT_LCHOWN)
 	{
@@ -347,14 +371,20 @@ b_chgrp(int argc, char** argv, Shbltin_t* context)
 		if (streq(s, "-"))
 			sp = sfstdin;
 		else if (!(sp = sfopen(NiL, s, "r")))
+		{
 			error(ERROR_exit(1), "%s: cannot read", s);
+			UNREACHABLE();
+		}
 		while (s = sfgetr(sp, '\n', 1))
 		{
 			getids(s, &t, &key, options);
 			if (!(m = (Map_t*)dtmatch(map, &key)))
 			{
 				if (!(m = (Map_t*)stakalloc(sizeof(Map_t))))
+				{
 					error(ERROR_exit(1), "out of memory [id dictionary]");
+					UNREACHABLE();
+				}
 				m->key = key;
 				m->to.uid = m->to.gid = NOID;
 				dtinsert(map, m);
@@ -389,7 +419,10 @@ b_chgrp(int argc, char** argv, Shbltin_t* context)
 		break;
 	}
 	if (!(fts = fts_open(argv + 1, flags, NiL)))
+	{
 		error(ERROR_system(1), "%s: not found", argv[1]);
+		UNREACHABLE();
+	}
 	while (!sh_checksig(context) && (ent = fts_read(fts)))
 		switch (ent->fts_info)
 		{

--- a/src/lib/libcmd/chmod.c
+++ b/src/lib/libcmd/chmod.c
@@ -202,7 +202,10 @@ b_chmod(int argc, char** argv, Shbltin_t* context)
 			continue;
 		case 'F':
 			if (stat(opt_info.arg, &st))
+			{
 				error(ERROR_exit(1), "%s: cannot stat", opt_info.arg);
+				UNREACHABLE();
+			}
 			mode = st.st_mode;
 			amode = "";
 			continue;
@@ -225,13 +228,16 @@ b_chmod(int argc, char** argv, Shbltin_t* context)
 			continue;
 		case '?':
 			error(ERROR_usage(2), "%s", opt_info.arg);
-			break;
+			UNREACHABLE();
 		}
 		break;
 	}
 	argv += opt_info.index;
 	if (error_info.errors || !*argv || !amode && !*(argv + 1))
+	{
 		error(ERROR_usage(2), "%s", optusage(NiL));
+		UNREACHABLE();
+	}
 	if (chlink)
 	{
 		flags &= ~FTS_META;
@@ -253,6 +259,7 @@ b_chmod(int argc, char** argv, Shbltin_t* context)
 			if (ignore)
 				umask(ignore);
 			error(ERROR_exit(1), "%s: invalid mode", amode);
+			UNREACHABLE();
 		}
 	}
 	if (!(fts = fts_open(argv, flags, NiL)))
@@ -260,6 +267,7 @@ b_chmod(int argc, char** argv, Shbltin_t* context)
 		if (ignore)
 			umask(ignore);
 		error(ERROR_system(1), "%s: not found", *argv);
+		UNREACHABLE();
 	}
 	while (!sh_checksig(context) && (ent = fts_read(fts)))
 		switch (ent->fts_info)

--- a/src/lib/libcmd/cksum.c
+++ b/src/lib/libcmd/cksum.c
@@ -307,7 +307,10 @@ verify(State_t* state, register char* s, char* check, Sfio_t* rp)
 		{
 			pr(state, rp, sp, file, -1, NiL, NiL);
 			if (!(t = sfstruse(rp)))
+			{
 				error(ERROR_SYSTEM|3, "out of space");
+				UNREACHABLE();
+			}
 			if (!streq(s, t))
 			{
 				if (state->silent)
@@ -528,8 +531,8 @@ b_cksum(int argc, register char** argv, Shbltin_t* context)
 			state.text = 1;
 			continue;
 		case '?':
-			error(ERROR_USAGE|4, "%s", opt_info.arg);
-			break;
+			error(ERROR_usage(2), "%s", opt_info.arg);
+			UNREACHABLE();
 		case ':':
 			error(2, "%s", opt_info.arg);
 			break;
@@ -538,7 +541,10 @@ b_cksum(int argc, register char** argv, Shbltin_t* context)
 	}
 	argv += opt_info.index;
 	if (error_info.errors)
-		error(ERROR_USAGE|4, "%s", optusage(NiL));
+	{
+		error(ERROR_usage(2), "%s", optusage(NiL));
+		UNREACHABLE();
+	}
 
 	/*
 	 * check the method
@@ -590,7 +596,10 @@ b_cksum(int argc, register char** argv, Shbltin_t* context)
 	else if (!*argv && !state.recursive)
 		pr(&state, sfstdout, sfstdin, "/dev/stdin", state.permissions, NiL, state.check);
 	else if (!(fts = fts_open(argv, flags, state.sort)))
+	{
 		error(ERROR_system(1), "%s: not found", *argv);
+		UNREACHABLE();
+	}
 	else
 	{
 		while (!sh_checksig(context) && (ent = fts_read(fts)))

--- a/src/lib/libcmd/cmp.c
+++ b/src/lib/libcmd/cmp.c
@@ -165,15 +165,24 @@ cmp(const char* file1, Sfio_t* f1, const char* file2, Sfio_t* f2, int flags, Sfo
 			if (!(p1 = (unsigned char*)sfreserve(f1, SF_UNBOUND, 0)) || (c1 = sfvalue(f1)) <= 0)
 			{
 				if (sferror(f1))
+				{
 					error(ERROR_exit(2), "read error on %s", file1);
+					UNREACHABLE();
+				}
 				if ((e2 - p2) > 0 || sfreserve(f2, SF_UNBOUND, 0) && sfvalue(f2) > 0)
 				{
 					ret = 1;
 					if (!(flags & CMP_SILENT))
+					{
 						error(ERROR_exit(1), "EOF on %s", file1);
+						UNREACHABLE();
+					}
 				}
 				if (sferror(f2))
+				{
 					error(ERROR_exit(2), "read error on %s", file2);
+					UNREACHABLE();
+				}
 				return ret;
 			}
 			if (count > 0 && c1 > count)
@@ -186,9 +195,15 @@ cmp(const char* file1, Sfio_t* f1, const char* file2, Sfio_t* f2, int flags, Sfo
 			if (!(p2 = (unsigned char*)sfreserve(f2, SF_UNBOUND, 0)) || (c2 = sfvalue(f2)) <= 0)
 			{
 				if (sferror(f2))
+				{
 					error(ERROR_exit(2), "read error on %s", file2);
+					UNREACHABLE();
+				}
 				if (!(flags & CMP_SILENT))
+				{
 					error(ERROR_exit(1), "EOF on %s", file2);
+					UNREACHABLE();
+				}
 				return 1;
 			}
 			e2 = p2 + c2;
@@ -311,13 +326,16 @@ b_cmp(int argc, register char** argv, Shbltin_t* context)
 			break;
 		case '?':
 			error(ERROR_usage(2), "%s", opt_info.arg);
-			break;
+			UNREACHABLE();
 		}
 		break;
 	}
 	argv += opt_info.index;
 	if (error_info.errors || !(file1 = *argv++) || !(file2 = *argv++))
+	{
 		error(ERROR_usage(2), "%s", optusage(NiL));
+		UNREACHABLE();
+	}
 	n = 2;
 	if (streq(file1, "-"))
 		f1 = sfstdin;

--- a/src/lib/libcmd/comm.c
+++ b/src/lib/libcmd/comm.c
@@ -170,28 +170,40 @@ b_comm(int argc, char *argv[], Shbltin_t* context)
 			break;
 		case '?':
 			error(ERROR_usage(2), "%s",opt_info.arg);
-			break;
+			UNREACHABLE();
 		}
 		break;
 	}
 	argv += opt_info.index;
 	argc -= opt_info.index;
 	if(error_info.errors || argc!=2)
+	{
 		error(ERROR_usage(2),"%s",optusage(NiL));
+		UNREACHABLE();
+	}
 	cp = *argv++;
 	if(streq(cp,"-"))
 		f1 = sfstdin;
 	else if(!(f1 = sfopen(NiL, cp,"r")))
+	{
 		error(ERROR_system(1),"%s: cannot open",cp);
+		UNREACHABLE();
+	}
 	cp = *argv;
 	if(streq(cp,"-"))
 		f2 = sfstdin;
 	else if(!(f2 = sfopen(NiL, cp,"r")))
+	{
 		error(ERROR_system(1),"%s: cannot open",cp);
+		UNREACHABLE();
+	}
 	if(mode)
 	{
 		if(comm(f1,f2,sfstdout,mode) < 0)
+		{
 			error(ERROR_system(1)," write error");
+			UNREACHABLE();
+		}
 	}
 	else if(f1==sfstdin || f2==sfstdin)
 		sfseek(sfstdin,(Sfoff_t)0,SEEK_END);

--- a/src/lib/libcmd/cp.c
+++ b/src/lib/libcmd/cp.c
@@ -289,7 +289,10 @@ visit(State_t* state, register FTSENT* ent)
 	if (state->directory)
 	{
 		if ((state->postsiz + len) > state->pathsiz && !(state->path = newof(state->path, char, state->pathsiz = roundof(state->postsiz + len, PATH_CHUNK), 0)))
+		{
 			error(ERROR_SYSTEM|3, "out of memory");
+			UNREACHABLE();
+		}
 		if (state->hierarchy && ent->fts_level == 0 && strchr(base, '/'))
 		{
 			s = state->path + state->postsiz;
@@ -525,7 +528,10 @@ visit(State_t* state, register FTSENT* ent)
 			sfprintf(state->tmp, "%s%s", state->path, state->suffix);
 		backup:
 			if (!(s = sfstruse(state->tmp)))
+			{
 				error(ERROR_SYSTEM|3, "%s: out of space", state->path);
+				UNREACHABLE();
+			}
 			if (rename(state->path, s))
 			{
 				error(ERROR_SYSTEM|2, "%s: cannot backup to %s", state->path, s);
@@ -688,7 +694,10 @@ b_cp(int argc, register char** argv, Shbltin_t* context)
 	if (!(sh = CMD_CONTEXT(context)) || !(state = (State_t*)sh->ptr))
 	{
 		if (!(state = newof(0, State_t, 1, 0)))
+		{
 			error(ERROR_SYSTEM|3, "out of memory");
+			UNREACHABLE();
+		}
 		if (sh)
 			sh->ptr = state;
 	}
@@ -701,7 +710,10 @@ b_cp(int argc, register char** argv, Shbltin_t* context)
 	state->uid = geteuid();
 	state->wflags = O_WRONLY|O_CREAT|O_TRUNC|O_BINARY;
 	if (!state->tmp && !(state->tmp = sfstropen()))
+	{
 		error(ERROR_SYSTEM|3, "out of space [tmp string]");
+		UNREACHABLE();
+	}
 	sfputr(state->tmp, usage_head, -1);
 	standard = !!conformance(0, 0);
 	switch (error_info.id[0])
@@ -738,7 +750,10 @@ b_cp(int argc, register char** argv, Shbltin_t* context)
 	}
 	sfputr(state->tmp, usage_tail, -1);
 	if (!(usage = sfstruse(state->tmp)))
+	{
 		error(ERROR_SYSTEM|3, "%s: out of space", state->path);
+		UNREACHABLE();
+	}
 	state->opname = state->op == CP ? ERROR_translate(0, 0, 0, "overwrite") : ERROR_translate(0, 0, 0, "replace");
 	for (;;)
 	{
@@ -873,7 +888,10 @@ b_cp(int argc, register char** argv, Shbltin_t* context)
 		argv++;
 	}
 	if (!(v = (char**)stkalloc(stkstd, (argc + 2) * sizeof(char*))))
+	{
 		error(ERROR_SYSTEM|3, "out of memory");
+		UNREACHABLE();
+	}
 	memcpy(v, argv, (argc + 1) * sizeof(char*));
 	argv = v;
 	if (!standard)
@@ -940,7 +958,10 @@ b_cp(int argc, register char** argv, Shbltin_t* context)
 		state->suflen = strlen(state->suffix);
 	}
 	if (argc <= 0 || error_info.errors)
-		error(ERROR_USAGE|4, "%s", optusage(NiL));
+	{
+		error(ERROR_usage(2), "%s", optusage(NiL));
+		UNREACHABLE();
+	}
 	if (!path_resolve)
 		state->flags |= fts_flags() | FTS_META;
 	file = argv[argc];
@@ -955,12 +976,18 @@ b_cp(int argc, register char** argv, Shbltin_t* context)
 	if (file != (char*)dot)
 		pathcanon(file, 0, 0);
 	if (!(state->directory = !stat(file, &st) && S_ISDIR(st.st_mode)) && argc > 1)
-		error(ERROR_USAGE|4, "%s", optusage(NiL));
+	{
+		error(ERROR_usage(2), "%s", optusage(NiL));
+		UNREACHABLE();
+	}
 	if (s && !state->directory)
 		error(3, "%s: not a directory", file);
 	state->postsiz = strlen(file);
 	if (state->pathsiz < roundof(state->postsiz + 2, PATH_CHUNK) && !(state->path = newof(state->path, char, state->pathsiz = roundof(state->postsiz + 2, PATH_CHUNK), 0)))
+	{
 		error(ERROR_SYSTEM|3, "out of memory");
+		UNREACHABLE();
+	}
 	memcpy(state->path, file, state->postsiz + 1);
 	if (state->directory && state->path[state->postsiz - 1] != '/')
 		state->path[state->postsiz++] = '/';

--- a/src/lib/libcmd/cut.c
+++ b/src/lib/libcmd/cut.c
@@ -138,7 +138,10 @@ cutinit(int mode, char* str, Delim_t* wdelim, Delim_t* ldelim, size_t reclen)
 	Cut_t*		cut;
 
 	if (!(cut = (Cut_t*)stakalloc(sizeof(Cut_t) + strlen(cp) * sizeof(int))))
+	{
 		error(ERROR_exit(1), "out of memory");
+		UNREACHABLE();
+	}
 	if (cut->mb = mbwide())
 	{
 		memset(cut->space, 0, sizeof(cut->space) / 2);
@@ -172,7 +175,10 @@ cutinit(int mode, char* str, Delim_t* wdelim, Delim_t* ldelim, size_t reclen)
 			{
 				--range;
 				if((n = (n ? (n-range) : (HUGE-1))) < 0)
+				{
 					error(ERROR_exit(1),"invalid range for c/f option");
+					UNREACHABLE();
+				}
 				*lp++ = range;
 				*lp++ = n;
 			}
@@ -230,18 +236,24 @@ cutinit(int mode, char* str, Delim_t* wdelim, Delim_t* ldelim, size_t reclen)
 
 		case '-':
 			if(range)
+			{
 				error(ERROR_exit(1),"bad list for c/f option");
+				UNREACHABLE();
+			}
 			range = n?n:1;
 			n = 0;
 			break;
 
 		default:
 			if(!isdigit(c))
+			{
 				error(ERROR_exit(1),"bad list for c/f option");
+				UNREACHABLE();
+			}
 			n = 10*n + (c-'0');
 			break;
 		}
-	/* NOTREACHED */
+	UNREACHABLE();
 }
 
 /*
@@ -659,17 +671,21 @@ b_cut(int argc, char** argv, Shbltin_t* context)
 			break;
 		case '?':
 			error(ERROR_usage(2), "%s", opt_info.arg);
-			break;
+			UNREACHABLE();
 		}
 		break;
 	}
 	argv += opt_info.index;
 	if (error_info.errors)
+	{
 		error(ERROR_usage(2), "%s",optusage(NiL));
+		UNREACHABLE();
+	}
 	if(!cp)
 	{
 		error(2, "b, c or f option must be specified");
 		error(ERROR_usage(2), "%s", optusage(NiL));
+		UNREACHABLE();
 	}
 	if(!*cp)
 		error(3, "non-empty b, c or f option must be specified");

--- a/src/lib/libcmd/date.c
+++ b/src/lib/libcmd/date.c
@@ -341,7 +341,10 @@ b_date(int argc, register char** argv, Shbltin_t* context)
 			continue;
 		case 'p':
 			if (!(f = newof(0, Fmt_t, 1, 0)))
+			{
 				error(ERROR_SYSTEM|3, "out of memory [format]");
+				UNREACHABLE();
+			}
 			f->next = fmts;
 			f->format = opt_info.arg;
 			fmts = f;
@@ -376,8 +379,8 @@ b_date(int argc, register char** argv, Shbltin_t* context)
 			listzones = tm_data.zone;
 			continue;
 		case '?':
-			error(ERROR_USAGE|4, "%s", opt_info.arg);
-			continue;
+			error(ERROR_usage(2), "%s", opt_info.arg);
+			UNREACHABLE();
 		case ':':
 			error(2, "%s", opt_info.arg);
 			continue;
@@ -386,7 +389,10 @@ b_date(int argc, register char** argv, Shbltin_t* context)
 	}
 	argv += opt_info.index;
 	if (error_info.errors)
-		error(ERROR_USAGE|4, "%s", optusage(NiL));
+	{
+		error(ERROR_usage(2), "%s", optusage(NiL));
+		UNREACHABLE();
+	}
 	now = tmxgettime();
 	if (listzones)
 	{
@@ -434,7 +440,10 @@ b_date(int argc, register char** argv, Shbltin_t* context)
 	else if (filetime)
 	{
 		if (!*argv)
-			error(ERROR_USAGE|4, "%s", optusage(NiL));
+		{
+			error(ERROR_usage(2), "%s", optusage(NiL));
+			UNREACHABLE();
+		}
 		n = argv[1] != 0;
 		while (s = *argv++)
 		{
@@ -474,7 +483,10 @@ b_date(int argc, register char** argv, Shbltin_t* context)
 		if (s || (s = string))
 		{
 			if (*argv && string)
-				error(ERROR_USAGE|4, "%s", optusage(NiL));
+			{
+				error(ERROR_usage(2), "%s", optusage(NiL));
+				UNREACHABLE();
+			}
 			now = convert(fmts, s, now);
 			if (*argv && (s = *++argv))
 			{
@@ -498,7 +510,10 @@ b_date(int argc, register char** argv, Shbltin_t* context)
 			sfprintf(sfstdout, "%s\n", buf);
 		}
 		else if (settime(context, cmd, now, increment, network))
+		{
 			error(ERROR_SYSTEM|3, "cannot set system time");
+			UNREACHABLE();
+		}
 	}
 	while (fmts != &fmt)
 	{

--- a/src/lib/libcmd/dirname.c
+++ b/src/lib/libcmd/dirname.c
@@ -121,14 +121,17 @@ b_dirname(int argc, char** argv, Shbltin_t* context)
 			break;
 		case '?':
 			error(ERROR_usage(2), "%s", opt_info.arg);
-			break;
+			UNREACHABLE();
 		}
 		break;
 	}
 	argv += opt_info.index;
 	argc -= opt_info.index;
 	if(error_info.errors || argc != 1)
+	{
 		error(ERROR_usage(2),"%s", optusage(NiL));
+		UNREACHABLE();
+	}
 	if(!mode)
 		l_dirname(sfstdout,argv[0]);
 	else if(pathpath(argv[0], "", mode, buf, sizeof(buf)))

--- a/src/lib/libcmd/expr.c
+++ b/src/lib/libcmd/expr.c
@@ -193,7 +193,10 @@ static int getnode(State_t* state, Node_t *np)
 	char*		ep;
 
 	if (!(cp = *state->arglist++))
+	{
 		error(ERROR_exit(2), "argument expected");
+		UNREACHABLE();
+	}
 	if (!state->standard)
 		switch (cp[0])
 		{
@@ -201,9 +204,15 @@ static int getnode(State_t* state, Node_t *np)
 			if (cp[1] == 'n' && !strcmp(cp, "index"))
 			{
 				if (!(cp = *state->arglist++))
+				{
 					error(ERROR_exit(2), "string argument expected");
+					UNREACHABLE();
+				}
 				if (!(ep = *state->arglist++))
+				{
 					error(ERROR_exit(2), "chars argument expected");
+					UNREACHABLE();
+				}
 				np->num = (ep = strpbrk(cp, ep)) ? (ep - cp + 1) : 0;
 				np->type = T_NUM;
 				goto next;
@@ -213,7 +222,10 @@ static int getnode(State_t* state, Node_t *np)
 			if (cp[1] == 'e' && !strcmp(cp, "length"))
 			{
 				if (!(cp = *state->arglist++))
+				{
 					error(ERROR_exit(2), "string argument expected");
+					UNREACHABLE();
+				}
 				np->num = strlen(cp);
 				np->type = T_NUM;
 				goto next;
@@ -223,27 +235,42 @@ static int getnode(State_t* state, Node_t *np)
 			if (cp[1] == 'a' && !strcmp(cp, "match"))
 			{
 				if (!(np->str = *state->arglist++))
+				{
 					error(ERROR_exit(2), "pattern argument expected");
+					UNREACHABLE();
+				}
 				np->type = T_STR;
 				return ':';
 			}
 			break;
 		case 'q':
 			if (cp[1] == 'u' && !strcmp(cp, "quote") && !(cp = *state->arglist++))
+			{
 				error(ERROR_exit(2), "string argument expected");
+				UNREACHABLE();
+			}
 			break;
 		case 's':
 			if (cp[1] == 'u' && !strcmp(cp, "substr"))
 			{
 				if (!(sp = *state->arglist++))
+				{
 					error(ERROR_exit(2), "string argument expected");
+					UNREACHABLE();
+				}
 				if (!(cp = *state->arglist++))
+				{
 					error(ERROR_exit(2), "position argument expected");
+					UNREACHABLE();
+				}
 				i = strtol(cp, &ep, 10);
 				if (*ep || --i < 0)
 					i = -1;
 				if (!(cp = *state->arglist++))
+				{
 					error(ERROR_exit(2), "length argument expected");
+					UNREACHABLE();
+				}
 				j = strtol(cp, &ep, 10);
 				if (*ep)
 					j = -1;
@@ -267,7 +294,10 @@ static int getnode(State_t* state, Node_t *np)
 	{
 		tok = expr_or(state, np);
 		if (tok != ')')
+		{
 			error(ERROR_exit(2),"closing parenthesis missing");
+			UNREACHABLE();
+		}
 	}
 	else
 	{
@@ -288,7 +318,7 @@ static int getnode(State_t* state, Node_t *np)
 		if (*cp==optable[i].opname[0] && cp[1]==optable[i].opname[1])
 			return optable[i].op;
 	error(ERROR_exit(2),"%s: unknown operator argument",cp);
-	return 0;
+	UNREACHABLE();
 }
 
 static int expr_cond(State_t* state, Node_t *np)
@@ -352,9 +382,15 @@ static int expr_mult(State_t* state, Node_t *np)
 		int op = (tok&T_OP);
 		tok = expr_cond(state, &rp);
 		if (!numeric(np) || !numeric(&rp))
+		{
 			error(ERROR_exit(2),"non-numeric argument");
+			UNREACHABLE();
+		}
 		if (op && rp.num==0)
+		{
 			error(ERROR_exit(2),"division by zero");
+			UNREACHABLE();
+		}
 		switch(op)
 		{
 		    case 0:
@@ -381,7 +417,10 @@ static int expr_add(State_t* state, Node_t *np)
 		int op = (tok&T_OP);
 		tok = expr_mult(state, &rp);
 		if (!numeric(np) || !numeric(&rp))
+		{
 			error(ERROR_exit(2),"non-numeric argument");
+			UNREACHABLE();
+		}
 		if (op)
 			np->num -= rp.num;
 		else
@@ -513,17 +552,27 @@ b_expr(int argc, char** argv, Shbltin_t* context)
 			 *	 unknown - options
 			 */
 			if(n=='?')
+			{
 				error(ERROR_usage(2), "%s", opt_info.arg);
+				UNREACHABLE();
+			}
 			if (opt_info.option[1] != '?')
 				break;
 			error(ERROR_usage(2), "%s", opt_info.arg);
+			UNREACHABLE();
 		}
 		if (error_info.errors)
+		{
 			error(ERROR_usage(2),"%s",optusage((char*)0));
+			UNREACHABLE();
+		}
 		state.arglist = argv+opt_info.index;
 	}
 	if (expr_or(&state, &node))
+	{
 		error(ERROR_exit(2),"syntax error");
+		UNREACHABLE();
+	}
 	if (node.type&T_STR)
 	{
 		if (*node.str)

--- a/src/lib/libcmd/fds.c
+++ b/src/lib/libcmd/fds.c
@@ -199,8 +199,8 @@ b_fds(int argc, char** argv, Shbltin_t* context)
 			unit = opt_info.num;
 			continue;
 		case '?':
-			error(ERROR_USAGE|4, "%s", opt_info.arg);
-			break;
+			error(ERROR_usage(2), "%s", opt_info.arg);
+			UNREACHABLE();
 		case ':':
 			error(2, "%s", opt_info.arg);
 			break;
@@ -209,13 +209,19 @@ b_fds(int argc, char** argv, Shbltin_t* context)
 	}
 	argv += opt_info.index;
 	if (error_info.errors || *argv)
-		error(ERROR_USAGE|4, "%s", optusage(NiL));
+	{
+		error(ERROR_usage(2), "%s", optusage(NiL));
+		UNREACHABLE();
+	}
 	if ((open_max = getconf("OPEN_MAX")) <= 0)
 		open_max = OPEN_MAX;
 	if (unit == 1)
 		sp = sfstdout;
 	else if (fstat(unit, &st) || !(sp = sfnew(NiL, NiL, SF_UNBOUND, unit, SF_WRITE)))
+	{
 		error(ERROR_SYSTEM|3, "%d: cannot write to file descriptor");
+		UNREACHABLE();
+	}
 	for (i = 0; i <= open_max; i++)
 	{
 		if (fstat(i, &st))

--- a/src/lib/libcmd/fmt.c
+++ b/src/lib/libcmd/fmt.c
@@ -602,13 +602,16 @@ b_fmt(int argc, char** argv, Shbltin_t* context)
 			break;
 		case '?':
 			error(ERROR_usage(2), "%s", opt_info.arg);
-			break;
+			UNREACHABLE();
 		}
 		break;
 	}
 	argv += opt_info.index;
 	if (error_info.errors)
+	{
 		error(ERROR_usage(2), "%s", optusage(NiL));
+		UNREACHABLE();
+	}
 	if (isoption(&fmt, 'o'))
 		setoption(&fmt, 'c');
 	if (isoption(&fmt, 's'))

--- a/src/lib/libcmd/fold.c
+++ b/src/lib/libcmd/fold.c
@@ -211,14 +211,17 @@ b_fold(int argc, char** argv, Shbltin_t* context)
 			continue;
 		case '?':
 			error(ERROR_usage(2), "%s", opt_info.arg);
-			continue;
+			UNREACHABLE();
 		}
 		break;
 	}
 	argv += opt_info.index;
 	argc -= opt_info.index;
 	if(error_info.errors)
+	{
 		error(ERROR_usage(2),"%s", optusage(NiL));
+		UNREACHABLE();
+	}
 	if(cp = *argv)
 		argv++;
 	do

--- a/src/lib/libcmd/getconf.c
+++ b/src/lib/libcmd/getconf.c
@@ -219,7 +219,7 @@ b_getconf(int argc, char** argv, Shbltin_t* context)
 			break;
 		case '?':
 			error(ERROR_usage(2), "%s", opt_info.arg);
-			break;
+			UNREACHABLE();
 		}
 		break;
 	}
@@ -237,7 +237,10 @@ b_getconf(int argc, char** argv, Shbltin_t* context)
 		}
 	}
 	if (error_info.errors || !name && *argv)
+	{
 		error(ERROR_usage(2), "%s", optusage(NiL));
+		UNREACHABLE();
+	}
 	if (!name)
 		astconflist(sfstdout, path, flags, pattern);
 	else

--- a/src/lib/libcmd/head.c
+++ b/src/lib/libcmd/head.c
@@ -108,7 +108,7 @@ b_head(int argc, register char** argv, Shbltin_t* context)
 			continue;
 		case '?':
 			error(ERROR_usage(2), "%s", opt_info.arg);
-			continue;
+			UNREACHABLE();
 		case ':':
 			error(2, "%s", opt_info.arg);
 			continue;
@@ -118,7 +118,10 @@ b_head(int argc, register char** argv, Shbltin_t* context)
 	argv += opt_info.index;
 	argc -= opt_info.index;
 	if (error_info.errors)
+	{
 		error(ERROR_usage(2), "%s", optusage(NiL));
+		UNREACHABLE();
+	}
 	if (cp = *argv)
 		argv++;
 	do

--- a/src/lib/libcmd/id.c
+++ b/src/lib/libcmd/id.c
@@ -232,7 +232,10 @@ getids(Sfio_t* sp, const char* name, register int flags)
 			if ((maxgroups = getgroups(0, groups)) <= 0)
 				maxgroups = NGROUPS_MAX;
 			if (!(groups = newof(0, gid_t, maxgroups + 1, 0)))
+			{
 				error(ERROR_exit(1), "out of memory [group array]");
+				UNREACHABLE();
+			}
 		}
 		ngroups = getgroups(maxgroups, groups);
 		for (i = j = 0; i < ngroups; i++)
@@ -251,7 +254,10 @@ getids(Sfio_t* sp, const char* name, register int flags)
 			{
 				user = strtol(name, &s, 0);
 				if (*s || !(pw = getpwuid(user)))
+				{
 					error(ERROR_exit(1), "%s: name not found", name);
+					UNREACHABLE();
+				}
 				name = pw->pw_name;
 			}
 			user = pw->pw_uid;
@@ -264,7 +270,10 @@ getids(Sfio_t* sp, const char* name, register int flags)
 			do
                         {
                                 if (!(fs = getfsgnam(name)))
+				{
                                         error(ERROR_exit(1), "%u: fss name not found", name);
+					UNREACHABLE();
+				}
                         } while (isfsg(fs));
                         fs_id = fs->fs_id;
 		}
@@ -451,7 +460,7 @@ b_id(int argc, char** argv, Shbltin_t* context)
 			break;
 		case '?':
 			error(ERROR_usage(2), "%s", opt_info.arg);
-			break;
+			UNREACHABLE();
 		}
 		break;
 	}
@@ -461,7 +470,10 @@ b_id(int argc, char** argv, Shbltin_t* context)
 	if (!power2(n))
 		error(2, "incompatible options selected");
 	if (error_info.errors || argc > 1)
+	{
 		error(ERROR_usage(2), "%s", optusage(NiL));
+		UNREACHABLE();
+	}
 	if (!(flags & ~(N_FLAG|R_FLAG)))
 	{
 		if (flags & N_FLAG) flags |= O_FLAG;

--- a/src/lib/libcmd/join.c
+++ b/src/lib/libcmd/join.c
@@ -824,7 +824,10 @@ b_join(int argc, char** argv, Shbltin_t* context)
 	cmdinit(argc, argv, context, ERROR_CATALOG, ERROR_NOTIFY);
 #endif
 	if (!(jp = init()))
+	{
 		error(ERROR_system(1),"out of memory");
+		UNREACHABLE();
+	}
 	jp->context = context;
 	for (;;)
 	{
@@ -918,7 +921,7 @@ b_join(int argc, char** argv, Shbltin_t* context)
 		case '?':
 			done(jp);
 			error(ERROR_usage(2), "%s", opt_info.arg);
-			break;
+			UNREACHABLE();
 		}
 		break;
 	}
@@ -928,6 +931,7 @@ b_join(int argc, char** argv, Shbltin_t* context)
 	{
 		done(jp);
 		error(ERROR_usage(2),"%s", optusage(NiL));
+		UNREACHABLE();
 	}
 	jp->ooutmode = jp->outmode;
 	jp->file[0].name = cp = *argv++;
@@ -946,6 +950,7 @@ b_join(int argc, char** argv, Shbltin_t* context)
 	{
 		done(jp);
 		error(ERROR_system(1),"%s: cannot open",cp);
+		UNREACHABLE();
 	}
 	jp->file[1].name = cp = *argv;
 	if (streq(cp,"-"))
@@ -963,6 +968,7 @@ b_join(int argc, char** argv, Shbltin_t* context)
 	{
 		done(jp);
 		error(ERROR_system(1),"%s: cannot open",cp);
+		UNREACHABLE();
 	}
 	if (jp->buffered)
 	{
@@ -976,6 +982,7 @@ b_join(int argc, char** argv, Shbltin_t* context)
 	{
 		done(jp);
 		error(ERROR_system(1),"write error");
+		UNREACHABLE();
 	}
 	else if (jp->file[0].iop==sfstdin || jp->file[1].iop==sfstdin)
 		sfseek(sfstdin,(Sfoff_t)0,SEEK_END);

--- a/src/lib/libcmd/logname.c
+++ b/src/lib/libcmd/logname.c
@@ -64,12 +64,15 @@ b_logname(int argc, char** argv, Shbltin_t* context)
 			continue;
 		case '?':
 			error(ERROR_usage(2), "%s", opt_info.arg);
-			continue;
+			UNREACHABLE();
 		}
 		break;
 	}
 	if (error_info.errors)
+	{
 		error(ERROR_usage(2), "%s", optusage(NiL));
+		UNREACHABLE();
+	}
 	if (!(logname = getlogin()))
 		logname = fmtuid(getuid());
 	sfputr(sfstdout, logname, '\n');

--- a/src/lib/libcmd/mkdir.c
+++ b/src/lib/libcmd/mkdir.c
@@ -98,13 +98,16 @@ b_mkdir(int argc, char** argv, Shbltin_t* context)
 			break;
 		case '?':
 			error(ERROR_usage(2), "%s", opt_info.arg);
-			break;
+			UNREACHABLE();
 		}
 		break;
 	}
 	argv += opt_info.index;
 	if (error_info.errors || !*argv)
+	{
 		error(ERROR_usage(2), "%s", optusage(NiL));
+		UNREACHABLE();
+	}
 	mask = umask(0);
 	if (mflag || pflag)
 	{

--- a/src/lib/libcmd/mkfifo.c
+++ b/src/lib/libcmd/mkfifo.c
@@ -73,13 +73,16 @@ b_mkfifo(int argc, char** argv, Shbltin_t* context)
 			break;
 		case '?':
 			error(ERROR_usage(2), "%s", opt_info.arg);
-			break;
+			UNREACHABLE();
 		}
 		break;
 	}
 	argv += opt_info.index;
 	if (error_info.errors || !*argv)
+	{
 		error(ERROR_usage(2), "%s", optusage(NiL));
+		UNREACHABLE();
+	}
 	mask = umask(0);
 	if (!mflag)
 	{

--- a/src/lib/libcmd/mktemp.c
+++ b/src/lib/libcmd/mktemp.c
@@ -116,13 +116,16 @@ b_mktemp(int argc, char** argv, Shbltin_t* context)
 			break;
 		case '?':
 			error(ERROR_usage(2), "%s", opt_info.arg);
-			break;
+			UNREACHABLE();
 		}
 		break;
 	}
 	argv += opt_info.index;
 	if (error_info.errors || (pfx = *argv++) && *argv)
+	{
 		error(ERROR_usage(2), "%s", optusage(NiL));
+		UNREACHABLE();
+	}
 	mask = umask(0);
 	if (!mode)
 		mode = (fdp ? (S_IRUSR|S_IWUSR) : S_IRWXU) & ~mask;

--- a/src/lib/libcmd/paste.c
+++ b/src/lib/libcmd/paste.c
@@ -199,13 +199,16 @@ b_paste(int argc, char** argv, Shbltin_t* context)
 			break;
 		case '?':
 			error(ERROR_usage(2), "%s", opt_info.arg);
-			break;
+			UNREACHABLE();
 		}
 		break;
 	}
 	argv += opt_info.index;
 	if(error_info.errors)
+	{
 		error(ERROR_usage(2),"%s", optusage(NiL));
+		UNREACHABLE();
+	}
 	if(!delim || !*delim)
 	{
 		delim = defdelim;
@@ -213,7 +216,10 @@ b_paste(int argc, char** argv, Shbltin_t* context)
 		delim[1] = 0;
 	}
 	if (!(delim = strdup(delim)))
+	{
 		error(ERROR_system(1), "out of memory");
+		UNREACHABLE();
+	}
 	dlen = dsiz = stresc(delim);
 	mp = 0;
 	if (mbwide())
@@ -232,6 +238,7 @@ b_paste(int argc, char** argv, Shbltin_t* context)
 			{
 				free(delim);
 				error(ERROR_system(1), "out of memory");
+				UNREACHABLE();
 			}
 			cp = delim;
 			dlen = 0;
@@ -254,7 +261,10 @@ b_paste(int argc, char** argv, Shbltin_t* context)
 	if(!sflag)
 	{
 		if (!(streams = (Sfio_t**)stakalloc(n*sizeof(Sfio_t*))))
+		{
 			error(ERROR_exit(1), "out of memory");
+			UNREACHABLE();
+		}
 		n = 0;
 	}
 	do

--- a/src/lib/libcmd/pathchk.c
+++ b/src/lib/libcmd/pathchk.c
@@ -252,13 +252,16 @@ b_pathchk(int argc, char** argv, Shbltin_t* context)
 			break;
 		case '?':
 			error(ERROR_usage(2), "%s", opt_info.arg);
-			break;
+			UNREACHABLE();
 		}
 		break;
 	}
 	argv += opt_info.index;
 	if (!*argv || error_info.errors)
+	{
 		error(ERROR_usage(2),"%s", optusage(NiL));
+		UNREACHABLE();
+	}
 	while (s = *argv++)
 		pathchk(s, mode);
 	return error_info.errors != 0;

--- a/src/lib/libcmd/pids.c
+++ b/src/lib/libcmd/pids.c
@@ -105,8 +105,8 @@ b_pids(int argc, char** argv, Shbltin_t* context)
 			format = opt_info.arg;
 			continue;
 		case '?':
-			error(ERROR_USAGE|4, "%s", opt_info.arg);
-			break;
+			error(ERROR_usage(2), "%s", opt_info.arg);
+			UNREACHABLE();
 		case ':':
 			error(2, "%s", opt_info.arg);
 			break;
@@ -115,7 +115,10 @@ b_pids(int argc, char** argv, Shbltin_t* context)
 	}
 	argv += opt_info.index;
 	if (error_info.errors || *argv)
-		error(ERROR_USAGE|4, "%s", optusage(NiL));
+	{
+		error(ERROR_usage(2), "%s", optusage(NiL));
+		UNREACHABLE();
+	}
 	if (!format)
 		format = FORMAT;
 	sfkeyprintf(sfstdout, format, format, key, NiL);

--- a/src/lib/libcmd/rev.c
+++ b/src/lib/libcmd/rev.c
@@ -134,13 +134,16 @@ b_rev(int argc, register char** argv, Shbltin_t* context)
 			break;
 		case '?':
 			error(ERROR_usage(2), "%s", opt_info.arg);
-			break;
+			UNREACHABLE();
 		}
 		break;
 	}
 	argv += opt_info.index;
 	if(error_info.errors)
+	{
 		error(ERROR_usage(2),"%s",optusage((char*)0));
+		UNREACHABLE();
+	}
 	n=0;
 	if(cp = *argv)
 		argv++;
@@ -161,7 +164,10 @@ b_rev(int argc, register char** argv, Shbltin_t* context)
 		if(fp!=sfstdin)
 			sfclose(fp);
 		if(line < 0)
+		{
 			error(ERROR_system(1),"write failed");
+			UNREACHABLE();
+		}
 	}
 	while(cp= *argv++);
 	return(n);

--- a/src/lib/libcmd/rm.c
+++ b/src/lib/libcmd/rm.c
@@ -366,8 +366,8 @@ b_rm(int argc, register char** argv, Shbltin_t* context)
 			state.verbose = 1;
 			continue;
 		case '?':
-			error(ERROR_USAGE|4, "%s", opt_info.arg);
-			break;
+			error(ERROR_usage(2), "%s", opt_info.arg);
+			UNREACHABLE();
 		case ':':
 			error(2, "%s", opt_info.arg);
 			break;
@@ -378,7 +378,10 @@ b_rm(int argc, register char** argv, Shbltin_t* context)
 	if (*argv && streq(*argv, "-") && !streq(*(argv - 1), "--"))
 		argv++;
 	if (error_info.errors || !*argv && !state.force)
-		error(ERROR_USAGE|4, "%s", optusage(NiL));
+	{
+		error(ERROR_usage(2), "%s", optusage(NiL));
+		UNREACHABLE();
+	}
 	if (!*argv)
 		return 0;
 

--- a/src/lib/libcmd/rmdir.c
+++ b/src/lib/libcmd/rmdir.c
@@ -82,13 +82,16 @@ b_rmdir(int argc, char** argv, Shbltin_t* context)
 			break;
 		case '?':
 			error(ERROR_usage(2), "%s", opt_info.arg);
-			break;
+			UNREACHABLE();
 		}
 		break;
 	}
 	argv += opt_info.index;
 	if (error_info.errors || !*argv)
+	{
 		error(ERROR_usage(2), "%s", optusage(NiL));
+		UNREACHABLE();
+	}
 	if (!pflag)
 		sflag = 0;
 	while (dir = *argv++)

--- a/src/lib/libcmd/stty.c
+++ b/src/lib/libcmd/stty.c
@@ -645,14 +645,23 @@ static void set(char *argv[], struct termios *sp)
 			off=1;
 		}
 		if(!(tp=lookup(cp)) || (off && (tp->type!=BIT) && (tp->type!=TABS)))
+		{
 			error(ERROR_exit(1),"%s: unknown mode",cp);
+			UNREACHABLE();
+		}
 		switch(tp->type)
 		{
 		    case CHAR:
 			if(off)
+			{
 				error(ERROR_exit(1),"%s: unknown mode",cp);
+				UNREACHABLE();
+			}
 			if(!*argv)
+			{
 				error(ERROR_exit(1),"missing argument to %s",cp);
+				UNREACHABLE();
+			}
 			c = gettchar(*argv++);
 			if(c>=0)
 				sp->c_cc[tp->mask] = c;
@@ -697,7 +706,10 @@ static void set(char *argv[], struct termios *sp)
 			struct winsize win;
 			int n;
 			if(ioctl(0,TIOCGWINSZ,&win)<0)
+			{
 				error(ERROR_system(1),"cannot set %s",tp->name);
+				UNREACHABLE();
+			}
 			if(!(cp= *argv))
 			{
 				sfprintf(sfstdout,"%d\n",tp->mask?win.ws_col:win.ws_row);
@@ -706,13 +718,19 @@ static void set(char *argv[], struct termios *sp)
 			argv++;
 			n=strtol(cp,&cp,10);
 			if(*cp)
+			{
 				error(ERROR_system(1),"%d: invalid number of %s",argv[-1],tp->name);
+				UNREACHABLE();
+			}
 			if(tp->mask)
 				win.ws_col = n;
 			else
 				win.ws_row = n;
 			if(ioctl(0,TIOCSWINSZ,&win)<0)
+			{
 				error(ERROR_system(1),"cannot set %s",tp->name);
+				UNREACHABLE();
+			}
 			break;
 		    }
 #endif
@@ -727,11 +745,15 @@ static void set(char *argv[], struct termios *sp)
 					break;
 				}
 				error(ERROR_exit(1), "%s: missing numeric argument", tp->name);
+				UNREACHABLE();
 			}
 			argv++;
 			c = (int)strtol(cp, &ep, 10);
 			if (*ep)
+			{
 				error(ERROR_exit(1), "%s: %s: numeric argument expected", tp->name, cp);
+				UNREACHABLE();
+			}
 			switch (tp->field)
 			{
 #if _mem_c_line_termios
@@ -748,7 +770,10 @@ static void set(char *argv[], struct termios *sp)
 						cfsetospeed(sp, c);
 				}
 				else
+				{
 					error(ERROR_exit(1), "%s: %s: invalid speed", tp->name, cp);
+					UNREACHABLE();
+				}
 				break;
 			case T_CHAR:
 				sp->c_cc[tp->mask] = c;
@@ -941,19 +966,28 @@ b_stty(int argc, char** argv, Shbltin_t* context)
 			if (!opt_info.offset)
 				error(2, "%s", opt_info.arg);
 			else if (!(tp = lookup(argv[opt_info.index]+1)) || (tp->type != BIT && tp->type != TABS))
+			{
 				error(ERROR_exit(1), "%s: unknown mode", argv[opt_info.index]);
+				UNREACHABLE();
+			}
 			break;
 		case '?':
 			error(ERROR_usage(2), "%s", opt_info.arg);
-			break;
+			UNREACHABLE();
 		}
 		break;
 	}
 	argv += opt_info.index;
 	if (error_info.errors || (flags && *argv) || (flags&(flags-1)))
+	{
 		error(ERROR_usage(2), "%s", optusage(NiL));
+		UNREACHABLE();
+	}
 	if (tcgetattr(fd, &tty) < 0)
+	{
 		error(ERROR_system(1), "not a tty");
+		UNREACHABLE();
+	}
 	if (flags & T_FLAG)
 		sfprintf(sfstdout, "%d\n", tcgetpgrp(0));
 	else if (*argv)
@@ -963,7 +997,10 @@ b_stty(int argc, char** argv, Shbltin_t* context)
 		else
 			set(argv, &tty);
 		if (tcsetattr(0, TCSANOW, &tty) < 0)
+		{
 			error(ERROR_system(1), "cannot set tty");
+			UNREACHABLE();
+		}
 	}
 	else
 		output(&tty, flags);

--- a/src/lib/libcmd/sync.c
+++ b/src/lib/libcmd/sync.c
@@ -63,17 +63,21 @@ b_sync(int argc, char** argv, Shbltin_t* context)
 			break;
 		case '?':
 			error(ERROR_usage(2), "%s", opt_info.arg);
-			break;
+			UNREACHABLE();
 		}
 		break;
 	}
 	argv += opt_info.index;
 	if (error_info.errors || *argv)
+	{
 		error(ERROR_usage(2), "%s", optusage(NiL));
+		UNREACHABLE();
+	}
 #if _lib_sync
 	sync();
+	return 0;
 #else
 	error(ERROR_usage(2), "failed -- the native system does not provide a sync(2) call");
+	UNREACHABLE();
 #endif
-	return 0;
 }

--- a/src/lib/libcmd/tail.c
+++ b/src/lib/libcmd/tail.c
@@ -515,7 +515,10 @@ b_tail(int argc, char** argv, Shbltin_t* context)
 			flags |= TIMEOUT;
 			timeout = strelapsed(opt_info.arg, &s, 1);
 			if (*s)
+			{
 				error(ERROR_exit(1), "%s: invalid elapsed time [%s]", opt_info.arg, s);
+				UNREACHABLE();
+			}
 			continue;
 		case 'v':
 			flags |= VERBOSE;
@@ -569,7 +572,7 @@ b_tail(int argc, char** argv, Shbltin_t* context)
 			continue;
 		case '?':
 			error(ERROR_usage(2), "%s", opt_info.arg);
-			break;
+			UNREACHABLE();
 		}
 		break;
 	}
@@ -611,7 +614,10 @@ b_tail(int argc, char** argv, Shbltin_t* context)
 	if (flags & FOLLOW)
 	{
 		if (!(fp = (Tail_t*)stakalloc(argc * sizeof(Tail_t))))
+		{
 			error(ERROR_system(1), "out of memory");
+			UNREACHABLE();
+		}
 		files = 0;
 		s = *argv;
 		do
@@ -718,7 +724,10 @@ b_tail(int argc, char** argv, Shbltin_t* context)
 				fp = fp->next;
 			}
 			if (sfsync(sfstdout))
+			{
 				error(ERROR_system(1), "write error");
+				UNREACHABLE();
+			}
 		}
 	done:
 		for (fp = files; fp; fp = fp->next)

--- a/src/lib/libcmd/tee.c
+++ b/src/lib/libcmd/tee.c
@@ -149,12 +149,15 @@ b_tee(int argc, register char** argv, Shbltin_t* context)
 			break;
 		case '?':
 			error(ERROR_usage(2), "%s", opt_info.arg);
-			break;
+			UNREACHABLE();
 		}
 		break;
 	}
 	if (error_info.errors)
+	{
 		error(ERROR_usage(2), "%s", optusage(NiL));
+		UNREACHABLE();
+	}
 	argv += opt_info.index;
 	argc -= opt_info.index;
 #if _ANCIENT_BSD_COMPATIBILITY

--- a/src/lib/libcmd/tty.c
+++ b/src/lib/libcmd/tty.c
@@ -79,12 +79,15 @@ b_tty(int argc, char** argv, Shbltin_t* context)
 			break;
 		case '?':
 			error(ERROR_usage(2), "%s", opt_info.arg);
-			break;
+			UNREACHABLE();
 		}
 		break;
 	}
 	if(error_info.errors)
+	{
 		error(ERROR_usage(2), "%s", optusage(NiL));
+		UNREACHABLE();
+	}
 	if(!(tty=ttyname(0)))
 	{
 		tty = ERROR_translate(0, 0, 0, "not a tty");

--- a/src/lib/libcmd/uname.c
+++ b/src/lib/libcmd/uname.c
@@ -337,13 +337,16 @@ b_uname(int argc, char** argv, Shbltin_t* context)
 			}
 		case '?':
 			error(ERROR_usage(2), "%s", opt_info.arg);
-			break;
+			UNREACHABLE();
 		}
 		break;
 	}
 	argv += opt_info.index;
 	if (error_info.errors || *argv && (flags || sethost) || sethost && flags)
+	{
 		error(ERROR_usage(2), "%s", optusage(NiL));
+		UNREACHABLE();
+	}
 	if (sethost)
 	{
 #if _lib_sethostname
@@ -356,6 +359,7 @@ b_uname(int argc, char** argv, Shbltin_t* context)
 #endif
 #endif
 		error(ERROR_system(1), "%s: cannot set host name", sethost);
+		UNREACHABLE();
 	}
 	else if (list)
 		astconflist(sfstdout, NiL, ASTCONF_base|ASTCONF_defined|ASTCONF_lower|ASTCONF_quote|ASTCONF_matchcall, "CS|SI");
@@ -381,7 +385,10 @@ b_uname(int argc, char** argv, Shbltin_t* context)
 			flags = OPT_system;
 		memzero(&ut, sizeof(ut));
 		if (uname(&ut) < 0)
+		{
 			error(ERROR_usage(2), "information unavailable");
+			UNREACHABLE();
+		}
 		output(OPT_system, ut.sysname, "sysname");
 		if (flags & OPT_nodename)
 		{

--- a/src/lib/libcmd/uniq.c
+++ b/src/lib/libcmd/uniq.c
@@ -303,7 +303,7 @@ b_uniq(int argc, char** argv, Shbltin_t* context)
 			break;
 		case '?':
 			error(ERROR_usage(2), "%s", opt_info.arg);
-			break;
+			UNREACHABLE();
 		}
 		break;
 	}
@@ -311,11 +311,17 @@ b_uniq(int argc, char** argv, Shbltin_t* context)
 	if(all && (mode&C_FLAG))
 		error(2, "-c and -D are mutually exclusive");
 	if(error_info.errors)
+	{
 		error(ERROR_usage(2), "%s", optusage(NiL));
+		UNREACHABLE();
+	}
 	if((cp = *argv) && (argv++,!streq(cp,"-")))
 	{
 		if(!(fpin = sfopen(NiL,cp,"r")))
+		{
 			error(ERROR_system(1),"%s: cannot open",cp);
+			UNREACHABLE();
+		}
 	}
 	else
 		fpin = sfstdin;
@@ -323,7 +329,10 @@ b_uniq(int argc, char** argv, Shbltin_t* context)
 	{
 		argv++;
 		if(!(fpout = sfopen(NiL,cp,"w")))
+		{
 			error(ERROR_system(1),"%s: cannot create",cp);
+			UNREACHABLE();
+		}
 	}
 	else
 		fpout = sfstdout;
@@ -331,6 +340,7 @@ b_uniq(int argc, char** argv, Shbltin_t* context)
 	{
 		error(2, "too many arguments");
 		error(ERROR_usage(2), "%s", optusage(NiL));
+		UNREACHABLE();
 	}
 	error_info.errors = uniq(fpin,fpout,fields,chars,width,mode,all,compare);
 	if(fpin!=sfstdin)

--- a/src/lib/libcmd/vmstate.c
+++ b/src/lib/libcmd/vmstate.c
@@ -163,8 +163,8 @@ b_vmstate(int argc, char** argv, Shbltin_t* context)
 			state.format = opt_info.arg;
 			continue;
 		case '?':
-			error(ERROR_USAGE|4, "%s", opt_info.arg);
-			break;
+			error(ERROR_usage(2), "%s", opt_info.arg);
+			UNREACHABLE();
 		case ':':
 			error(2, "%s", opt_info.arg);
 			break;
@@ -173,7 +173,10 @@ b_vmstate(int argc, char** argv, Shbltin_t* context)
 	}
 	argv += opt_info.index;
 	if (error_info.errors || *argv)
-		error(ERROR_USAGE|4, "%s", optusage(NiL));
+	{
+		error(ERROR_usage(2), "%s", optusage(NiL));
+		UNREACHABLE();
+	}
 	if (!state.format)
 		state.format = FORMAT;
 

--- a/src/lib/libcmd/wc.c
+++ b/src/lib/libcmd/wc.c
@@ -129,13 +129,16 @@ b_wc(int argc,register char **argv, Shbltin_t* context)
 			break;
 		case '?':
 			error(ERROR_usage(2), "%s", opt_info.arg);
-			break;
+			UNREACHABLE();
 		}
 		break;
 	}
 	argv += opt_info.index;
 	if (error_info.errors)
+	{
 		error(ERROR_usage(2), "%s", optusage(NiL));
+		UNREACHABLE();
+	}
 	if (mode&WC_MBYTE)
 	{
 		if (mode&WC_CHARS)

--- a/src/lib/libdll/dllscan.c
+++ b/src/lib/libdll/dllscan.c
@@ -201,7 +201,7 @@ vercmp(FTSENT* const* ap, FTSENT* const* bp)
 		if (!*b++)
 			return 1;
 	}
-	/*NOTREACHED*/
+	UNREACHABLE();
 }
 
 /*


### PR DESCRIPTION
This pull request adds usage of the `__builtin_unreachable()` compiler builtin and the `noreturn` attribute. The purpose of these is to improve GCC/Clang compiler optimizations (this change also fixes a few compiler warnings). These are used when a function doesn't return (such as `errormsg` used with `ERROR_exit(1)`). Changes of note:

src/cmd/ksh93/sh/io.c: `outexcept()`:
\- Avoid using `__builtin_unreachable()` here since `errormsg` can return despite using `ERROR_system(1)` (see https://github.com/att/ast/issues/1336).

src/cmd/ksh93/tests/io.sh:
\- Add a regression test for the ksh2020 bug referenced above.

src/lib/libast/features/common:
\- Detect the existence of either the C11 `stdnoreturn.h` header or the GCC `noreturn` attribute, preferring the former when available.
\- Test for the existence of `__builtin_unreachable()` (the feature test is from https://github.com/ksh93/ksh/pull/243#issuecomment-808569808).