### PR TITLE
`cd -` shouldn't ignore `$OLDPWD` when in a new scope

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,11 @@ For full details, see the git log at: https://github.com/ksh93/ksh
 
 Any uppercase BUG_* names are modernish shell bug IDs.
 
+2021-03-31:
+
+- Fixed a bug that caused 'cd -' to ignore the current value of $OLDPWD
+  when it's set to a different directory in a new scope.
+
 2021-03-29:
 
 - Fixed an intermittent crash that could occur in vi mode when using the 'b'

--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,7 @@ Any uppercase BUG_* names are modernish shell bug IDs.
 
 - Fixed a bug that caused 'cd -' to ignore the current value of $OLDPWD
   when it's set to a different directory in a new scope.
+
 - Fixed a related bug that caused ksh to use the wrong value for $PWD
   when in a new scope.
 

--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,8 @@ Any uppercase BUG_* names are modernish shell bug IDs.
 
 - Fixed a bug that caused 'cd -' to ignore the current value of $OLDPWD
   when it's set to a different directory in a new scope.
+- Fixed a related bug that caused ksh to use the wrong value for $PWD
+  when in a new scope.
 
 2021-03-29:
 

--- a/src/cmd/ksh93/COMPATIBILITY
+++ b/src/cmd/ksh93/COMPATIBILITY
@@ -116,7 +116,7 @@ For more details, see the NEWS file and for complete details, see the git log.
 	For example:
 		ksh -c 'OLDPWD=/bin; OLDPWD=/tmp cd - > /dev/null; echo $OLDPWD'
 		ksh -c 'cd /var; PWD=/tmp cd /usr; echo $PWD'
-	prints '/bin' followed by '/var'.
+	now prints '/bin' followed by '/var'.
 ____________________________________________________________________________
 
 		KSH-93 VS. KSH-88

--- a/src/cmd/ksh93/COMPATIBILITY
+++ b/src/cmd/ksh93/COMPATIBILITY
@@ -111,6 +111,12 @@ For more details, see the NEWS file and for complete details, see the git log.
 	Turning on the new --globcasedetect shell option restores
 	case-insensitive globbing for case-insensitive file systems.
 
+22.	If $PWD or $OLDPWD are passed as invocation-local assignments to cd,
+	their values are no longer altered in the outer scope when cd finishes.
+	For example:
+		ksh -c 'OLDPWD=/bin; OLDPWD=/tmp cd - > /dev/null; echo $OLDPWD'
+		ksh -c 'cd /var; PWD=/tmp cd /usr; echo $PWD'
+	prints '/bin' followed by '/var'.
 ____________________________________________________________________________
 
 		KSH-93 VS. KSH-88

--- a/src/cmd/ksh93/bltins/cd_pwd.c
+++ b/src/cmd/ksh93/bltins/cd_pwd.c
@@ -57,7 +57,7 @@ int	b_cd(int argc, char *argv[],Shbltin_t *context)
 	register Shell_t *shp = context->shp;
 	int saverrno=0;
 	int rval,flag=0;
-	char *oldpwd;
+	static char *oldpwd;
 	Namval_t *opwdnod, *pwdnod;
 	if(sh_isoption(SH_RESTRICTED))
 		errormsg(SH_DICT,ERROR_exit(1),e_restricted+4);
@@ -81,6 +81,8 @@ int	b_cd(int argc, char *argv[],Shbltin_t *context)
 	dir =  argv[0];
 	if(error_info.errors>0 || argc >2)
 		errormsg(SH_DICT,ERROR_usage(2),"%s",optusage((char*)0));
+	if(oldpwd && oldpwd!=shp->pwd && oldpwd!=e_dot)
+		free(oldpwd);
 	oldpwd = path_pwd(shp,0);
 	opwdnod = sh_scoped(shp,OLDPWDNOD);
 	pwdnod = sh_scoped(shp,PWDNOD);
@@ -221,8 +223,6 @@ success:
 	nv_scan(sh_subtracktree(1),rehash,(void*)0,NV_TAGGED,NV_TAGGED);
 	path_newdir(shp,shp->pathlist);
 	path_newdir(shp,shp->cdpathlist);
-	if(oldpwd && oldpwd!=e_dot)
-		free(oldpwd);
 	return(0);
 }
 

