### PR TITLE
Fix more bugs that occur when enabling ASan

### DIFF
--- a/src/cmd/ksh93/bltins/typeset.c
+++ b/src/cmd/ksh93/bltins/typeset.c
@@ -1581,7 +1581,7 @@ static void print_scan(Sfio_t *file, int flag, Dt_t *root, int option,struct tda
 			if(name)
 			{
 				char *newname = nv_name(np);
-				if(memcmp(name,newname,len)==0 && newname[len]== '.')
+				if(strncmp(name,newname,len)==0 && newname[len]== '.')
 					continue;
 				name = 0;
 			}

--- a/src/cmd/ksh93/edit/vi.c
+++ b/src/cmd/ksh93/edit/vi.c
@@ -992,7 +992,7 @@ static int cntlmode(Vi_t *vp)
 				c = (virtual[0]=='#');
 				while(p-- >= virtual)
 				{
-					if(*p=='\n' || p<virtual)
+					if(p<virtual || *p=='\n')
 					{
 						if(c) /* delete '#' */
 						{

--- a/src/cmd/ksh93/sh/name.c
+++ b/src/cmd/ksh93/sh/name.c
@@ -187,7 +187,7 @@ Namval_t *nv_addnode(Namval_t* np, int remove)
 		nv_delete(np,root,NV_NOFREE);
 		np = nv_search(sp->rp->nvname,root,NV_ADD);
 	}
-	if(sp->numnodes && memcmp(np->nvname,NV_CLASS,sizeof(NV_CLASS)-1))
+	if(sp->numnodes && strncmp(np->nvname,NV_CLASS,sizeof(NV_CLASS)-1))
 	{
 		name = (sp->nodes[0])->nvname;
 		i = strlen(name);

--- a/src/cmd/ksh93/sh/nvtree.c
+++ b/src/cmd/ksh93/sh/nvtree.c
@@ -181,7 +181,7 @@ void *nv_diropen(Namval_t *np,const char *name)
 		{
 			char *cp = nv_name(dp->hp);
 			c = strlen(cp);
-			if(memcmp(name,cp,c) || name[c]!='[')
+			if(strncmp(name,cp,c) || name[c]!='[')
 				dp->hp = (Namval_t*)dtnext(dp->root,dp->hp);
 			else
 			{

--- a/src/cmd/ksh93/sh/nvtype.c
+++ b/src/cmd/ksh93/sh/nvtype.c
@@ -883,7 +883,7 @@ Namval_t *nv_mktype(Namval_t **nodes, int numnodes)
 				continue;
 		}
 		nnodes++;
-		if(name && memcmp(&name[m],&np->nvname[m],n)==0 && np->nvname[m+n]=='.')
+		if(name && strncmp(&name[m],&np->nvname[m],n)==0 && np->nvname[m+n]=='.')
 			offset -= sizeof(char*);
 		dsize = nv_datasize(np,&offset);
 		if(!nv_isarray(np) && (dp=(Namtype_t*)nv_hasdisc(np, &type_disc)))

--- a/src/cmd/ksh93/tests/pty.sh
+++ b/src/cmd/ksh93/tests/pty.sh
@@ -826,5 +826,22 @@ w :\E_
 r ^:test-2: : One\\ "Two Three"\$'Four Five'\.mp3\r\n$
 !
 
+# err_exit #
+((SHOPT_VSH)) && tst $LINENO <<"!"
+L crash when entering comment into history file (vi mode)
+# https://github.com/att/ast/issues/798
+
+d 15
+p :test-1:
+w set -o vi
+r ^:test-1: set -o vi\r\n$
+c foo \E#
+r ^:test-2: #foo\r\n$
+w hist -lnN 1
+r ^:test-3: hist -lnN 1\r\n$
+r \t#foo\r\n$
+r \thist -lnN 1\r\n$
+!
+
 # ======
 exit $((Errors<125?Errors:125))

--- a/src/cmd/ksh93/tests/pty.sh
+++ b/src/cmd/ksh93/tests/pty.sh
@@ -833,12 +833,10 @@ L crash when entering comment into history file (vi mode)
 
 d 15
 p :test-1:
-w set -o vi
-r ^:test-1: set -o vi\r\n$
 c foo \E#
-r ^:test-2: #foo\r\n$
+r ^:test-1: #foo\r\n$
 w hist -lnN 1
-r ^:test-3: hist -lnN 1\r\n$
+r ^:test-2: hist -lnN 1\r\n$
 r \t#foo\r\n$
 r \thist -lnN 1\r\n$
 !


### PR DESCRIPTION
src/cmd/ksh93/{bltins/typeset,sh/name,sh/nvtree,sh/nvtype}.c:
\- Replace more instances of `memcmp` with `strncmp` to fix heap-buffer-overflow errors when running the regression tests with ASan enabled.

src/cmd/ksh93/edit/vi.c:
\- Fix an invalid dereference of the `p` pointer to fix a crash in vi mode when entering a comment into the command history. This bugfix was backported from ksh2020: https://github.com/att/ast/issues/798

src/cmd/ksh93/tests/pty.sh:
\- Add a regression test for the vi mode crash.