### PR TITLE
Fix file descriptor leaks in the `hist` builtin

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,6 +9,9 @@ Any uppercase BUG_* names are modernish shell bug IDs.
   special floating point constants Inf and NaN so that $((inf)) and $((nan))
   refer to the variables by those names as the standard requires. (BUG_ARITHNAN)
 
+- Fixed two file descriptor leaks in the hist builtin that occurred when
+  the -s flag ran a command or encountered an error.
+
 2021-11-14:
 
 - Fixed: ksh crashed after unsetting .sh.match and then matching a pattern.

--- a/src/cmd/ksh93/bltins/hist.c
+++ b/src/cmd/ksh93/bltins/hist.c
@@ -264,18 +264,22 @@ int	b_hist(int argc,char *argv[], Shbltin_t *context)
 	sh_onstate(SH_HISTORY);
 	sh_onstate(SH_VERBOSE);	/* echo lines as read */
 	if(replace)
+	{
 		hist_subst(error_info.id,fdo,replace);
+		sh_close(fdo);
+	}
 	else if(error_info.errors == 0)
 	{
-		char buff[IOBSIZE+1];
-		Sfio_t *iop = sfnew(NIL(Sfio_t*),buff,IOBSIZE,fdo,SF_READ);
 		/* read in and run the command */
 		if(shp->hist_depth++ > HIST_RECURSE)
 		{
+			sh_close(fdo);
 			errormsg(SH_DICT,ERROR_exit(1),e_toodeep,"history");
 			UNREACHABLE();
 		}
-		sh_eval(iop,1);
+		char buff[IOBSIZE+1];
+		Sfio_t *iop = sfnew(NIL(Sfio_t*),buff,IOBSIZE,fdo,SF_READ);
+		sh_eval(iop,1); /* this will close fdo */
 		shp->hist_depth--;
 	}
 	else
@@ -313,6 +317,7 @@ static void hist_subst(const char *command,int fd,char *replace)
 	*newp++ =  0;
 	if((sp=sh_substitute(string,replace,newp))==0)
 	{
+		sh_close(fd);
 		errormsg(SH_DICT,ERROR_exit(1),e_subst,command);
 		UNREACHABLE();
 	}

--- a/src/cmd/ksh93/bltins/hist.c
+++ b/src/cmd/ksh93/bltins/hist.c
@@ -270,6 +270,8 @@ int	b_hist(int argc,char *argv[], Shbltin_t *context)
 	}
 	else if(error_info.errors == 0)
 	{
+		char buff[IOBSIZE+1];
+		Sfio_t *iop;
 		/* read in and run the command */
 		if(shp->hist_depth++ > HIST_RECURSE)
 		{
@@ -277,8 +279,7 @@ int	b_hist(int argc,char *argv[], Shbltin_t *context)
 			errormsg(SH_DICT,ERROR_exit(1),e_toodeep,"history");
 			UNREACHABLE();
 		}
-		char buff[IOBSIZE+1];
-		Sfio_t *iop = sfnew(NIL(Sfio_t*),buff,IOBSIZE,fdo,SF_READ);
+		iop = sfnew(NIL(Sfio_t*),buff,IOBSIZE,fdo,SF_READ);
 		sh_eval(iop,1); /* this will close fdo */
 		shp->hist_depth--;
 	}


### PR DESCRIPTION
This commit fixes two file descriptor leaks in the `hist` builtin. The bugfix for the first file descriptor leak was backported from ksh2020 (see https://github.com/att/ast/issues/872 and https://github.com/att/ast/commit/73bd61b5). Reproducer:
```
$ ls /proc/$$/fd
0  1  2  3
$ echo no
no
$ hist -s no=yes
echo yes
yes
$ ls /proc/$$/fd
0  1  2  3 4
```

The second file descriptor leak occurs after a substitution error in the `hist` builtin (this leak wasn't fixed in ksh2020). Reproducer:
```
$ echo no
no
$ ls /proc/$$/fd
0  1  10  11  2
$ hist -s no=yes
ksh: hist: hist: bad substitution
$ hist -s no=yes
ksh: hist: hist: bad substitution
$ ls /proc/$$/fd
0  1  10  11  2  3  4
```

src/cmd/ksh93/bltins/hist.c:
\- Close leftover file descriptors when an error occurs and after `hist -s` runs a command.

src/cmd/ksh93/tests/builtins.sh:
\- Add two regression tests for both of the file descriptor leaks.