### PR TITLE
Enable some memory leak tests for standard malloc

### DIFF
--- a/src/cmd/ksh93/tests/leaks.sh
+++ b/src/cmd/ksh93/tests/leaks.sh
@@ -286,9 +286,7 @@ done
 after=$(getmem)
 err_exit_if_leak 'indexed array in function'
 
-if [[ $vmalloc == enabled ]]
-then	LANG=$saveLANG	# comment out to test remaining leak (2/2)
-fi
+[[ $vmalloc == enabled ]] && LANG=$saveLANG	# comment out to test remaining leak (2/2)
 
 # ======
 # Memory leak in typeset (Red Hat #1036470)

--- a/src/cmd/ksh93/tests/leaks.sh
+++ b/src/cmd/ksh93/tests/leaks.sh
@@ -256,9 +256,7 @@ err_exit_if_leak 'script sourced in virtual subshell'
 
 # TODO: When ksh is compiled with vmalloc, both of these tests still leak (although much less
 # after the patch) when run in a non-C locale.
-if [[ $vmalloc == enabled ]]
-then	saveLANG=$LANG; LANG=C	# comment out to test remaining leak (1/2)
-fi
+[[ $vmalloc == enabled ]] && saveLANG=$LANG && LANG=C	# comment out to test remaining leak (1/2)
 
 function _hash
 {


### PR DESCRIPTION
The memory leak regression tests added in commit 05683ec7 only leak memory in the C.UTF-8 locale if ksh is compiled with vmalloc. I've ran these regression tests against ksh93v- and neither fail in that version of ksh, which indicates the bug causing these tests to fail may be similar to the one that causes https://github.com/ksh93/ksh/issues/95. Since the memory leak tests work with `-D_std_malloc`, only set `$LANG` to 'C' if ksh is compiled with vmalloc enabled.