### PR TITLE
nvdisc.c: Fix crash after an error or signal in discipline function

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,12 @@ For full details, see the git log at: https://github.com/ksh93/ksh
 
 Any uppercase BUG_* names are modernish shell bug IDs.
 
+2021-12-01:
+
+- Fixed a memory fault that occurred when a discipline function exited
+  with an error from a special builtin or when a discipline function exited
+  because of a signal.
+
 2021-11-29:
 
 - Fixed a memory fault that prevented ksh from functioning on ARM-based Macs.

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -21,7 +21,7 @@
 
 #define SH_RELEASE_FORK	"93u+m"		/* only change if you develop a new ksh93 fork */
 #define SH_RELEASE_SVER	"1.1.0-alpha"	/* semantic version number: https://semver.org */
-#define SH_RELEASE_DATE	"2021-11-29"	/* must be in this format for $((.sh.version)) */
+#define SH_RELEASE_DATE	"2021-12-01"	/* must be in this format for $((.sh.version)) */
 #define SH_RELEASE_CPYR	"(c) 2020-2021 Contributors to ksh " SH_RELEASE_FORK
 
 /* Scripts sometimes field-split ${.sh.version}, so don't change amount of whitespace. */


### PR DESCRIPTION
This patch fixes the crashes experienced when a discipline function (such as `.sh.tilde.set()` or `PS2.get()`) exits because of a signal or an error from a special builtin. The crashes were caused by ksh entering an inconsistent state after performing a `longjmp` away from the `assign()` and `lookup()` functions in nvdisc.c. Fixing the crash requires entering a new context, then setting a nonlocal goto with `sigsetjmp`. Any longjmps that happen while running the discipline function will go back to `assign`/`lookup`, allowing ksh to do a proper cleanup afterwards.

I haven't added the regression test for this bug to pty.sh. The test I made does work when ran with the bugfix applied to ksh, but it causes CPU-hungry hangups in unpatched versions of ksh. I couldn't create a good workaround for the hangups, but I'll leave the test here in case anyone manages to fix it:
```diff
--- a/src/cmd/ksh93/tests/pty.sh
+++ b/src/cmd/ksh93/tests/pty.sh
@@ -907,5 +907,26 @@ w true); echo "Exit status is $?"
 u Exit status is 0
 !
 
+# err_exit #
+tst $LINENO << "!"
+L crash when discipline functions exit with an error
+# https://github.com/ksh93/ksh/issues/346
+
+w PS1.get() {; printf '$ '; trap --invalid-flag 2>/dev/null; }
+w PS2.get() {; printf '> '; trap --invalid-flag 2>/dev/null; }
+w .sh.tilde.set() {
+w case ${.sh.value} in
+w '~ret') .sh.value='Exit status is' ;;
+w esac
+w trap --invalid-flag 2>/dev/null
+w }
+w echo ~
+w echo ~ret
+s 50
+w echo ~
+w echo ~ret $?
+u Exit status is 0
+!
+
 # ======
 exit $((Errors<125?Errors:125))
```

Resolves: https://github.com/ksh93/ksh/issues/346