### PR TITLE
arithmetic: Fix the octal leading zero mess

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,19 @@ For full details, see the git log at: https://github.com/ksh93/ksh
 
 Any uppercase BUG_* names are modernish shell bug IDs.
 
+2021-11-16:
+
+- By default, arithmetic expressions in ksh no longer interpret a number
+  with a leading zero as octal in any context. Use 8#octalnumber instead.
+  Before, ksh would arbitrarily recognize the leading octal zero in some
+  contexts but not others, e.g., both of:
+	$ x=010; echo "$((x)), $(($x))"
+	$ set -o letoctal; x=010; let y=$x z=010; echo "$y, $z"
+  would output '10, 8'. These now output '10, 10' and '8, 8', respectively.
+  Arithmetic expressions now also behave identically within and outside
+  ((...)) and $((...)). Setting the --posix compliance option turns on the
+  recognition of the leading octal zero for all arithmetic contexts.
+
 2021-11-15:
 
 - In arithmetic evaluation, the --posix compliance option now disables the
@@ -41,11 +54,6 @@ Any uppercase BUG_* names are modernish shell bug IDs.
   echo/print/printf to /dev/full now always yields a non-zero exit status.
 
 2021-09-13:
-
-- Fixed a bug introduced in 93u+ 2012-02-07 that caused the 'printf' builtin
-  (and its 'print -f' equivalent) to fail to recognise integer arguments with a
-  leading zero as octal numbers. For example, 'printf "%d\n" 010' now once
-  again outputs '8' instead of '10'.
 
 - Disable the POSIX arithmetic context while running a command substitution
   invoked from within an arithmetic expression. This fixes a bug that caused

--- a/src/cmd/ksh93/COMPATIBILITY
+++ b/src/cmd/ksh93/COMPATIBILITY
@@ -151,10 +151,15 @@ For more details, see the NEWS file and for complete details, see the git log.
 	correctly negates another '!', e.g., [[ ! ! 1 -eq 1 ]] now returns
 	0/true. Note that this has always been the case for 'test'/'['.
 
-28.	In the 'printf' builtin (and the 'print -f' equivalent), numeric
-	arguments with a leading zero are now once again recognized as octal
-	numbers as in ksh93 versions before 2012-02-07, and as POSIX requires.
-	For example, 'printf "%d\n" 010' now once again outputs '8'.
+28.	By default, arithmetic expressions in ksh no longer interpret a number
+	with a leading zero as octal in any context. Use 8#octalnumber instead.
+	Before, ksh would arbitrarily recognize the leading octal zero in some
+	contexts but not others. One of several examples is:
+		x=010; echo "$((x)), $(($x))"
+	would output '10, 8'. This now outputs '10, 10'. Arithmetic
+	expressions now also behave identically within and outside ((...))
+	and $((...)). Setting the --posix compliance option turns on the
+	recognition of the leading octal zero for all arithmetic contexts.
 
 ____________________________________________________________________________
 

--- a/src/cmd/ksh93/bltins/print.c
+++ b/src/cmd/ksh93/bltins/print.c
@@ -884,9 +884,7 @@ static int extend(Sfio_t* sp, void* v, Sffmt_t* fe)
 				}
 				break;
 			default:
-				shp->inarith = 1;	/* POSIX compliance: recognize octal constants, e.g. printf '%d\n' 010 */
 				d = sh_strnum(argp,&lastchar,0);
