### PR TITLE
Correct memory fault when removing default nameref KSH_VERSION

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,12 @@ For full details, see the git log at: https://github.com/ksh93/ksh
 
 Any uppercase BUG_* names are modernish shell bug IDs.
 
+2021-04-12:
+
+- Corrected a memory fault when an attempt was made to unset the default
+  nameref KSH_VERSION from the shell environment prior to any other name
+  reference variable creation or modificaton.
+
 2021-04-11:
 
 - Fixed two related regressions introduced on 2020-06-16:

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -20,7 +20,7 @@
 
 #define SH_RELEASE_FORK	"93u+m"		/* only change if you develop a new ksh93 fork */
 #define SH_RELEASE_SVER	"1.0.0-alpha"	/* semantic version number: https://semver.org */
-#define SH_RELEASE_DATE	"2021-04-11"	/* must be in this format for $((.sh.version)) */
+#define SH_RELEASE_DATE	"2021-04-12"	/* must be in this format for $((.sh.version)) */
 #define SH_RELEASE_CPYR	"(c) 2020-2021 Contributors to ksh " SH_RELEASE_FORK
 
 /* Scripts sometimes field-split ${.sh.version}, so don't change amount of whitespace. */

--- a/src/cmd/ksh93/sh/name.c
+++ b/src/cmd/ksh93/sh/name.c
@@ -2578,7 +2578,7 @@ void	_nv_unset(register Namval_t *np,int flags)
 	else if(nv_isref(np) && !nv_isattr(np,NV_EXPORT|NV_MINIMAL) && np->nvalue.nrp)
 	{
 
-		if(np->nvalue.nrp->root)
+		if(np->nvalue.nrp->root && Refdict)
 			dtdelete(Refdict,(void*)np->nvalue.nrp);
 		if(np->nvalue.nrp->sub)
 			free(np->nvalue.nrp->sub);

--- a/src/cmd/ksh93/tests/nameref.sh
+++ b/src/cmd/ksh93/tests/nameref.sh
@@ -684,4 +684,7 @@ typeset -n ref='arr[2]'
 
 $SHELL  2> /dev/null -c 'function x { nameref lv=gg ; compound -A lv.c=( [4]=( x=1 )) ; } ; compound gg ; x' || err_exit 'compound array assignment with nameref in a function failed'
 
+$SHELL -c 'unset -n KSH_VERSION' 2> /dev/null || err_exit 'Unable to unset nameref KSH_VERSION.'
+
+# ======
 exit $((Errors<125?Errors:125))


### PR DESCRIPTION
This commit fixes a segmentation fault when an attempt was made to unset
the default KSH_VERSION variable prior any other nameref activity such as
creating another nameref or even reassigning the nameref KSH_VERSION to
something else.

(new shell without prior nameref activity)
$ nameref
KSH_VERSION=.sh.version
$ unset -n KSH_VERSION
Memory fault

src/cmd/ksh93/sh/name.c:_nv_unset():
- Add a 'Refdict' check before attempting to remove a value from it as
  apparently one does not exist until some sort of nameref activity occurs
  after shell startup as the default nameref of 'KSH_VERSION=.sh.version'
  does not create one.

src/cmd/ksh93/tests/nameref.sh:
- Add test for removal of default nameref KSH_VERSION