### PR TITLE
Set a different pseudorandom seed after forking a subshell

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,12 @@ For full details, see the git log at: https://github.com/ksh93/ksh
 
 Any uppercase BUG_* names are modernish shell bug IDs.
 
+2021-04-24:
+
+- When a forked subshell is created, ksh will now set a new pseudorandom seed.
+  This fixes a bug that caused forked subshells to use the same random numbers
+  for the $RANDOM variable.
+
 2021-04-22:
 
 - shcomp (the shell bytecode compiler) was fixed to correctly compile process

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -20,7 +20,7 @@
 
 #define SH_RELEASE_FORK	"93u+m"		/* only change if you develop a new ksh93 fork */
 #define SH_RELEASE_SVER	"1.0.0-alpha"	/* semantic version number: https://semver.org */
-#define SH_RELEASE_DATE	"2021-04-22"	/* must be in this format for $((.sh.version)) */
+#define SH_RELEASE_DATE	"2021-04-24"	/* must be in this format for $((.sh.version)) */
 #define SH_RELEASE_CPYR	"(c) 2020-2021 Contributors to ksh " SH_RELEASE_FORK
 
 /* Scripts sometimes field-split ${.sh.version}, so don't change amount of whitespace. */

--- a/src/cmd/ksh93/sh/subshell.c
+++ b/src/cmd/ksh93/sh/subshell.c
@@ -207,6 +207,10 @@ void sh_subfork(void)
 			sp->subpid = pid;
 		if(trap)
 			free((void*)trap);
+		/* set a different pseudorandom seed to avoid using the same one as the forked subshell */
+		char *random = nv_getval(RANDNOD);
+		if(random)
+			srand((unsigned int)atoi(random));
 		siglongjmp(*shp->jmplist,SH_JMPSUB);
 	}
 	else

--- a/src/cmd/ksh93/tests/variables.sh
+++ b/src/cmd/ksh93/tests/variables.sh
@@ -1097,7 +1097,7 @@ $SHELL -c '
 	for var
 	do
 		(
-			ulimit -t unlimited
+			ulimit -t unlimited 2> /dev/null
 			test -v $var
 		)
 	done

--- a/src/cmd/ksh93/tests/variables.sh
+++ b/src/cmd/ksh93/tests/variables.sh
@@ -1098,7 +1098,7 @@ $SHELL -c '
 	do
 		(
 			ulimit -t unlimited
-			test $var
+			test -v $var
 		)
 	done
 	exit $((errors + 1))	# a possible erroneous asynchronous fork would cause exit status 0


### PR DESCRIPTION
This pull request fixes the issue detailed in bug #285. The main problem is that ksh doesn't set a new pseudorandom seed after forking a subshell. The reproducer uses a redirect to fork a subshell, although the redirect can be replaced with `ulimit -t unlimited` to achieve the same result. When ksh forks a subshell, it should not continue to use the same pseudorandom seed as the subshell. This is because while `nget_rand()` can get a different random number using the same seed, it only does so if it knows what the last random number was. Once a subshell forks, `nget_rand()` (in the parent shell) isn't able to know what the last random number was in the forked subshell.

`src/cmd/ksh93/sh/subshell.c`: `sh_subfork()`:
- After forking a subshell, set a pseudorandom seed in the parent shell that's different from the one the forked subshell is using. This seed is based off of the last obtained random number. If `$RANDOM` is unset, a new seed will not be set (since there is no random number to use).

`src/cmd/ksh93/tests/variables.sh`:
- Add two regression tests for `$RANDOM` after it's used in a forked subshell. The second test makes sure we are actually using a different pseudorandom seed, rather than the next number from the same seed.
- Add a comment noting the `unset RANDOM` that occurs later in the variables.sh script is important.

Fixes: https://github.com/ksh93/ksh/issues/285