### PR TITLE
tests/builtins.sh: Fix dtksh regression test failures

### DIFF
--- a/src/cmd/ksh93/tests/builtins.sh
+++ b/src/cmd/ksh93/tests/builtins.sh
@@ -988,7 +988,7 @@ EOF
 # Builtins should handle unrecognized options correctly
 while IFS= read -r bltin <&3
 do	case $bltin in
-	echo | test | true | false | \[ | : | getconf | */getconf | uname | */uname | Dt* | X* | login | newgrp )
+	echo | test | true | false | \[ | : | getconf | */getconf | uname | */uname | catclose | catgets | catopen | Dt* | _Dt* | X* | login | newgrp )
 		continue ;;
 	/*/*)	expect="Usage: ${bltin##*/} "
 		actual=$({ PATH=${bltin%/*}; "${bltin##*/}" --this-option-does-not-exist; } 2>&1) ;;


### PR DESCRIPTION
The usage options test wasn't properly excluding all [dtksh](https://sourceforge.net/p/cdesktopenv/code/ci/master/tree/cde/programs/dtksh/) builtins, which was causing the regression tests to fail when run under dtksh. This commit adds exclusions for the builtins missed in commit ef4fe41 to fix the builtins.sh regression tests.