### PR TITLE
Fix math feature tests when compiling with tcc

### DIFF
--- a/src/cmd/INIT/iffe.sh
+++ b/src/cmd/INIT/iffe.sh
@@ -4066,6 +4066,9 @@ $std
 $usr
 $pre
 $inc
+#ifdef _IFFE_type
+$v i;
+#else
 typedef int (*_IFFE_fun)();
 #ifdef _IFFE_extern
 _BEGIN_EXTERNS_
@@ -4073,6 +4076,7 @@ extern int $v();
 _END_EXTERNS_
 #endif
 static _IFFE_fun i=(_IFFE_fun)$v;int main(){return ((unsigned int)i)^0xaaaa;}
+#endif
 "
 					d=-D_IFFE_extern
 					if	compile $cc -c $tmp.c <&$nullin >&$nullout
@@ -4100,8 +4104,10 @@ static _IFFE_fun i=(_IFFE_fun)$v;int main(){return ((unsigned int)i)^0xaaaa;}
 								;;
 							esac
 						fi
-					else	case $intrinsic in
-						'')	copy $tmp.c "
+					else	if	compile $cc -D_IFFE_type -c $tmp.c <&$nullin >&$nullout
+						then	c=1
+						else	case $intrinsic in
+							'')	copy $tmp.c "
 $tst
 $ext
 $std
@@ -4113,13 +4119,15 @@ extern int foo();
 _END_EXTERNS_
 static int ((*i)())=foo;int main(){return(i==0);}
 "
-							compile $cc -c $tmp.c <&$nullin >&$nullout
-							intrinsic=$?
-							;;
-						esac
+								compile $cc -c $tmp.c <&$nullin >&$nullout
+								intrinsic=$?
+								;;
+							esac
+							c=$intrinsic
+						fi
 						case $o in
-						mth)	report $intrinsic 1 "$v() in math lib" "$v() not in math lib" "default for function $v()" ;;
-						*)	report $intrinsic 1 "$v() in default lib(s)" "$v() not in default lib(s)" "default for function $v()" ;;
+						mth)	report $c 1 "$v() in math lib" "$v() not in math lib" "default for function $v()" ;;
+						*)	report $c 1 "$v() in default lib(s)" "$v() not in default lib(s)" "default for function $v()" ;;
 						esac
 					fi
 					;;


### PR DESCRIPTION
Commit 92f7ca54 broke compilation with [tcc](https://repo.or.cz/tinycc.git/) on Linux. The following error would occur while compiling ksh with tcc:
```
In file included from /home/johno/GitRepos/KornShell/ksh/src/cmd/ksh93/data/strdata.c:105:
./FEATURE/math:91: error: too many basic types
mamake [cmd/ksh93]: *** exit code 1 making strdata.o
```
This build failure is fixed by backporting the relevant bugfix from the 93v- version of `iffe`.

`src/cmd/INIT/iffe.sh`:
\- Backport the 2013 `iffe` bugfix for the intrinsic function test to rule out type names (dated 2013-08-11 in the 93v- changelog).