### PR TITLE
Back port ksh93v- float, int, and exp10 changes from math.tab

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,9 +5,10 @@ Any uppercase BUG_* names are modernish shell bug IDs.
 
 2021-05-07:
 
-- Back ported three ksh93v- math.tab changes allowing for an exp10 math
-  function if one exits, a new float function, and lastly an updated int
-  function that rounds to zero instead of being an alias to floor.
+- Backported three ksh 93v- math.tab changes, allowing for an exp10()
+  arithmetic function if one exists in the C library, a new float()
+  function, and lastly an updated int() function that rounds to zero
+  instead of being an alias to floor().
 
 2021-05-05:
 

--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,12 @@ For full details, see the git log at: https://github.com/ksh93/ksh
 
 Any uppercase BUG_* names are modernish shell bug IDs.
 
+2021-05-07:
+
+- Back ported three ksh93v- math.tab changes allowing for an exp10 math
+  function if one exits, a new float function, and lastly an updated int
+  function that rounds to zero instead of being an alias to floor.
+
 2021-05-05:
 
 - Fixed: a preceding variable assignment like foo=bar in 'foo=bar command'

--- a/src/cmd/ksh93/COMPATIBILITY
+++ b/src/cmd/ksh93/COMPATIBILITY
@@ -138,6 +138,10 @@ For more details, see the NEWS file and for complete details, see the git log.
 	$RANDOM sequence in the parent environment. In addition, upon
 	invoking a subshell, $RANDOM is now reseeded (as mksh and bash do).
 
+26.	The builtin math function int has changed to round towards zero
+	instead of negative infinity. Previously, int was an alias to floor
+	but now it behaves like trunc.
+
 ____________________________________________________________________________
 
 		KSH-93 VS. KSH-88

--- a/src/cmd/ksh93/COMPATIBILITY
+++ b/src/cmd/ksh93/COMPATIBILITY
@@ -138,9 +138,9 @@ For more details, see the NEWS file and for complete details, see the git log.
 	$RANDOM sequence in the parent environment. In addition, upon
 	invoking a subshell, $RANDOM is now reseeded (as mksh and bash do).
 
-26.	The builtin math function int has changed to round towards zero
-	instead of negative infinity. Previously, int was an alias to floor
-	but now it behaves like trunc.
+26.	The built-in arithmetic function int() has changed to round towards
+	zero instead of negative infinity. Previously, int() was an alias to
+	floor(), but now it behaves like trunc().
 
 ____________________________________________________________________________
 

--- a/src/cmd/ksh93/data/math.tab
+++ b/src/cmd/ksh93/data/math.tab
@@ -1,6 +1,27 @@
+########################################################################
+#                                                                      #
+#               This software is part of the ast package               #
+#          Copyright (c) 1982-2013 AT&T Intellectual Property          #
+#          Copyright (c) 2020-2021 Contributors to ksh 93u+m           #
+#                      and is licensed under the                       #
+#                 Eclipse Public License, Version 1.0                  #
+#                    by AT&T Intellectual Property                     #
+#                                                                      #
+#                A copy of the License is available at                 #
+#          http://www.eclipse.org/org/documents/epl-v10.html           #
+#         (with md5 checksum b35adb5213ca9657e911e9befb180842)         #
+#                                                                      #
+#              Information and Software Systems Research               #
+#                            AT&T Research                             #
+#                           Florham Park NJ                            #
+#                                                                      #
+#                  David Korn <dgk@research.att.com>                   #
+#                                                                      #
+########################################################################
+
 # <return type: i:integer f:floating-point> <#floating-point-args> <function-name> [<alias> ...]
 # <function-name>l variants are handled by features/math.sh
-# @(#)math.tab (AT&T Research) 2010-10-26
+# @(#)math.tab (AT&T Research) 2013-08-11
 f 1 acos
 f 1 acosh
 f 1 asin

--- a/src/cmd/ksh93/data/math.tab
+++ b/src/cmd/ksh93/data/math.tab
@@ -17,11 +17,13 @@ f 1 erf
 f 1 erfc
 f 1 exp
 f 1 exp2
+f 1 exp10
 f 1 expm1
 f 1 fabs abs
 f 2 fdim
 f 1 finite
-f 1 floor int
+f 1 float
+f 1 floor
 f 3 fma
 f 2 fmax
 f 2 fmin
@@ -30,6 +32,7 @@ i 1 fpclassify
 i 1 fpclass
 f 2 hypot
 i 1 ilogb
+f 1 int
 i 1 isfinite
 i 2 isgreater
 i 2 isgreaterequal

--- a/src/cmd/ksh93/features/math.sh
+++ b/src/cmd/ksh93/features/math.sh
@@ -1,7 +1,7 @@
 ########################################################################
 #                                                                      #
 #               This software is part of the ast package               #
-#          Copyright (c) 1982-2012 AT&T Intellectual Property          #
+#          Copyright (c) 1982-2013 AT&T Intellectual Property          #
 #          Copyright (c) 2020-2021 Contributors to ksh 93u+m           #
 #                      and is licensed under the                       #
 #                 Eclipse Public License, Version 1.0                  #
@@ -21,7 +21,7 @@
 : generate the ksh math builtin table
 : include math.tab
 
