### PR TITLE
`typeset -T` shouldn't list types created with `enum`

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,11 @@ For full details, see the git log at: https://github.com/ksh93/ksh
 
 Any uppercase BUG_* names are modernish shell bug IDs.
 
+2021-11-20:
+
+- Listing types with 'typeset -T' no longer displays incomplete versions of
+  types created by the enum built-in.
+
 2021-11-18:
 
 - The printf built-in command now supports a -v option as on bash and zsh.

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -21,7 +21,7 @@
 
 #define SH_RELEASE_FORK	"93u+m"		/* only change if you develop a new ksh93 fork */
 #define SH_RELEASE_SVER	"1.1.0-alpha"	/* semantic version number: https://semver.org */
-#define SH_RELEASE_DATE	"2021-11-18"	/* must be in this format for $((.sh.version)) */
+#define SH_RELEASE_DATE	"2021-11-20"	/* must be in this format for $((.sh.version)) */
 #define SH_RELEASE_CPYR	"(c) 2020-2021 Contributors to ksh " SH_RELEASE_FORK
 
 /* Scripts sometimes field-split ${.sh.version}, so don't change amount of whitespace. */

--- a/src/cmd/ksh93/sh/nvtype.c
+++ b/src/cmd/ksh93/sh/nvtype.c
@@ -1580,13 +1580,16 @@ int	sh_outtype(Shell_t *shp,Sfio_t *out)
 	if(indent==0)
 	for(tp = (Namval_t*)dtfirst(dp); tp; tp = (Namval_t*)dtnext(dp,tp))
 	{
+		/* skip over enums */
+		if(tp->nvfun && !nv_isvtree(tp))
+			continue;
 		if(!nv_search(tp->nvname,shp->bltin_tree,0))
 			continue;
 		sfprintf(out,"typeset -T %s\n",tp->nvname);
 	}
 	for(tp = (Namval_t*)dtfirst(dp); tp; tp = (Namval_t*)dtnext(dp,tp))
 	{
-		if(nv_isnull(tp))
+		if(nv_isnull(tp) || !nv_isvtree(tp))
 			continue;
 		if(indent && (memcmp(tp->nvname,shp->prefix,n-1) || tp->nvname[n-1]!='.' || strchr(tp->nvname+n,'.')))
 			continue;

--- a/src/cmd/ksh93/tests/types.sh
+++ b/src/cmd/ksh93/tests/types.sh
@@ -634,4 +634,10 @@ bar.foo+=(bam)
 "$SHELL" -c 'typeset -T al=(typeset bar); al foo=(bar=testset)' || err_exit "type names that start with 'a' don't work"
 
 # ======
+# 'typeset -T' shouldn't list types created by enum
+got=$($SHELL -c 'enum Foo_t=(foo bar); typeset -T')
+[[ -z $got ]] || err_exit "Types created by enum are listed with 'typeset -T'" \
+	"(got $(printf %q "$got"))"
+
+# ======
 exit $((Errors<125?Errors:125))


### PR DESCRIPTION
Listing types with `typeset -T` will list not only types created with `typeset`, but also types created with `enum`. However, the types created by `enum` are not displayed correctly in the resulting output:

```sh
$ enum Foo_t=(foo bar)
$ typeset -T
typeset -T Foo_t
typeset -T Foo_t=fo)
```

The fix for this bug was backported from ksh93v- 2013-10-08.

src/cmd/ksh93/sh/nvtype.c:
\- `sh_outtype()`: Skip over enums when listing types with `typeset -T`. This prevents types created by `enum` from appearing in the output of `typeset -T`.

I'll note that ksh93v- also added `enum -p` for the purpose of listing enum types. It hasn't been added to this pull request since that is not a bugfix, and the feature addition itself is buggy:
```sh
# This reproducer causes ksh93v- to freeze
$ typeset -T Bar_t=(typeset bar; typeset baz)
$ enum -p
```