### PR TITLE
Fix the handling of the `--posix` long option

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,14 @@ For full details, see the git log at: https://github.com/ksh93/ksh
 
 Any uppercase BUG_* names are modernish shell bug IDs.
 
+2021-04-09:
+
+- Fixed a bug that caused ksh to enable -c during the shell's initialization
+  if the only argument passed was --posix.
+
+- Fixed a related bug that caused 'set --posix' to leave the braceexpand and
+  letoctal shell options unchanged.
+
 2021-04-08:
 
 - Path-bound builtins will now be used by restricted shells if /opt/ast/bin

--- a/NEWS
+++ b/NEWS
@@ -11,6 +11,9 @@ Any uppercase BUG_* names are modernish shell bug IDs.
 - Fixed a related bug that caused 'set --posix' to leave the braceexpand and
   letoctal shell options unchanged.
 
+- Fixed a bug that caused 'set --default' to unset the restricted option
+  in restricted shells.
+
 2021-04-08:
 
 - Path-bound builtins will now be used by restricted shells if /opt/ast/bin

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -20,7 +20,7 @@
 
 #define SH_RELEASE_FORK	"93u+m"		/* only change if you develop a new ksh93 fork */
 #define SH_RELEASE_SVER	"1.0.0-alpha"	/* semantic version number: https://semver.org */
-#define SH_RELEASE_DATE	"2021-04-08"	/* must be in this format for $((.sh.version)) */
+#define SH_RELEASE_DATE	"2021-04-09"	/* must be in this format for $((.sh.version)) */
 #define SH_RELEASE_CPYR	"(c) 2020-2021 Contributors to ksh " SH_RELEASE_FORK
 
 /* Scripts sometimes field-split ${.sh.version}, so don't change amount of whitespace. */

--- a/src/cmd/ksh93/sh/args.c
+++ b/src/cmd/ksh93/sh/args.c
@@ -178,10 +178,22 @@ int sh_argopts(int argc,register char *argv[], void *context)
 			break;
 		    case -5:	/* --posix must be handled explicitly to stop AST optget(3) overriding it */
 			if(opt_info.num)
+			{
 				on_option(&newflags,SH_POSIX);
+				on_option(&newflags,SH_LETOCTAL);
+#if SHOPT_BRACEPAT
+				off_option(&newflags,SH_BRACEEXPAND);
+#endif
+			}
 			else
+			{
 				off_option(&newflags,SH_POSIX);
-			break;
+				off_option(&newflags,SH_LETOCTAL);
+#if SHOPT_BRACEPAT
+				on_option(&newflags,SH_BRACEEXPAND);
+#endif
+			}
+			continue;
 		    case -6:	/* --default */
 			{
 				register const Shtable_t *tp;

--- a/src/cmd/ksh93/sh/args.c
+++ b/src/cmd/ksh93/sh/args.c
@@ -176,30 +176,12 @@ int sh_argopts(int argc,register char *argv[], void *context)
 				UNREACHABLE();
 			}
 			break;
-		    case -5:	/* --posix must be handled explicitly to stop AST optget(3) overriding it */
-			if(opt_info.num)
-			{
-				on_option(&newflags,SH_POSIX);
-				on_option(&newflags,SH_LETOCTAL);
-#if SHOPT_BRACEPAT
-				off_option(&newflags,SH_BRACEEXPAND);
-#endif
-			}
-			else
-			{
-				off_option(&newflags,SH_POSIX);
-				off_option(&newflags,SH_LETOCTAL);
-#if SHOPT_BRACEPAT
-				on_option(&newflags,SH_BRACEEXPAND);
-#endif
-			}
-			continue;
 		    case -6:	/* --default */
 			{
 				register const Shtable_t *tp;
 				for(tp=shtab_options; o = tp->sh_number; tp++)
-					if(!(o&SH_COMMANDLINE) && is_option(&newflags,o&0xff))
-						off_option(&newflags,o&0xff);
+					if(!(o&SH_COMMANDLINE) && (o&=0xff)!=SH_RESTRICTED && is_option(&newflags,o))
+						off_option(&newflags,o);
 			}
 			defaultflag++;
 		    	continue;
@@ -243,6 +225,7 @@ int sh_argopts(int argc,register char *argv[], void *context)
 			if(cp=strchr(optksh,n))
 				o = flagval[cp-optksh];
 			break;