-# @(#)math.sh (AT&T Research) 2012-06-13
+# @(#)math.sh (AT&T Research) 2013-08-11
 
 case $ZSH_VERSION in
 ?*)	emulate ksh ;;

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -21,7 +21,7 @@
 
 #define SH_RELEASE_FORK	"93u+m"		/* only change if you develop a new ksh93 fork */
 #define SH_RELEASE_SVER	"1.0.0-alpha"	/* semantic version number: https://semver.org */
-#define SH_RELEASE_DATE	"2021-05-05"	/* must be in this format for $((.sh.version)) */
+#define SH_RELEASE_DATE	"2021-05-07"	/* must be in this format for $((.sh.version)) */
 #define SH_RELEASE_CPYR	"(c) 2020-2021 Contributors to ksh " SH_RELEASE_FORK
 
 /* Scripts sometimes field-split ${.sh.version}, so don't change amount of whitespace. */

--- a/src/cmd/ksh93/sh.1
+++ b/src/cmd/ksh93/sh.1
@@ -2973,8 +2973,8 @@ can be used within an arithmetic expression:
 .PP
 .if t .RS
 .B
-.if n abs acos acosh asin asinh atan atan2 atanh cbrt ceil copysign cos cosh erf erfc exp exp2 expm1 fabs fpclassify fdim finite floor fma fmax fmin fmod hypot ilogb int isfinite sinf isnan isnormal issubnormal issubordered iszero j0 j1 jn lgamma log log10 log2 logb nearbyint nextafter nexttoward pow remainder rint round scanb signbit sin sinh sqrt tan tanh tgamma trunc y0 y1 yn
-.if t abs   acos   acosh   asin   asinh   atan   atan2   atanh   cbrt   ceil copysign   cos   cosh   erf  erfc   exp   exp2   expm1   fabs   fpclassify fdim   finite   floor  fma   fmax   fmod   j0      j1      jn      hypot   ilogb   int   isfinite   isinf   isnan   isnormal  issubnormal   issubordered   iszero lgamma   log   log10 log2   logb   nearbyint   nextafter   nexttoward  pow   rint   round   scalb   signbit sin   sinh   sqrt   tan   tanh   tgamma   trunc   y0      y1      yn
+.if n abs acos acosh asin asinh atan atan2 atanh cbrt ceil copysign cos cosh erf erfc exp exp10 exp2 expm1 fabs fdim finite float floor fma fmax fmin fmod fpclass fpclassify hypot ilogb int isfinite isgreater isgreaterequal isinf isinfinite isless islessequal islessgreater isnan isnormal issubnormal isunordered iszero j0 j1 jn ldexp lgamma log log10 log1p log2 logb nearbyint nextafter nexttoward pow remainder rint round scalb scalbn signbit sin sinh sqrt tan tanh tgamma trunc y0 y1 yn
+.if t abs   acos   acosh   asin   asinh   atan   atan2   atanh   cbrt   ceil   copysign   cos   cosh   erf   erfc   exp   exp10   exp2   expm1   fabs   fdim   finite   float   floor   fma   fmax   fmin   fmod   fpclass   fpclassify   hypot   ilogb   int   isfinite   isgreater   isgreaterequal   isinf   isinfinite   isless   islessequal   islessgreater   isnan   isnormal   issubnormal   isunordered   iszero   j0   j1   jn   ldexp   lgamma   log   log10   log1p   log2   logb   nearbyint   nextafter   nexttoward   pow   remainder   rint   round   scalb   scalbn   signbit   sin   sinh   sqrt   tan   tanh   tgamma   trunc   y0   y1   yn
 .if t .RE
 
 In addition, arithmetic functions can be defined as shell functions with a

--- a/src/cmd/ksh93/tests/arith.sh
+++ b/src/cmd/ksh93/tests/arith.sh
@@ -850,4 +850,29 @@ got=$(
 [[ $got == *recursion* ]] && err_exit "recursion level not reset on readonly error (subshell)"
 
 # ======
+# Some math function tests and only error if function exits
+unset got
+got=0
+if ( (( exp10(3) )) ) 2> /dev/null
+then
+	(( (got=exp10(3)) == 1000 )) ||  err_exit "exp10(3) != 1000, got '$got'"
+fi
+got=0
+if ( (( int(6.89) )) ) 2> /dev/null
+then
+	(( (got=int(6.89)) == 6 )) ||  err_exit "int(6.89) != 6, got '$got'"
+fi
+got=0
+if ( (( int(-6.89) )) ) 2> /dev/null
+then
+	(( (got=int(-6.89)) == -6 )) ||  err_exit "int(-6.89) != -6, got '$got'"
+fi
+float got=-1
+if ( (( float(2./3) )) ) 2> /dev/null
+then
+	(( (got=float(2./3)) == 2./3 )) ||  err_exit "float(2./3) != 2./3, got '$got'"
+fi
+unset got
+
+# ======
 exit $((Errors<125?Errors:125))


### PR DESCRIPTION
Back ported some builtin math function updates from ksh93v- for a new int(), exp10(), and float().
References: [math.tab](https://github.com/att/ast/blob/2016-01-10-beta/src/cmd/ksh93/data/math.tab), [math.sh](https://github.com/att/ast/blob/2016-01-10-beta/src/cmd/ksh93/features/math.sh)

src/cmd/ksh93/data/math.tab:
- Added exp10()
- Remove int() as being an alias to floor()
- Created entries for local float() and local int() which are defined in
  features/math.sh.

src/cmd/ksh93/features/math.sh:
- parsed out floor and int related code from ksh93v-

src/cmd/ksh93/tests/arith.sh:
- added in regression tests for exp10, float, and int