--- a/src/cmd/ksh93/bltins/cd_pwd.c
+++ b/src/cmd/ksh93/bltins/cd_pwd.c
@@ -89,7 +89,7 @@ int	b_cd(int argc, char *argv[],Shbltin_t *context)
 	else if(!dir)
 		dir = nv_getval(HOME);
 	else if(*dir == '-' && dir[1]==0)
-		dir = nv_getval(opwdnod);
+		dir = (char*)sh_scoped(shp,opwdnod)->nvalue.cp;
 	if(!dir || *dir==0)
 		errormsg(SH_DICT,ERROR_exit(1),argc==2?e_subst+4:e_direct);
 	/*
@@ -188,7 +188,7 @@ int	b_cd(int argc, char *argv[],Shbltin_t *context)
 		errormsg(SH_DICT,ERROR_system(1),"%s:",dir);
 	}
 success:
-	if(dir == nv_getval(opwdnod) || argc==2)
+	if(dir == sh_scoped(shp,opwdnod)->nvalue.cp || argc==2)
 		dp = dir;	/* print out directory for cd - */
 	if(flag)
 	{

--- a/src/cmd/ksh93/bltins/cd_pwd.c
+++ b/src/cmd/ksh93/bltins/cd_pwd.c
@@ -82,14 +82,19 @@ int	b_cd(int argc, char *argv[],Shbltin_t *context)
 	if(error_info.errors>0 || argc >2)
 		errormsg(SH_DICT,ERROR_usage(2),"%s",optusage((char*)0));
 	oldpwd = path_pwd(shp,0);
-	opwdnod = (shp->subshell?sh_assignok(OLDPWDNOD,1):OLDPWDNOD); 
-	pwdnod = (shp->subshell?sh_assignok(PWDNOD,1):PWDNOD); 
+	opwdnod = sh_scoped(shp,OLDPWDNOD);
+	pwdnod = sh_scoped(shp,PWDNOD);
+	if(shp->subshell)
+	{
+		opwdnod = sh_assignok(opwdnod,1);
+		pwdnod = sh_assignok(pwdnod,1);
+	}
 	if(argc==2)
 		dir = sh_substitute(oldpwd,dir,argv[1]);
 	else if(!dir)
 		dir = nv_getval(HOME);
 	else if(*dir == '-' && dir[1]==0)
-		dir = (char*)sh_scoped(shp,opwdnod)->nvalue.cp;
+		dir = nv_getval(opwdnod);
 	if(!dir || *dir==0)
 		errormsg(SH_DICT,ERROR_exit(1),argc==2?e_subst+4:e_direct);
 	/*
@@ -188,7 +193,7 @@ int	b_cd(int argc, char *argv[],Shbltin_t *context)
 		errormsg(SH_DICT,ERROR_system(1),"%s:",dir);
 	}
 success:
-	if(dir == sh_scoped(shp,opwdnod)->nvalue.cp || argc==2)
+	if(dir == nv_getval(opwdnod) || argc==2)
 		dp = dir;	/* print out directory for cd - */
 	if(flag)
 	{

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -20,7 +20,7 @@
 
 #define SH_RELEASE_FORK	"93u+m"		/* only change if you develop a new ksh93 fork */
 #define SH_RELEASE_SVER	"1.0.0-alpha"	/* semantic version number: https://semver.org */
-#define SH_RELEASE_DATE	"2021-03-29"	/* must be in this format for $((.sh.version)) */
+#define SH_RELEASE_DATE	"2021-03-31"	/* must be in this format for $((.sh.version)) */
 #define SH_RELEASE_CPYR	"(c) 2020-2021 Contributors to ksh " SH_RELEASE_FORK
 
 /* Scripts sometimes field-split ${.sh.version}, so don't change amount of whitespace. */

--- a/src/cmd/ksh93/sh/path.c
+++ b/src/cmd/ksh93/sh/path.c
@@ -254,7 +254,7 @@ char *path_pwd(Shell_t *shp,int flag)
 	cp = nv_getval(pwdnod);
 	if(!(cp && *cp=='/' && test_inode(cp,e_dot)))
 	{
-		/* Get PWD using getcwd(2), fall back to "." */
+		/* Get PWD using getcwd(3), fall back to "." */
 		cp = getcwd(NIL(char*),0);
 		if(!cp)
 			return((char*)e_dot);

--- a/src/cmd/ksh93/sh/path.c
+++ b/src/cmd/ksh93/sh/path.c
@@ -244,49 +244,29 @@ static pid_t path_xargs(Shell_t *shp,const char *path, char *argv[],char *const 
 char *path_pwd(Shell_t *shp,int flag)
 {
 	register char *cp;
-	register int count = 0;
+	Namval_t *pwdnod;
 	NOT_USED(flag);
+	/* Don't bother if PWD already set */
 	if(shp->pwd)
 		return((char*)shp->pwd);
-	while(1) 
+	/* First see if PWD variable is correct */
+	pwdnod = sh_scoped(shp,PWDNOD);
+	cp = nv_getval(pwdnod);
+	if(!(cp && *cp=='/' && test_inode(cp,e_dot)))
 	{
-		/* try from lowest to highest */
-		switch(count++)
-		{
-			case 0:
-				cp = nv_getval(PWDNOD);
-				break;
-			case 1:
-				cp = nv_getval(HOME);
-				break;
-			case 2:
-				cp = "/";
-				break;
-			case 3:
-			{
-				if(cp=getcwd(NIL(char*),0))
-				{  
-					nv_offattr(PWDNOD,NV_NOFREE);
-					_nv_unset(PWDNOD,0);
-					PWDNOD->nvalue.cp = cp;
-					goto skip;
-				}
-				break;
-			}
-			case 4:
-				return((char*)e_dot);
-		}
-		if(cp && *cp=='/' && test_inode(cp,e_dot))
-			break;
+		/* Get PWD using getcwd(2), fall back to "." */
+		cp = getcwd(NIL(char*),0);
+		if(!cp)
+			return((char*)e_dot);
+		/* Store in PWD variable */
+		if(shp->subshell)
+			pwdnod = sh_assignok(pwdnod,1);
+		nv_offattr(pwdnod,NV_NOFREE);
+		nv_putval(pwdnod,cp,NV_RDONLY);
 	}
-	if(count>1)
-	{
-		nv_offattr(PWDNOD,NV_NOFREE);
-		nv_putval(PWDNOD,cp,NV_RDONLY);
-	}
-skip:
-	nv_onattr(PWDNOD,NV_NOFREE|NV_EXPORT);
-	shp->pwd = (char*)(PWDNOD->nvalue.cp);
+	nv_onattr(pwdnod,NV_NOFREE|NV_EXPORT);
+	/* Set shell PWD */
+	shp->pwd = (char*)(pwdnod->nvalue.cp);
 	return(cp);
 }
 

--- a/src/cmd/ksh93/tests/builtins.sh
+++ b/src/cmd/ksh93/tests/builtins.sh
@@ -1102,7 +1102,6 @@ got=$(fn)
 	err_exit "PWD isn't set after cd if already set in function scope" \
 	"(expected $(printf %q "$exp"), got $(printf %q "$got"))"
 
-: <<'disabled'
 # $PWD should be set correctly after cd (disabled for now)
 exp="$PWD
 $PWD"
@@ -1110,7 +1109,6 @@ got=$(echo $PWD; PWD=/tmp cd /home; echo $PWD)
 [[ $got == "$exp" ]] ||
 	err_exit "PWD is incorrect after cd" \
 	"(expected $(printf %q "$exp"), got $(printf %q "$got"))"
-disabled
 
 # Test for $OLDPWD and/or $PWD leaking out of subshell
 exp='/tmp /dev'

--- a/src/cmd/ksh93/tests/builtins.sh
+++ b/src/cmd/ksh93/tests/builtins.sh
@@ -1102,6 +1102,16 @@ got=$(fn)
 	err_exit "PWD isn't set after cd if already set in function scope" \
 	"(expected $(printf %q "$exp"), got $(printf %q "$got"))"
 
+: <<'disabled'
+# $PWD should be set correctly after cd (disabled for now)
+exp="$PWD
+$PWD"
+got=$(echo $PWD; PWD=/tmp cd /home; echo $PWD)
+[[ $got == "$exp" ]] ||
+	err_exit "PWD is incorrect after cd" \
+	"(expected $(printf %q "$exp"), got $(printf %q "$got"))"
+disabled
+
 # Test for $OLDPWD and/or $PWD leaking out of subshell
 exp='/tmp /dev'
 got=$(

--- a/src/cmd/ksh93/tests/builtins.sh
+++ b/src/cmd/ksh93/tests/builtins.sh
@@ -1060,4 +1060,18 @@ exp=1
 [[ $got == $exp ]] || err_exit "'kill %' has the wrong exit status (expected '$exp'; got '$got')"
 
 # ======
+# 'cd -' should recognize the value of an overriden $OLDPWD variable
+mkdir "$tmp/oldpwd" "$tmp/otherpwd"
+expect="$tmp/oldpwd"
+OLDPWD="$expect"
+cd - > /dev/null
+[[ $PWD == $tmp/oldpwd ]] || err_exit "cd - doesn't recognize overridden OLDPWD variable (expected $expect, got $PWD)"
+
+cd "$tmp"
+OLDPWD="$tmp/otherpwd"
+actual="$(OLDPWD="$tmp/oldpwd" cd -)"
+[[ $actual == $expect ]] ||
+	err_exit "cd - doesn't recognize overridden OLDPWD variable if it is overridden in new scope (expected $expect, got $actual)"
+
+# ======
 exit $((Errors<125?Errors:125))

--- a/src/cmd/ksh93/tests/builtins.sh
+++ b/src/cmd/ksh93/tests/builtins.sh
@@ -1102,7 +1102,7 @@ got=$(fn)
 	err_exit "PWD isn't set after cd if already set in function scope" \
 	"(expected $(printf %q "$exp"), got $(printf %q "$got"))"
 
-# $PWD should be set correctly after cd (disabled for now)
+# $PWD should be set correctly after cd
 exp="$PWD
 $PWD"
 got=$(echo $PWD; PWD=/tmp cd /home; echo $PWD)

--- a/src/cmd/ksh93/tests/leaks.sh
+++ b/src/cmd/ksh93/tests/leaks.sh
@@ -424,8 +424,11 @@ before=$(getmem)
 for ((i=0; i < N; i++))
 do	cd /tmp
 	cd - > /dev/null
+	PWD=/foo
+	OLDPWD=/bar
 	cd /bin
 	cd /usr
+	cd /home
 	cd /home
 	cd - > /dev/null
 done

--- a/src/cmd/ksh93/tests/leaks.sh
+++ b/src/cmd/ksh93/tests/leaks.sh
@@ -418,4 +418,20 @@ err_exit_if_leak 'unset PATH in subshell'
 disabled
 
 # ======
+# Test for a memory leak after 'cd' (in relation to $PWD and $OLDPWD)
+original_pwd=$PWD
+before=$(getmem)
+for ((i=0; i < N; i++))
+do	cd /tmp
+	cd - > /dev/null
+	cd /bin
+	cd /usr
+	cd /home
+	cd - > /dev/null
+done
+after=$(getmem)
+err_exit_if_leak 'PWD and/or OLDPWD changed by cd'
+cd $original_pwd
+
+# ======
 exit $((Errors<125?Errors:125))

--- a/src/cmd/ksh93/tests/leaks.sh
+++ b/src/cmd/ksh93/tests/leaks.sh
@@ -431,6 +431,9 @@ do	cd /tmp
 	cd /home
 	cd /home
 	cd - > /dev/null
+	unset OLDPWD PWD
+	cd /bin
+	cd /tmp
 done
 after=$(getmem)
 err_exit_if_leak 'PWD and/or OLDPWD changed by cd'


### PR DESCRIPTION
This bug was first reported at https://github.com/att/ast/issues/8. The `cd` command currently takes the value of `$OLDPWD` from the wrong scope. In the following example `cd -` will change the directory to /bin instead of /tmp:
```sh
$ OLDPWD=/bin ksh93 -c 'OLDPWD=/tmp cd -'
/bin
````

src/cmd/ksh93/bltins/cd_pwd.c:
\- Backport the ksh2020 bugfix which uses `sh_scoped()` to obtain the correct value of `$OLDPWD`.

src/cmd/ksh93/tests/builtins.sh:
\- Backport the ksh2020 regression tests for `cd -` when `$OLDPWD` is set.