+		    case -5:	/* --posix must be handled explicitly to stop AST optget(3) overriding it */
 		    case ':':
 			if(opt_info.name[0]=='-'&&opt_info.name[1]=='-')
 			{

--- a/src/cmd/ksh93/tests/options.sh
+++ b/src/cmd/ksh93/tests/options.sh
@@ -531,8 +531,14 @@ if [[ -o ?posix ]]; then
 	(set -o posix +o letoctal; [[ -o letoctal ]]) && err_exit "failed to stop posix option from turning on letoctal"
 if((SHOPT_BRACEPAT)); then
 	(set +B; set -o posix -B; [[ -o braceexpand ]]) || err_exit "failed to stop posix option from turning off bracceexpand"
+	(set --posix; [[ -o braceexpand ]]) && err_exit "set --posix fails to disable braceexpand"
+	(set -o posix; [[ -o braceexpand ]]) && err_exit "set -o posix fails to disable braceexpand"
 fi # SHOPT_BRACEPAT
 	(set --default -o posix; [[ -o letoctal ]]) && err_exit "set --default failed to stop posix option from changing others"
+	(set --posix; [[ -o letoctal ]]) || err_exit "set --posix fails to enable letoctal"
+	(set -o posix; [[ -o letoctal ]]) || err_exit "set -o posix fails to enable letoctal"
+	$SHELL --posix < <(echo 'exit 0') || err_exit "ksh fails to handle --posix during startup"
+	$SHELL -o posix < <(echo 'exit 0') || err_exit "ksh fails to handle -o posix during startup"
 fi
 
 # ======

--- a/src/cmd/ksh93/tests/restricted.sh
+++ b/src/cmd/ksh93/tests/restricted.sh
@@ -71,9 +71,9 @@ done
 
 # ======
 # The restricted option cannot be unset
-check_restricted 'set +r' 2> /dev/null || err_exit "'set +r' unsets the restricted option"
-check_restricted 'set +o restricted' 2> /dev/null || err_exit "'set +o restricted' unsets the restricted option"
-check_restricted 'set --default; $(whence -p true)' 2> /dev/null || err_exit "'set --default' unsets the restricted option"
+check_restricted 'set +r' || err_exit "'set +r' unsets the restricted option"
+check_restricted 'set +o restricted' || err_exit "'set +o restricted' unsets the restricted option"
+check_restricted 'set --default; $(whence -p true)' || err_exit "'set --default' unsets the restricted option"
 
 # ======
 exit $((Errors<125?Errors:125))

--- a/src/cmd/ksh93/tests/restricted.sh
+++ b/src/cmd/ksh93/tests/restricted.sh
@@ -70,9 +70,10 @@ do	check_restricted  "function foo { typeset $i=foobar;};foo" || err_exit "$i ca
 done
 
 # ======
-# 'set +r' and 'set +o restricted' should not unset the restricted option
+# The restricted option cannot be unset
 check_restricted 'set +r' 2> /dev/null || err_exit "'set +r' unsets the restricted option"
 check_restricted 'set +o restricted' 2> /dev/null || err_exit "'set +o restricted' unsets the restricted option"
+check_restricted 'set --default; $(whence -p true)' 2> /dev/null || err_exit "'set --default' unsets the restricted option"
 
 # ======
 exit $((Errors<125?Errors:125))


### PR DESCRIPTION
src/cmd/ksh93/sh/args.c: `sh_argopts()`:
\- When the posix option is enabled with `--posix`, disable braceexpand and enable letoctal (and when the posix option is disabled, do the opposite). This change fixes two bugs:

1) `set --posix` had no effect on the letoctal or braceexpand options. Reproducer:
```sh
$ set --posix
$ [[ -o braceexpand ]]; echo $?
0
$ [[ -o letoctal ]]; echo $?
1
```

2) `ksh --posix` could not run scripts correctly because it wrongly enabled `-c`. Reproducer:
```sh
$ ksh --posix < <(echo 'exit 0')
ksh: -c requires argument
Usage: ksh [--posix] [arg ...]
Help: ksh [ --help | --man ] 2>&1
```

src/cmd/ksh93/tests/options.sh:
\- Add regression tests for the bugs described above, using `-o posix` and `--posix`.