### PR TITLE
Add support for process substitutions to the deparser

### DIFF
--- a/src/cmd/ksh93/sh/deparse.c
+++ b/src/cmd/ksh93/sh/deparse.c
@@ -40,9 +40,10 @@
 
 
 /* flags that can be specified with p_tree() */
-#define NO_NEWLINE	1
-#define NEED_BRACE	2
-#define NO_BRACKET	4
+#define NO_NEWLINE	(1 << 0)
+#define NEED_BRACE	(1 << 1)
+#define NO_BRACKET	(1 << 2)
+#define PROCSUBST	(1 << 3)
 
 static void p_comlist(const struct dolnod*,int);
 static void p_arg(const struct argnod*, int endchar, int opts);
@@ -62,8 +63,6 @@ static const struct ionod *here_doc;
 static Sfio_t *outfile;
 static const char *forinit = "";
 
-extern void sh_deparse(Sfio_t*, const Shnode_t*,int);
-
 void sh_deparse(Sfio_t *out, const Shnode_t *t,int tflags)
 {
 	outfile = out;
@@ -77,9 +76,12 @@ static void p_tree(register const Shnode_t *t,register int tflags)
 	register char *cp;
 	int save = end_line;
 	int needbrace = (tflags&NEED_BRACE);
+	int procsub = (tflags&PROCSUBST);
 	tflags &= ~NEED_BRACE;
 	if(tflags&NO_NEWLINE)
 		end_line = ' ';
+	else if(procsub)
+		end_line = ')';
 	else
 		end_line = '\n';
 	switch(t->tre.tretyp&COMMSK)
@@ -113,7 +115,7 @@ static void p_tree(register const Shnode_t *t,register int tflags)
 		case TFORK:
 			if(needbrace)
 				tflags |= NEED_BRACE;
-			if(t->tre.tretyp&(FAMP|FCOOP))
+			if((t->tre.tretyp&(FAMP|FCOOP)) && (t->tre.tretyp&(FAMP|FINT))!=FAMP)
 			{
 				tflags = NEED_BRACE|NO_NEWLINE;
 				end_line = ' ';
@@ -125,12 +127,12 @@ static void p_tree(register const Shnode_t *t,register int tflags)
 				p_redirect(t->fork.forkio);
 			if(t->tre.tretyp&FCOOP)
 			{
-				sfputr(outfile,"|&",'\n');
+				sfputr(outfile,"|&",procsub?')':'\n');
 				begin_line = 1;
 			}
-			else if(t->tre.tretyp&FAMP)
+			else if((t->tre.tretyp&(FAMP|FINT))==(FAMP|FINT))
 			{
-				sfputr(outfile,"&",'\n');
+				sfputr(outfile,"&",procsub?')':'\n');
 				begin_line = 1;
 			}
 			break;
@@ -401,13 +403,13 @@ static void p_arg(register const struct argnod *arg,register int endchar,int opt
 		else if(opts)
 			flag = ' ';
 		cp = arg->argval;
-		if(*cp==0 && (arg->argflag&ARG_EXP)  && arg->argchn.ap)
+		if(*cp==0 && (arg->argflag&ARG_EXP) && arg->argchn.ap)
 		{
+			/* process substitution */
 			int c = (arg->argflag&ARG_RAW)?'>':'<';
 			sfputc(outfile,c);
 			sfputc(outfile,'(');
-			p_tree((Shnode_t*)arg->argchn.ap,0);
-			sfputc(outfile,')');
+			p_tree((Shnode_t*)arg->argchn.ap,PROCSUBST);
 		}
 		else if(*cp==0 && opts==POST && arg->argchn.ap)
 		{
@@ -489,7 +491,17 @@ static void p_redirect(register const struct ionod *iop)
 		}
 		if((iof&IOLSEEK) && (iof&IOARITH))
 			iof2 = iof, iof = ' ';
-		if(iop->iodelim)
+		if((iop->iofile & IOPROCSUB) && !(iop->iofile & IOLSEEK))
+		{
+			/* process substitution as argument to redirection */
+			if(iop->iofile & IOPUT)
+				sfwrite(outfile,">(",2);
+			else
+				sfwrite(outfile,"<(",2);
+			p_tree((Shnode_t*)iop->ioname,PROCSUBST);
+			sfputc(outfile,iof);
+		}
+		else if(iop->iodelim)
 		{
 			if(!(iop->iofile&IODOC))
 				sfwrite(outfile,"''",2);


### PR DESCRIPTION
Like `tdump()` and `trestore()` before commit 32d1abb1, `sh_deparse()` fails to handle process substitutions correctly. This limitation of the shell deparser is rather minor since it's unused. However, seeing as the deparser was [left in the code base intentionally](https://github.com/ksh93/ksh/issues/219#issuecomment-803517022) it should at least handle process substitutions correctly.

<details open>
<summary>shcomp reproducer</summary>

This bugfix was tested by adding support for the deparser to `shcomp`. I've included the addition in the patch below, although it's not currently part of the pull request diff (though I could add it to `shcomp` if that's desirable).
```diff
--- a/src/cmd/ksh93/sh/shcomp.c
+++ b/src/cmd/ksh93/sh/shcomp.c
@@ -36,7 +36,7 @@ static const char usage[] =
 "[-license?http://www.eclipse.org/org/documents/epl-v10.html]"
 "[--catalog?" SH_DICT "]"
 "[+NAME?shcomp - compile a shell script]"
-"[+DESCRIPTION?Unless \b-D\b is specified, \bshcomp\b takes a shell script, "
+"[+DESCRIPTION?Unless one of \b-D\b or \b-d\b is specified, \bshcomp\b takes a shell script, "
 	"\ainfile\a, and creates a binary format file, \aoutfile\a, that "
 	"\bksh\b can read and execute with the same effect as the original "
 	"script.]"
@@ -50,6 +50,7 @@ static const char usage[] =
 	"will be read from standard input.]"
 "[D:dictionary?Generate a list of strings that need to be placed in a message "
 	"catalog for internationalization.]"
+"[d:deparse?Dump a deparsed version of the shell script to \aoutfile\a.]"
 "[n:noexec?Displays warning messages for obsolete or non-conforming "
 	"constructs.] "
 "[v:verbose?Displays input from \ainfile\a onto standard error as it "
@@ -79,13 +80,16 @@ int main(int argc, char *argv[])
 	Namval_t *np;
 	Shnode_t *t;
 	char *cp;
-	int n, nflag=0, vflag=0, dflag=0;
+	int n, nflag=0, vflag=0, dflag=0, deparse=0;
 	error_info.id = argv[0];
 	while(n = optget(argv, usage )) switch(n)
 	{
 	    case 'D':
 		dflag=1;
 		break;
+	    case 'd':
+		deparse=1;
+		break;
 	    case 'v':
 		vflag=1;
 		break;
@@ -137,7 +141,7 @@ int main(int argc, char *argv[])
 		sh_onoption(SH_NOEXEC);
 	if(vflag)
 		sh_onoption(SH_VERBOSE);
-	if(!dflag)
+	if(!dflag && !deparse)
 		sfwrite(out,header,sizeof(header));
 	shp->inlineno = 1;
 #if SHOPT_BRACEPAT
@@ -150,7 +154,9 @@ int main(int argc, char *argv[])
 		{
 			if((t->tre.tretyp&(COMMSK|COMSCAN))==0 && t->com.comnamp && strcmp(nv_name((Namval_t*)t->com.comnamp),"alias")==0)
 				sh_exec(t,0);
-			if(!dflag && sh_tdump(out,t) < 0)
+			if(deparse)
+				sh_deparse(out,t,0);
+			else if(!dflag && sh_tdump(out,t) < 0)
 			{
 				errormsg(SH_DICT,ERROR_exit(1),"dump failed");
 				UNREACHABLE();
```

Deparser output before and after this bugfix:
```sh
$ cat ./procsubs.sh
#!/bin/ksh

foo() {
	:
}

cat < <(echo 'foo')
echo bad > >(sed 's/bad/good/g')

echo <(true)
echo <(true &)
echo >(true &)
echo >(true 'quoted arg')

true > >(foo) 2< <(true)
true > >(foo) 2< <(true) | false
false < <(false &)
false < <(true; foo)
: > >(cat /etc/hosts |&)

# Before bugfix
$ ./shcomp-before -d ./procsubs.sh
foo()
 {
		:
}
cat < 

echo bad > $'\xca\x04'
echo <(true
)
echo <(true &
)
echo >(true &
&
)
echo >(true 'quoted arg' &
)
true > $'\xca\x04' 2< 

true > $'\xca\x04' 2< 
 | false
false < 

false < 

: > $'\xca\x04'

# After fixing process substitution support in the deparser
$ ./shcomp-after -d ./procsubs.sh
foo()
 {
		:
}
cat < <(echo foo)
echo bad > >(sed s/bad/good/g)
echo <(true)
echo <(true &)
echo >(true &)
echo >(true 'quoted arg')
true > >(foo) 2< <(true)
true > >(foo) 2< <(true) | false
false < <(false &)
false < <(true
foo)
: > >(cat /etc/hosts |&)
```

</details>

<details open>
<summary>Primary changes</summary>

`src/cmd/ksh93/sh/deparse.c`:
\- Add a `PROCSUBST` flag for handling process substitutions in `sh_deparse()`.
\- If we're handling a process substitution, add an ending `)` without an extra newline.
\- Avoid adding an extra ` &` to commands inside of a process substitution. An extra ` &` is only added if the `FAMP` and `FINT` flags are set, which indicates the command was spawned as a separate job with `&`.
\- Add process substitution handling to `p_redirect()` by calling `p_tree()` when encountering a process substitution.

</details>