### PR TITLE
Adjust readonly regression tests for freezes

### DIFF
--- a/src/cmd/ksh93/tests/readonly.sh
+++ b/src/cmd/ksh93/tests/readonly.sh
@@ -320,7 +320,6 @@ ulimit --cpu 3 2>/dev/null
 for ((i=0; i<n; i++))
 do
 	got=$(
-		((.sh.version < 20210404)) && ulimit -t unlimited 2>/dev/null	# fork to dodge an arith recursion detection bug
 		trap "${rtests[$i].res}" EXIT
 		eval "${rtests[$i].ini}"
 		eval "${rtests[$i].chg}" 2>&1

--- a/src/cmd/ksh93/tests/readonly.sh
+++ b/src/cmd/ksh93/tests/readonly.sh
@@ -314,18 +314,20 @@ rtests=(
 	)
 )
 
-typeset -i i
+typeset -i i n
 n=${#rtests[@]}
-for ((i=0; i<$n; i++))
+ulimit --cpu 3 2>/dev/null
+for ((i=0; i<n; i++))
 do
-	(	trap "${rtests[$i].res}" EXIT
+	got=$(
+		trap "${rtests[$i].res}" EXIT
 		eval "${rtests[$i].ini}"
-		eval "${rtests[$i].chg}"
-	) 2>&1 | read -d $'\x17' got
+		eval "${rtests[$i].chg}" 2>&1
+	)
 	[[ $got == *$': is read only\n'* ]] || err_exit "Readonly variable did not warn for rtests[$i]: "\
 		"setup='${rtests[$i].ini}', change='${rtests[$i].chg}'"
 	got=${got#*$': is read only\n'}
-	[[ $got == *"${rtests[$i].exp}"$'\n' ]] || err_exit "Readonly variable changed on rtests[$i]: "\
+	[[ $got == *"${rtests[$i].exp}" ]] || err_exit "Readonly variable changed on rtests[$i]: "\
 		"expected '${rtests[$i].exp}', got '$got'"
 done
 unset i n got rtests

--- a/src/cmd/ksh93/tests/readonly.sh
+++ b/src/cmd/ksh93/tests/readonly.sh
@@ -318,15 +318,14 @@ typeset -i i
 n=${#rtests[@]}
 for ((i=0; i<$n; i++))
 do
-	got=$(
-		trap "${rtests[$i].res}" EXIT
+	(	trap "${rtests[$i].res}" EXIT
 		eval "${rtests[$i].ini}"
-		eval "${rtests[$i].chg}" 2>&1
-	)
+		eval "${rtests[$i].chg}"
+	) 2>&1 | read -d $'\x17' got
 	[[ $got == *$': is read only\n'* ]] || err_exit "Readonly variable did not warn for rtests[$i]: "\
 		"setup='${rtests[$i].ini}', change='${rtests[$i].chg}'"
 	got=${got#*$': is read only\n'}
-	[[ ${rtests[$i].exp} == "$got" ]] || err_exit "Readonly variable changed on rtests[$i]: "\
+	[[ $got == *"${rtests[$i].exp}"$'\n' ]] || err_exit "Readonly variable changed on rtests[$i]: "\
 		"expected '${rtests[$i].exp}', got '$got'"
 done
 unset i n got rtests


### PR DESCRIPTION
src/cmd/ksh93/tests/readonly.sh:
- Adjust testing method from using command substitution `$(...)` to
  using a command subshell `(...)` with a read to capture output of
  tests.

  Note: `$'\x17'` was used in the read as the delimiter as more than
  likely ASCII code ETB / 23 (decimal) / 17 (hex) / 027 (octal) will
  not exist in the redirected output allowing the read to capture to
  end of file.