### PR TITLE
Fix `printf %T` ignoring the current locale in LC_TIME

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,9 @@ Any uppercase BUG_* names are modernish shell bug IDs.
 - Path-bound builtins will now be used by restricted shells if /opt/ast/bin
   is in the $PATH upon invoking the shell or before setting it to restricted.
 
+- Fixed a bug that caused "printf '%T\n' now" to ignore $LC_ALL and $LC_TIME
+  if the current locale was previously set, unset then set again.
+
 2021-04-07:
 
 - The $LC_TIME variable is now recognized by ksh and if set to an invalid

--- a/src/lib/libast/tm/tmlocale.c
+++ b/src/lib/libast/tm/tmlocale.c
@@ -638,7 +638,7 @@ tmlocale(void)
 			state.format = tm_info.deformat;
 	}
 
-	/* load the locate set in LC_TIME */
+	/* load the locale set in LC_TIME */
 	li = LCINFO(AST_LC_TIME);
 	if (!li->data || state.locale != li)
 	{

--- a/src/lib/libast/tm/tmlocale.c
+++ b/src/lib/libast/tm/tmlocale.c
@@ -637,8 +637,14 @@ tmlocale(void)
 		else if (tm_info.deformat != tm_info.format[TM_DEFAULT])
 			state.format = tm_info.deformat;
 	}
+
+	/* load the locate set in LC_TIME */
 	li = LCINFO(AST_LC_TIME);
-	if (!li->data)
+	if (!li->data || state.locale != li)
+	{
 		load(li);
+		state.locale = li;
+	}
+
 	return tm_info.format;
 }


### PR DESCRIPTION
src/lib/libast/tm/tmlocale.c:
\- Load the locale set by LC_TIME or LC_ALL if it hasn't been loaded before or if it was loaded previously but isn't the current locale.

src/cmd/ksh93/tests/locale.sh:
\- Add a regression test using the nl_NL.UTF-8 and ja_JP.UTF-8 locales.

Fixes: https://github.com/ksh93/ksh/issues/261