### PR TITLE
Fix memory fault on ARM-based Macs

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,10 @@ For full details, see the git log at: https://github.com/ksh93/ksh
 
 Any uppercase BUG_* names are modernish shell bug IDs.
 
+2021-11-28:
+
+- Fixed a memory fault that prevented ksh from functioning on ARM-based Macs.
+
 2021-11-24:
 
 - The --posix mode was amended to stop the '.' command (but not 'source') from

--- a/src/cmd/ksh93/README
+++ b/src/cmd/ksh93/README
@@ -262,6 +262,7 @@ failures (crashes, and/or important functionality does not work).
 *	illumos: OmniOS 2020-08-19 (gcc) on x86_64
 	macOS 10.13.6 (High Sierra) on x86_64
 	macOS 10.14.6 (Mojave) on x86_64
+*	macOS 12.0.1 (Monterey) on ARM64
 *	NetBSD 8.1 on x86_64
 *	NetBSD 9.2 on x86_64
 *	OpenBSD 6.8 on x86_64

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -21,7 +21,7 @@
 
 #define SH_RELEASE_FORK	"93u+m"		/* only change if you develop a new ksh93 fork */
 #define SH_RELEASE_SVER	"1.1.0-alpha"	/* semantic version number: https://semver.org */
-#define SH_RELEASE_DATE	"2021-11-24"	/* must be in this format for $((.sh.version)) */
+#define SH_RELEASE_DATE	"2021-11-28"	/* must be in this format for $((.sh.version)) */
 #define SH_RELEASE_CPYR	"(c) 2020-2021 Contributors to ksh " SH_RELEASE_FORK
 
 /* Scripts sometimes field-split ${.sh.version}, so don't change amount of whitespace. */

--- a/src/lib/libast/comp/omitted.c
+++ b/src/lib/libast/comp/omitted.c
@@ -1092,9 +1092,7 @@ utime(const char* path, const struct utimbuf* ut)
  * own bsd-like macros
  */
 
-#if !_lib_bzero || defined(bzero)
-
-#undef	bzero
+#if !_lib_bzero
 
 void
 bzero(void* b, size_t n)


### PR DESCRIPTION
Ksh segfaults on M1 Macs because libast ships a broken implementation of `bzero` on macOS, overriding the default `bzero` implementation. Apple has disabled libast's `bzero` function since 2018-12-04[*], which indicates other problems involving it have popped up on macOS before. This commit applies Apple's patch to fix the segfault on aarch64.

src/lib/libast/comp/omitted.c:
\- Only fallback to the libast `bzero` function if the OS lacks an implementation of `bzero`.
\- Remove the `bzero` undef since this fallback is only reached if the OS doesn't have `bzero`.

[*]: https://opensource.apple.com/source/ksh/ksh-27/patches/src__lib__libast__comp__omitted.c.diff.auto.html

Fixes #329