### PR TITLE
Shorten command name used to test ENAMETOOLONG exit status

### DIFF
--- a/src/cmd/ksh93/tests/path.sh
+++ b/src/cmd/ksh93/tests/path.sh
@@ -879,7 +879,7 @@ got=$?
 	"(expected $exp, got $got)"
 
 # Tests for attempting to use a command name that's too long.
-name_max=$(getconf NAME_MAX $PWD)
+name_max=$(builtin getconf 2>/dev/null; getconf NAME_MAX . 2>/dev/null || echo 255)
 long_cmd="$(awk -v ORS= 'BEGIN { for(i=0;i<'$name_max';i++) print "xx"; }')"
 exp=127
 PATH=$PWD $SHELL -c "$long_cmd" > /dev/null 2>&1

--- a/src/cmd/ksh93/tests/path.sh
+++ b/src/cmd/ksh93/tests/path.sh
@@ -879,7 +879,8 @@ got=$?
 	"(expected $exp, got $got)"
 
 # Tests for attempting to use a command name that's too long.
-long_cmd=$(awk -v ORS= 'BEGIN { for(i=0;i<500;i++) print "xxxxxxxxxx"; }')
+name_max=$(getconf NAME_MAX $PWD)
+long_cmd="$(awk -v ORS= 'BEGIN { for(i=0;i<'$name_max';i++) print "xx"; }')"
 exp=127
 PATH=$PWD $SHELL -c "$long_cmd" > /dev/null 2>&1
 got=$?


### PR DESCRIPTION
A change in FreeBSD 13 now causes extremely long command names to exit with `errno` set to `E2BIG` if the command name can't fit in the list of arguments. This was causing the regression tests for `ENAMETOOLONG` to fail on FreeBSD 13 because the exit status for these errors differ (`ENAMETOOLONG` uses exit status 127 while `E2BIG` uses exit status 126). To fix the failing regression tests, the command name has been shortened to twice the length of `NAME_MAX`. This length is still long enough to trigger an `ENAMETOOLONG` error without causing an `E2BIG` failure on FreeBSD 13.

Fixes #331