### PR TITLE
The `time` keyword shouldn't override `errexit`

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,11 @@ For full details, see the git log at: https://github.com/ksh93/ksh
 
 Any uppercase BUG_* names are modernish shell bug IDs.
 
+2021-11-27:
+
+- A bug that caused the time keyword to override the errexit shell option has
+  been fixed.
+
 2021-11-24:
 
 - The --posix mode was amended to stop the '.' command (but not 'source') from

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -21,7 +21,7 @@
 
 #define SH_RELEASE_FORK	"93u+m"		/* only change if you develop a new ksh93 fork */
 #define SH_RELEASE_SVER	"1.1.0-alpha"	/* semantic version number: https://semver.org */
-#define SH_RELEASE_DATE	"2021-11-24"	/* must be in this format for $((.sh.version)) */
+#define SH_RELEASE_DATE	"2021-11-27"	/* must be in this format for $((.sh.version)) */
 #define SH_RELEASE_CPYR	"(c) 2020-2021 Contributors to ksh " SH_RELEASE_FORK
 
 /* Scripts sometimes field-split ${.sh.version}, so don't change amount of whitespace. */

--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -2404,7 +2404,7 @@ int sh_exec(register const Shnode_t *t, int flags)
 #endif
 				job.waitall = 1;
 				sh_onstate(SH_TIMING);
-				sh_exec(t->par.partre,OPTIMIZE);
+				sh_exec(t->par.partre,sh_isstate(SH_ERREXIT)|OPTIMIZE);
 				if(!timer_on)
 					sh_offstate(SH_TIMING);
 				job.waitall = 0;

--- a/src/cmd/ksh93/tests/basic.sh
+++ b/src/cmd/ksh93/tests/basic.sh
@@ -601,6 +601,20 @@ eu=$(
 )
 [[ ${us:1:1} == ${eu:1:1} ]] && err_exit "The time keyword ignores the locale's radix point (both are ${eu:1:1})"
 
+# The time keyword should obey the errexit option
+# https://www.illumos.org/issues/7694
+time_errexit="$tmp/time_errexit.sh"
+cat > "$time_errexit" << 'EOF'
+time false
+echo FAILURE
+true
+EOF
+got=$($SHELL -e "$time_errexit" 2>&1)
+(( $? == 0 )) && err_exit "The time keyword ignores the errexit option" \
+	"(got $(printf %q "$got"))"
+[[ -z $got ]] || err_exit "The time keyword produces output when a timed command fails and the errexit option is on" \
+	"(got $(printf %q "$got"))"
+
 # ======
 # Expansion of multibyte characters after expansion of single-character names $1..$9, $?, $!, $-, etc.
 case ${LC_ALL:-${LC_CTYPE:-${LANG:-}}} in


### PR DESCRIPTION
This bug was first reported in <https://www.illumos.org/issues/7694>. The `time` keyword currently overrides the `errexit` shell option, allowing failing scripts to continue after an error:

```sh
$ cat 1.sh
#!/bin/sh
time false   # This should cause the script to exit
echo FAILURE
true
$ arch/*/bin/ksh -o errexit 1.sh

real    0m0.00s
user    0m0.00s
sys     0m0.00s
FAILURE
```

src/cmd/ksh93/sh/xec.c:
\- When the `time` keyword runs a command, pass the `errexit` state flag to the `sh_exec` call. This state flag is required for ksh to exit when a command fails while the `errexit` option is on.

src/cmd/ksh93/tests/basic.sh:
\- Add a regression test based on the reproducer from the bug report.