-				shp->inarith = 0;
 				if(d<longmin)
 				{
 					errormsg(SH_DICT,ERROR_warn(0),e_overflow,argp);

--- a/src/cmd/ksh93/include/argnod.h
+++ b/src/cmd/ksh93/include/argnod.h
@@ -125,7 +125,6 @@ struct argnod
 #define ARG_ARITH	0x100	/* arithmetic expansion */
 #define ARG_OPTIMIZE	0x200	/* try to optimize */
 #define ARG_NOGLOB	0x400	/* no file name expansion */
-#define ARG_LET		0x800	/* processing let command arguments */
 #define ARG_ARRAYOK	0x1000	/* $x[sub] ==> ${x[sub]} */
 
 extern struct dolnod	*sh_argcreate(char*[]);

--- a/src/cmd/ksh93/include/defs.h
+++ b/src/cmd/ksh93/include/defs.h
@@ -204,7 +204,6 @@ struct shared
 	char		used_pos;	/* used positional parameter */\
 	char		universe; \
 	char		winch; \
-	char		inarith; 	/* set when in POSIX arith context, i.e. leading zero = octal, e.g. in ((...)) */ \
 	short		arithrecursion;	/* current arithmetic recursion level */ \
 	char		indebug; 	/* set when in debug trap */ \
 	unsigned char	ignsig;		/* ignored signal in subshell */ \

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -21,7 +21,7 @@
 
 #define SH_RELEASE_FORK	"93u+m"		/* only change if you develop a new ksh93 fork */
 #define SH_RELEASE_SVER	"1.1.0-alpha"	/* semantic version number: https://semver.org */
-#define SH_RELEASE_DATE	"2021-11-15"	/* must be in this format for $((.sh.version)) */
+#define SH_RELEASE_DATE	"2021-11-16"	/* must be in this format for $((.sh.version)) */
 #define SH_RELEASE_CPYR	"(c) 2020-2021 Contributors to ksh " SH_RELEASE_FORK
 
 /* Scripts sometimes field-split ${.sh.version}, so don't change amount of whitespace. */

--- a/src/cmd/ksh93/sh.1
+++ b/src/cmd/ksh93/sh.1
@@ -332,7 +332,7 @@ The arithmetic expression
 .I expr1
 is evaluated first
 (see
-.I "Arithmetic evaluation"
+.I "Arithmetic Evaluation"
 below).
 The arithmetic expression
 .I expr2
@@ -1029,7 +1029,7 @@ for an indexed array is denoted by
 an
 .I arithmetic expression\^
 (see
-.I "Arithmetic evaluation"
+.I "Arithmetic Evaluation"
 below)
 between a
 .B [
@@ -1693,7 +1693,7 @@ is assigned a new value.
 .B .sh.math
 Used for defining arithmetic functions
 (see
-.I "Arithmetic evaluation"
+.I "Arithmetic Evaluation"
 below)
 and stores the list of user defined arithmetic functions.
 .TP
@@ -6447,7 +6447,7 @@ is a separate
 .I "arithmetic expression"
 to be evaluated.
 .B let
-only recognizes octal constants starting with
+only recognizes octal numbers starting with
 .B 0
 when the
 .B set
@@ -6456,7 +6456,7 @@ option
 is on.
 See
 .I "Arithmetic Evaluation"
-above, for a description of arithmetic expression evaluation.
+above for a description of arithmetic expression evaluation.
 .sp .5
 The exit status is
 0 if the value of the last expression
@@ -7174,7 +7174,7 @@ Same as
 .B letoctal
 The
 .B let
-command allows octal constants starting with
+command allows octal numbers starting with
 .BR 0 .
 On by default if ksh is invoked as \fBsh\fR or \fBrsh\fR.
 .TP 8
@@ -7249,6 +7249,10 @@ if no file descriptor number precedes it;
 disables the special floating point constants \fBInf\fR and \fBNaN\fR in
 arithmetic evaluation so that, e.g., \fB$((inf))\fR and \fB$((nan))\fR refer
 to the variables by those names;
+.IP \[bu]
+enables the recognition of a leading zero as introducing an octal number in
+all arithmetic evaluation contexts, except in the \fBlet\fR built-in while
+\fBletoctal\fR is off;
 .IP \[bu]
 changes the \fBtest\fR/\fB[\fR built-in command to make its deprecated
 \fIexpr1\fR \fB-a\fR \fIexpr2\fR and \fIexpr1\fR \fB-o\fR \fIexpr2\fR operators

--- a/src/cmd/ksh93/sh/args.c
+++ b/src/cmd/ksh93/sh/args.c
@@ -664,8 +664,6 @@ char **sh_argbuild(Shell_t *shp,int *nargs, const struct comnod *comptr,int flag
 		*nargs = 0;
 		if(ac)
 		{
-			if(ac->comnamp == SYSLET)
-				flag |= ARG_LET;
 			argp = ac->comarg;
 			while(argp)
 			{

--- a/src/cmd/ksh93/sh/name.c
+++ b/src/cmd/ksh93/sh/name.c
@@ -2954,14 +2954,7 @@ Sfdouble_t nv_getnum(register Namval_t *np)
 		}
 	}
 	else if((str=nv_getval(np)) && *str!=0)
-	{
-		if(nv_isattr(np,NV_LJUST|NV_RJUST) || (*str=='0' && !(str[1]=='x'||str[1]=='X')))
-		{
-			while(*str=='0')
-				str++;
-		}
 		r = sh_arith(shp,str);
-	}
 	return(r);
 }
 

--- a/src/cmd/ksh93/sh/nvdisc.c
+++ b/src/cmd/ksh93/sh/nvdisc.c
@@ -105,14 +105,7 @@ Sfdouble_t nv_getn(Namval_t *np, register Namfun_t *nfp)
 		else
 			str = nv_getv(np,fp?fp:nfp);
 		if(str && *str)
-		{
-			if(nv_isattr(np,NV_LJUST|NV_RJUST) || (*str=='0' && !(str[1]=='x'||str[1]=='X')))
-			{
-				while(*str=='0')
-					str++;
-			}
 			d = sh_arith(shp,str);
-		}
 	}
 	return(d);
 }

--- a/src/cmd/ksh93/sh/subshell.c
+++ b/src/cmd/ksh93/sh/subshell.c
@@ -470,7 +470,6 @@ Sfio_t *sh_subshell(Shell_t *shp,Shnode_t *t, volatile int flags, int comsub)
 	struct rand *rp;		/* current $RANDOM discipline function data */
 	unsigned int save_rand_seed;	/* parent shell $RANDOM seed */
 	int save_rand_last;		/* last random number from $RANDOM in parent shell */
-	char save_inarith;		/* flag indicating POSIX arithmetic context */
 	memset((char*)sp, 0, sizeof(*sp));
 	sfsync(shp->outpool);
 	sh_sigcheck(shp);
@@ -592,9 +591,6 @@ Sfio_t *sh_subshell(Shell_t *shp,Shnode_t *t, volatile int flags, int comsub)
 	{
 		if(comsub)
 		{
-			/* a comsub within an arithmetic expression must not itself be in an arithmetic context */
-			save_inarith = shp->inarith;
-			shp->inarith = 0;
 			/* disable job control */
 			shp->spid = 0;
 			sp->jobcontrol = job.jobcontrol;
@@ -738,8 +734,6 @@ Sfio_t *sh_subshell(Shell_t *shp,Shnode_t *t, volatile int flags, int comsub)
 			sh_close(sp->tmpfd);
 		}
 		shp->fdstatus[1] = sp->fdstatus;
-		/* restore POSIX arithmetic context flag */
-		shp->inarith = save_inarith;
 	}
 	if(!shp->subshare)
 	{


### PR DESCRIPTION
In C/POSIX arithmetic, a leading 0 denotes an octal number, e.g.
010 == 8. But this is not a desirable feature as it can cause
problems with processing things like dates with a leading zero.
In ksh, you should use 8#10 instead ("10" with base 8).

It would be tolerable if ksh at least implemented it consistently.
But AT&T made an incredible mess of it. For anyone who is not
intimately familiar with ksh internals, it is inscrutable where
arithmetic evaluation special-cases a leading 0 and where it
doesn't. Here are just some of the surprises/inconsistencies:

1. The AT&T maintainers tried to honour a leading 0 inside of
   ((...)) and $((...)) and not for arithmetic contexts outside it,
   but even that inconsistency was never quite consistent.

2. Since 2010-12-12, $((x)) and $(($x)) are different:
      $ /bin/ksh -c 'x=010; echo $((x)) $(($x))'
      10 8
   That's a clear violation of both POSIX and the principle of
   least astonishment. $((x)) and $(($x)) should be the same in
   all cases.

3. 'let' with '-o letoctal' acts in this bizarre way:
      $ set -o letoctal; x=010; let "y1=$x" "y2=010"; echo $y1 $y2
      10 8
   That's right, 'let y=$x' is different from 'let y=010' even
   when $x contains the same string value '010'! This violates
   established shell grammar on the most basic level.

This commit introduces consistency. By default, ksh now acts like
mksh and zsh: the octal leading zero is disabled in all arithmetic
contexts equally. In POSIX mode, it is enabled equally.

The one exception is the 'let' built-in, where this can still be
controlled independently with the letoctal option as before (but,
because letoctal is synched with posix when switching that on/off,
it's consistent by default).

We're also removing the hackery that causes variable expansions for
the 'let' builtin to be quietly altered, so that 'x=010; let y=$x'
now does the same as 'let y=010' even with letoctal on.

Various files:
- Get rid of now-redundant sh.inarith (shp->inarith) flag, as we're
  no longer distinguishing between being inside or outside ((...)).

src/cmd/ksh93/sh/arith.c:
- arith(): Let disabling POSIX octal constants by skipping leading
  zeros depend on either the letoctal option being off (if we're
  running the "let" built-in") or the posix option being off.
- sh_strnum(): Preset a base of 10 for strtonll(3) depending on the
  posix or letoctal option being off, not on the sh.inarith flag.

src/cmd/ksh93/include/argnod.h,
src/cmd/ksh93/sh/args.c,
src/cmd/ksh93/sh/macro.c:
- Remove astonishing hackery that violated shell grammar for 'let'.

src/cmd/ksh93/sh/name.c (nv_getnum()),
src/cmd/ksh93/sh/nvdisc.c (nv_getn()):
- Remove loops for skipping leading zeroes that included a broken
  check for justify/zerofill attributes, thereby fixing this bug:
	$ typeset -Z x=0x15; echo $((x))
	-ksh: x15: parameter not set
  Even if this code wasn't redundant before, it is now: sh_arith()
  is called immediately after the removed code and it ignores
  leading zeroes via sh_strnum() and strtonll(3).

Resolves: https://github.com/ksh93/ksh/issues/334