### PR TITLE
Don't detect unset functions with whence (re: 13c57e4b)

### DIFF
--- a/src/cmd/ksh93/bltins/whence.c
+++ b/src/cmd/ksh93/bltins/whence.c
@@ -192,7 +192,7 @@ static int whence(Shell_t *shp,char **argv, register int flags)
 		}
 		/* built-ins and functions next */
 	bltins:
-		if(!(flags&F_FLAG) && (np = nv_bfsearch(name, shp->fun_tree, &nq, &notused)) && !is_abuiltin(np))
+		if(!(flags&F_FLAG) && (np = nv_bfsearch(name, shp->fun_tree, &nq, &notused)) && !is_abuiltin(np) && nv_isattr(np, NV_FUNCTION))
 		{
 			if(flags&Q_FLAG)
 				continue;

--- a/src/cmd/ksh93/bltins/whence.c
+++ b/src/cmd/ksh93/bltins/whence.c
@@ -192,7 +192,7 @@ static int whence(Shell_t *shp,char **argv, register int flags)
 		}
 		/* built-ins and functions next */
 	bltins:
-		if(!(flags&F_FLAG) && (np = nv_bfsearch(name, shp->fun_tree, &nq, &notused)) && !is_abuiltin(np) && nv_isattr(np, NV_FUNCTION))
+		if(!(flags&F_FLAG) && (np = nv_bfsearch(name, shp->fun_tree, &nq, &notused)) && is_afunction(np))
 		{
 			if(flags&Q_FLAG)
 				continue;

--- a/src/cmd/ksh93/tests/subshell.sh
+++ b/src/cmd/ksh93/tests/subshell.sh
@@ -700,6 +700,7 @@ got=$( f() { echo WRONG; }; ( unset -f f; PATH=/dev/null f 2>&1 ) )
 	"(expected match of $(printf %q "$exp"), got $(printf %q "$got"))"
 
 # Functions unset in a subshell shouldn't be detected by type (whence -v)
+# https://github.com/ksh93/ksh/pull/287
 notafunc() {
 	echo 'Failure'
 }

--- a/src/cmd/ksh93/tests/subshell.sh
+++ b/src/cmd/ksh93/tests/subshell.sh
@@ -699,6 +699,15 @@ got=$( f() { echo WRONG; }; ( unset -f f; PATH=/dev/null f 2>&1 ) )
 [[ $got == $exp ]] || err_exit 'unset -f fails in sub-subshell on function set in subshell' \
 	"(expected match of $(printf %q "$exp"), got $(printf %q "$got"))"
 
+# Functions unset in a subshell shouldn't be detected by type (whence -v)
+notafunc() {
+	echo 'Failure'
+}
+exp=Success
+got=$(unset -f notafunc; type notafunc 2>/dev/null || echo Success)
+[[ $got == "$exp" ]] || err_exit "type/whence -v finds function in virtual subshell after it's unset with 'unset -f'" \
+	"(expected $(printf %q "$exp"), got $(printf %q "$got"))"
+
 # ======
 # Unsetting or redefining aliases within subshells
 


### PR DESCRIPTION
`src/cmd/ksh93/bltins/whence.c`:
- The previous commit that fixed `unset -f` in virtual subshells left one bug. The `type` builtin (or `whence -v`) could still find the unset function in virtual subshells. To fix this bug, avoid detecting functions in the `whence` builtin unless they have the `NV_FUNCTION` attribute. Reproducer:
```sh
$ foo() { echo foo; }
$ (unset -f foo; type foo)
foo is an undefined function
```  

`src/cmd/ksh93/tests/subshell.sh`:
- Add a regression test for using `type` on a function unset inside of a virtual subshell.