### PR TITLE
nv_disc(NV_LAST) loses trailing shell context from discipline stack

### DIFF
--- a/src/cmd/ksh93/sh/nvdisc.c
+++ b/src/cmd/ksh93/sh/nvdisc.c
@@ -752,7 +752,7 @@ Namfun_t *nv_disc(register Namval_t *np, register Namfun_t* fp, int mode)
 			if(lp && !lp->disc)
 				fp->next = lp;
 			else
-				fp->next = 0;
+				fp->next = *lpp;
 		}
 		else
 		{


### PR DESCRIPTION
This is the underlying cause for the issue worked around in
  https://github.com/ksh93/ksh/commit/3654ee73c03fb622dc878d6d

Each environment variable (name/value pair) has a linked list of disciplines
attached to it, and at the end of that list there is optionally a shell context
pointer. For example, for the EDITOR variable:

	> ::bp libshell.so.1`put_ed
	> ::run
	$
	$ EDITOR=vim
	> ::stack ! head -1
	libshell.so.1`put_ed+0x14(e06208, e01c58, 0, dced90)
	> e06208::print Namval_t
	{
	    nvname = 0xfffffbffeec40a0e "EDITOR"
	    nvfun = 0xdced90
	    nvalue = 0
	}
	> e06208::print Namval_t nvfun | ::print Namfun_t
	{
	    disc = libshell.so.1`EDITOR_disc
	    next = libshell.so.1`sh+0x710
	}

Here, the EDITOR Namval_t has a discipline stack containing
EDITOR_disc and &Shell_t.nvfun.

The problem arises when a new discipline is pushed onto the stack, such as when
using typeset -u to add an upper-case translation discipline.

    $ typeset -u EDITOR
    > e06208::print Namval_t
    {
        nvname = 0xfffffbffeec40a0e "EDITOR"
        nvfun = 0xdced90
        nvalue = 0xe0fdb0 "vim"
    }
    > e06208::print Namval_t nvfun | ::print Namfun_t
    {
        disc = libshell.so.1`EDITOR_disc
        next = 0xdc27a0
    }
    > e06208::print Namval_t nvfun | ::print Namfun_t next | ::print Namfun_t
    {
        disc = libshell.so.1`TRANS_disc
        next = 0
    }

TRANS_disc has been pushed onto the end of the discipline stack, but the
shell handle has been lost.

With this change, the attributes and variables tests pass (this is on
illumos where this change originates).