### PR TITLE
Port over illumos fixes for conf.sh

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,11 @@ For full details, see the git log at: https://github.com/ksh93/ksh
 
 Any uppercase BUG_* names are modernish shell bug IDs.
 
+2021-12-05:
+
+- Fixed an issue on illumos that caused some parameters in the getconf
+  builtin to fail.
+
 2021-12-01:
 
 - Fixed a memory fault that occurred when a discipline function exited

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -21,7 +21,7 @@
 
 #define SH_RELEASE_FORK	"93u+m"		/* only change if you develop a new ksh93 fork */
 #define SH_RELEASE_SVER	"1.1.0-alpha"	/* semantic version number: https://semver.org */
-#define SH_RELEASE_DATE	"2021-12-01"	/* must be in this format for $((.sh.version)) */
+#define SH_RELEASE_DATE	"2021-12-05"	/* must be in this format for $((.sh.version)) */
 #define SH_RELEASE_CPYR	"(c) 2020-2021 Contributors to ksh " SH_RELEASE_FORK
 
 /* Scripts sometimes field-split ${.sh.version}, so don't change amount of whitespace. */

--- a/src/lib/libast/comp/conf.sh
+++ b/src/lib/libast/comp/conf.sh
@@ -243,7 +243,7 @@ case $append$extra in
 						;;
 					*" -$f- "*)
 						;;
-					*)	if	iffe -n - hdr $f | grep _hdr_$f >/dev/null
+					*)	if	iffe -c "$cc" -n - hdr $f | grep _hdr_$f >/dev/null
 						then	hdr="$hdr $f"
 							headers=$headers$nl#include$sp'<'$1'>'
 						else	hdr="$hdr -$f-"
@@ -382,8 +382,8 @@ sort -u > $tmp.f
 {
 sed \
 	-e 's/[^ABCDEFGHIJKLMNOPQRSTUVWXYZ_0123456789]/ /g' \
-	-e 's/[ 	][ 	]*/\n/g' \
-	`cat $tmp.f` 2>/dev/null |
+	-e 's/[ 	][ 	]*/%/g' \
+	`cat $tmp.f` 2>/dev/null | tr '%' '\n' | \
 	egrep '^(SI|_(CS|PC|SC|SI))_.'
 	case $CONF_getconf_a in
 	?*)	$CONF_getconf $CONF_getconf_a | sed 's,[=:    ].*,,'


### PR DESCRIPTION
This pull request ports over two of Andy Fiddaman's bugfixes to conf.sh on illumos:

\- The compiler isn't passed on to an invocation of iffe. The bugfix is from this commit: <https://github.com/citrus-it/ast/commit/63563232>

\- The getconf builtin is missing several parameters on illumos. Reproducer:
```sh
$ /opt/ast/bin/getconf ADDRESS_WIDTH
getconf: Invalid argument (ADDRESS_WIDTH)  # Should output '64'
```
This bug occurs because `conf.sh` expects GNU `sed` and fails to work properly with other `sed` implementations. The bugfix and original bug report can be found here:
https://www.illumos.org/issues/14044
https://github.com/citrus-it/ast/commit/ba443cfd