### PR TITLE
Fix bugs related to `uname -d` in the `uname` builtin

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,14 @@ For full details, see the git log at: https://github.com/ksh93/ksh
 
 Any uppercase BUG_* names are modernish shell bug IDs.
 
+2021-04-03:
+
+- Fixed a bug that caused the uname builtin's -d option to change the output
+  of the -o option.
+
+- Fixed a possible crash that could occur when showing the domain name
+  with the uname builtin's -d option.
+
 2021-03-31:
 
 - Fixed a bug that caused 'cd -' to ignore the current value of $OLDPWD

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -20,7 +20,7 @@
 
 #define SH_RELEASE_FORK	"93u+m"		/* only change if you develop a new ksh93 fork */
 #define SH_RELEASE_SVER	"1.0.0-alpha"	/* semantic version number: https://semver.org */
-#define SH_RELEASE_DATE	"2021-03-31"	/* must be in this format for $((.sh.version)) */
+#define SH_RELEASE_DATE	"2021-04-03"	/* must be in this format for $((.sh.version)) */
 #define SH_RELEASE_CPYR	"(c) 2020-2021 Contributors to ksh " SH_RELEASE_FORK
 
 /* Scripts sometimes field-split ${.sh.version}, so don't change amount of whitespace. */

--- a/src/cmd/ksh93/tests/builtins.sh
+++ b/src/cmd/ksh93/tests/builtins.sh
@@ -1145,8 +1145,11 @@ got=$(
 builtin uname
 exp=$(uname -o)
 
-# Test for a possible crash (to avoid crashing the script, fork the command substitution)
-[[ ! -z $(ulimit -t unlimited; uname -d) ]] || err_exit "'uname -d' failed"
+# Test for a possible crash (to avoid crashing the script, fork the subshell)
+(
+	ulimit -t unlimited
+	uname -d > /dev/null
+) || err_exit "'uname -d' crashes"
 
 # 'uname -d' shouldn't change the output of 'uname -o'
 got=$(ulimit -t unlimited; uname -d > /dev/null; uname -o)

--- a/src/cmd/ksh93/tests/builtins.sh
+++ b/src/cmd/ksh93/tests/builtins.sh
@@ -1140,4 +1140,18 @@ got=$(
 	"(expected $(printf %q "$exp"), got $(printf %q "$got"))"
 
 # ======
+# Test for bugs related to 'uname -d'
+# https://github.com/att/ast/pull/1187
+builtin uname
+exp=$(uname -o)
+
+# Test for a possible crash (to avoid crashing the script, fork the command substitution)
+[[ ! -z $(ulimit -t unlimited; uname -d) ]] || err_exit "'uname -d' failed"
+
+# 'uname -d' shouldn't change the output of 'uname -o'
+got=$(ulimit -t unlimited; uname -d > /dev/null; uname -o)
+[[ $exp == $got ]] || err_exit "'uname -d' changes the output of 'uname -o'" \
+	"(expected $(printf %q "$exp"), got $(printf %q "$got"))"
+
+# ======
 exit $((Errors<125?Errors:125))

--- a/src/lib/libcmd/uname.c
+++ b/src/lib/libcmd/uname.c
@@ -493,12 +493,14 @@ b_uname(int argc, char** argv, Shbltin_t* context)
 		if (flags & OPT_domain)
 		{
 			if (!*(s = astconf("SRPC_DOMAIN", NiL, NiL)))
+			{
 #if _lib_getdomainname
 				getdomainname(buf, sizeof(buf));
 				s = buf;
 #else
 				/*NOP*/;
 #endif
+			}
 			output(OPT_domain, s, "domain");
 		}
 #if _mem_m_type_utsname

--- a/src/lib/libcmd/uname.c
+++ b/src/lib/libcmd/uname.c
@@ -494,7 +494,8 @@ b_uname(int argc, char** argv, Shbltin_t* context)
 		{
 			if (!*(s = astconf("SRPC_DOMAIN", NiL, NiL)))
 #if _lib_getdomainname
-				getdomainname(s, sizeof(buf));
+				getdomainname(buf, sizeof(buf));
+				s = buf;
 #else
 				/*NOP*/;
 #endif


### PR DESCRIPTION
This commit fixes a bug in the `uname` builtin's `-d` option that could change the output of `-o` (I was only able to reproduce this bug on Linux):
```sh
$ builtin uname
$ uname -o
GNU/Linux
$ uname -d
(none)
$ uname -o
(none)
```
I identified this patch from ksh2020 as a fix for this bug: https://github.com/att/ast/pull/1187.  The linked patch was meant to fix a crash in `uname -d`, although I've had no luck in getting `uname` to crash: https://github.com/att/ast/issues/1184.

src/lib/libcmd/uname.c:
\- Pass correct buffer to `getdomainname()` while processing `uname -d`.

src/cmd/ksh93/tests/builtins.sh:
\- Add a regression test for the reported `uname -d` crash.
\- Add a regression test for the output of `uname -o` after `uname -d`.
\- To handle potential crashes when running the regression tests in older versions of ksh, fork the command substitutions that run `uname -d`.