### PR TITLE
sh.1: Backport login shell man page addition from ksh93v-

### DIFF
--- a/src/cmd/ksh93/sh.1
+++ b/src/cmd/ksh93/sh.1
@@ -8311,6 +8311,11 @@ shell, commands are read from
 and then from
 .BR \s-1$HOME\s+1/.profile
 if it exists.
+Alternatively, the option
+.B \-l
+causes the shell to be treated as a
+.I login
+shell.
 Next, for interactive shells, commands are read from
 the file named by
 .SM


### PR DESCRIPTION
This small addition to the man page adds a description for the `-l` (login shell) option. It was mentioned on the old ast-users mailing list:
https://www.mail-archive.com/ast-users@lists.research.att.com/msg00299.html