### PR TITLE
Fix various compiler warnings and minor issues

### DIFF
--- a/docs/ksh/builtins.html
+++ b/docs/ksh/builtins.html
@@ -458,7 +458,7 @@ while(1) switch(n=optget(argv,"xf:&#0091;file&#0093;"))
 		break;
 	case '?':
 		error(ERROR_usage(2), opt_info.arg);
-		break;
+		UNREACHABLE();
 }
 </DIV>
 </PRE>

--- a/src/cmd/INIT/ratz.c
+++ b/src/cmd/INIT/ratz.c
@@ -812,10 +812,6 @@ void   zcfree  OF((voidpf opaque, voidpf ptr));
 #ifndef _ZUTIL_C
 #define _ZUTIL_C
 
-#if 0 && !_PACKAGE_ast && !defined(STDC)
-extern void exit OF((int));
-#endif
-
 #ifndef HAVE_MEMCPY
 
 void zmemcpy(dest, source, len)
@@ -962,14 +958,6 @@ void  zcfree (voidpf opaque, voidpf ptr)
 
 
 #ifndef MY_ZCALLOC /* Any system without a special alloc function */
-
-#if 0 && !_PACKAGE_ast
-#ifndef STDC
-extern voidp  malloc OF((uInt size));
-extern voidp  calloc OF((uInt items, uInt size));
-extern void   free   OF((voidpf ptr));
-#endif
-#endif
 
 voidpf zcalloc (opaque, items, size)
     voidpf opaque;
@@ -3624,13 +3612,6 @@ typedef voidp gzFile;
 #ifdef __MVS__
 #  pragma map (fdopen , "\174\174FDOPEN")
    FILE *fdopen(int, const char *);
-#endif
-
-#if 0 && !_PACKAGE_ast
-#ifndef STDC
-extern voidp  malloc OF((uInt size));
-extern void   free   OF((voidpf ptr));
-#endif
 #endif
 
 #define ALLOC(size) malloc(size)

--- a/src/cmd/ksh93/Mamfile
+++ b/src/cmd/ksh93/Mamfile
@@ -53,8 +53,8 @@ make install
 					exec - esac
 					exec - continue
 					exec - elif test ! -f ${INSTALLROOT}/lib/lib$i.a
-					exec - then case `{ ${CC} ${mam_cc_FLAGS} ${KSH_RELFLAGS} ${KSH_SHOPTFLAGS} ${CCFLAGS} -L${INSTALLROOT}/lib ${LDFLAGS} -o 1.${COTEMP}.x 1.${COTEMP}.o -l$i 2>&1 || echo '' $x ;} | sed -e 's/[][()+@?]/#/g' || :` in
-					exec - *$x*) case `{ ${CC} ${mam_cc_FLAGS} ${KSH_RELFLAGS} ${KSH_SHOPTFLAGS} ${CCFLAGS} ${LDFLAGS} -o 1.${COTEMP}.x 1.${COTEMP}.o -l$i 2>&1 || echo '' $x ;} | sed -e 's/[][()+@?]/#/g' || :` in
+					exec - then case `{ ${CC} ${mam_cc_FLAGS} ${KSH_RELFLAGS} ${KSH_SHOPTFLAGS} ${CCFLAGS} -L${INSTALLROOT}/lib ${LDFLAGS} -o 1.${COTEMP}.x 1.${COTEMP}.o -l$i 2>&1 || echo '' "$x" ;} | sed -e 's/[][()+@?]/#/g' || :` in
+					exec - *$x*) case `{ ${CC} ${mam_cc_FLAGS} ${KSH_RELFLAGS} ${KSH_SHOPTFLAGS} ${CCFLAGS} ${LDFLAGS} -o 1.${COTEMP}.x 1.${COTEMP}.o -l$i 2>&1 || echo '' "$x" ;} | sed -e 's/[][()+@?]/#/g' || :` in
 					exec - *$x*) continue ;;
 					exec - esac
 					exec - ;;

--- a/src/cmd/ksh93/README
+++ b/src/cmd/ksh93/README
@@ -271,6 +271,8 @@ failures (crashes, and/or important functionality does not work).
 	Solaris 11.4 (Solaris Studio 12.5 cc) on x86_64
 *	UnixWare 7.1.4 on x86
 ***	Windows 7 using Cygwin on x86
+***	Windows 10 using Cygwin on x86_64
+***	Windows 11 using Cygwin on x86_64
 
 #### REPORTING BUGS ####
 

--- a/src/cmd/ksh93/bltins/cd_pwd.c
+++ b/src/cmd/ksh93/bltins/cd_pwd.c
@@ -95,6 +95,7 @@ int	b_cd(int argc, char *argv[],Shbltin_t *context)
 		oldpwd = (char*)pwdnod->nvalue.cp;  /* if path_pwd() failed to get the pwd, use $PWD */
 	if(shp->subshell)
 	{
+		 /* clone $OLDPWD and $PWD into the subshell's scope */
 		opwdnod = sh_assignok(opwdnod,1);
 		pwdnod = sh_assignok(pwdnod,1);
 	}

--- a/src/cmd/ksh93/bltins/misc.c
+++ b/src/cmd/ksh93/bltins/misc.c
@@ -525,6 +525,7 @@ static void	print_times(struct timeval utime, struct timeval stime)
 	sfprintf(sfstdout, "%dm%02d%c%03ds %dm%02d%c%03ds\n", ut_min, ut_sec, radix, ut_ms, st_min, st_sec, radix, st_ms);
 }
 #if _lib_getrusage
+/* getrusage tends to have higher precision */
 static void	print_cpu_times(void)
 {
 	struct rusage usage;

--- a/src/cmd/ksh93/bltins/mkservice.c
+++ b/src/cmd/ksh93/bltins/mkservice.c
@@ -116,7 +116,7 @@ typedef struct Service_s Service_t;
 struct Service_s
 {
 	Namfun_t	fun;
-	short		fd;
+	int		fd;
 	int		refcount;
 	int		(*acceptf)(Service_t*,int);
 	int		(*actionf)(Service_t*,int,int);
@@ -126,7 +126,7 @@ struct Service_s
 	Namval_t*	disc[elementsof(disctab)-1];
 };
 
-static short		*file_list;
+static int		*file_list;
 static Sfio_t		**poll_list;
 static Service_t	**service_list;
 static int		npoll;

--- a/src/cmd/ksh93/bltins/read.c
+++ b/src/cmd/ksh93/bltins/read.c
@@ -53,8 +53,8 @@ struct read_save
 {
         char	**argv;
 	char	*prompt;
-        short	fd;
-        short	plen;
+        int	fd;
+        int	plen;
 	int	flags;
 	ssize_t	len;
         long	timeout;

--- a/src/cmd/ksh93/bltins/sleep.c
+++ b/src/cmd/ksh93/bltins/sleep.c
@@ -34,12 +34,6 @@
 #include	"builtins.h"
 #include	"FEATURE/time"
 #include	"FEATURE/poll"
-#ifdef _NEXT_SOURCE
-#   define sleep	_ast_sleep
-#endif /* _NEXT_SOURCE */
-#ifdef _lib_poll_notimer
-#   undef _lib_poll
-#endif /* _lib_poll_notimer */
 
 int	b_sleep(register int argc,char *argv[],Shbltin_t *context)
 {
@@ -122,7 +116,7 @@ skip:
 		tloc += (time_t)(d+.5);
 	}
 	if(sflag && d==0)
-		pause();
+		pause();  /* 'sleep -s' waits until a signal is sent */
 	else while(1)
 	{
 		time_t now;
@@ -142,7 +136,9 @@ skip:
 }
 
 /*
- * delay execution for time <t>
+ * Delay execution for time <t>.
+ * If sflag==1, stop sleeping when any signal is received
+ * (such as SIGWINCH in an interactive shell).
  */
 
 void sh_delay(double t, int sflag)

--- a/src/cmd/ksh93/bltins/test.c
+++ b/src/cmd/ksh93/bltins/test.c
@@ -130,6 +130,7 @@ int b_test(int argc, char *argv[],Shbltin_t *context)
 	}
 	if(argc <= 1)
 	{
+		/* POSIX requires the test builtin to return 1 if expression is missing */
 		exitval = 1;
 		goto done;
 	}
@@ -401,7 +402,7 @@ int test_unop(Shell_t *shp,register int op,register const char *arg)
 	    case 'l':
 #endif
 	    case 'L':
-	    case 'h': /* undocumented, and hopefully will disappear */
+	    case 'h':
 		if(*arg==0 || arg[strlen(arg)-1]=='/' || lstat(arg,&statb)<0)
 			return(0);
 		return(S_ISLNK(statb.st_mode));

--- a/src/cmd/ksh93/bltins/trap.c
+++ b/src/cmd/ksh93/bltins/trap.c
@@ -85,7 +85,7 @@ int	b_trap(int argc,char *argv[],Shbltin_t *context)
 				/*
 				 * NOTE: 2007-11-26: workaround for tests/signal.sh
 				 * if function semantics can be worked out then it
-				 * may merit a -d,--default option
+				 * may merit a -d/--default option
 				 */
 				else if(*action=='+' && action[1]==0 && shp->st.self == &shp->global)
 				{
@@ -375,12 +375,13 @@ static int sig_number(Shell_t *shp,const char *string)
 		}
 		if(n<0 && shp->gd->sigruntime[1] && (name=stakptr(o)) && *name++=='R' && *name++=='T')
 		{
-			if(name[0]=='M' && name[1]=='I' && name[2]=='N' && name[3]=='+')
+			/* Real-time signals */
+			if(name[0]=='M' && name[1]=='I' && name[2]=='N' && name[3]=='+')	/* MIN+ */
 			{
 				if((sig=(int)strtol(name+4,&name,10)) >= 0 && !*name)
 					n = shp->gd->sigruntime[SH_SIGRTMIN] + sig;
 			}
-			else if(name[0]=='M' && name[1]=='A' && name[2]=='X' && name[3]=='-')
+			else if(name[0]=='M' && name[1]=='A' && name[2]=='X' && name[3]=='-')	/* MAX- */
 			{
 				if((sig=(int)strtol(name+4,&name,10)) >= 0 && !*name)
 					n = shp->gd->sigruntime[SH_SIGRTMAX] - sig;

--- a/src/cmd/ksh93/bltins/typeset.c
+++ b/src/cmd/ksh93/bltins/typeset.c
@@ -185,7 +185,7 @@ int    b_alias(int argc,register char *argv[],Shbltin_t *context)
 			nv_scan(troot,nv_rehash,(void*)0,NV_TAGGED,NV_TAGGED);
 	}
 	else if(argv[1] && tdata.sh->subshell && !tdata.sh->subshare)
-		sh_subfork();			/* avoid affecting main shell's alias table */
+		sh_subfork();			/* avoid affecting the parent shell's alias table */
 	return(setall(argv,flag,troot,&tdata));
 }
 
@@ -652,7 +652,7 @@ static int     setall(char **argv,register int flag,Dt_t *troot,struct tdata *tp
 		{
 			register unsigned newflag;
 			register Namval_t *np;
-			Namarr_t	*ap;
+			Namarr_t	*ap=0;
 			Namval_t	*mp;
 			unsigned curflag;
 			if(troot == shp->fun_tree)
@@ -1359,9 +1359,8 @@ static int unall(int argc, char **argv, register Dt_t *troot, Shell_t* shp)
 				}
 			}
 			/*
-			 * When aliases are removed from the tree, the NV_NOFREE attribute must be used for
-			 * preset aliases since those are given the NV_NOFREE attribute. _nv_unset discards
-			 * NV_NOFREE so the status of NV_NOFREE is obtained now to prevent an invalid free crash.
+			 * Preset aliases have the NV_NOFREE attribute and cannot be safely freed from memory.
+			 * _nv_unset discards this flag so it's obtained now to prevent an invalid free crash.
 			 */
 			if(troot==shp->alias_tree)
 				nofree_attr = nv_isattr(np,NV_NOFREE);	/* note: returns bitmask, not boolean */

--- a/src/cmd/ksh93/bltins/whence.c
+++ b/src/cmd/ksh93/bltins/whence.c
@@ -105,7 +105,7 @@ int	b_command(register int argc,char *argv[],Shbltin_t *context)
 }
 
 /*
- *  for the whence command
+ * for the whence and type commands
  */
 int	b_whence(int argc,char *argv[],Shbltin_t *context)
 {
@@ -113,7 +113,7 @@ int	b_whence(int argc,char *argv[],Shbltin_t *context)
 	register Shell_t *shp = context->shp;
 	NOT_USED(argc);
 	if(*argv[0]=='t')
-		flags = V_FLAG;
+		flags = V_FLAG;  /* <t>ype == whence -v */
 	while((n = optget(argv,sh_optwhence))) switch(n)
 	{
 	    case 'a':
@@ -193,8 +193,8 @@ static int whence(Shell_t *shp,char **argv, register int flags)
 			cp = 0;
 			aflag++;
 		}
-		/* built-ins and functions next */
 	bltins:
+		/* functions */
 		if(!(flags&F_FLAG) && (np = nv_bfsearch(name, shp->fun_tree, &nq, &notused)) && is_afunction(np))
 		{
 			if(flags&Q_FLAG)
@@ -219,6 +219,7 @@ static int whence(Shell_t *shp,char **argv, register int flags)
 				continue;
 			aflag++;
 		}
+		/* built-ins */
 		if((np = nv_bfsearch(name, shp->bltin_tree, &nq, &notused)) && !nv_isnull(np))
 		{
 			if(flags&V_FLAG)
@@ -309,7 +310,7 @@ static int whence(Shell_t *shp,char **argv, register int flags)
 				if(flags&V_FLAG)
 					 errormsg(SH_DICT,ERROR_exit(0),e_found,sh_fmtq(name));
 			}
-			/* If -a given, continue with next result */
+			/* If -a is active, continue to the next result */
 			if(aflag)
 			{
 				if(aflag<=1)

--- a/src/cmd/ksh93/builtins.mm
+++ b/src/cmd/ksh93/builtins.mm
@@ -452,7 +452,7 @@ while(1) switch(n=optget(argv,"xf:[file]"))
 		break;
 	case '?':
 		error(ERROR_usage(2), opt_info.arg);
-		break;
+		UNREACHABLE();
 }
 .EE
 .H 2 "Storage Management"

--- a/src/cmd/ksh93/data/builtins.c
+++ b/src/cmd/ksh93/data/builtins.c
@@ -152,7 +152,7 @@ const struct shtable3 shtab_builtins[] =
 	CMDLIST(wc)
 	CMDLIST(sync)
 #if !_std_malloc && !_AST_std_malloc
-	CMDLIST(vmstate)
+	CMDLIST(vmstate)  /* vmstate only works with vmalloc */
 #endif
 #endif
 #if SHOPT_REGRESS
@@ -473,10 +473,7 @@ const char sh_optcd[] =
 	"written to standard output.]"
 "[+?If both \b-L\b and \b-P\b are specified, the last one specified will "
 	"be used.  If neither \b-P\b or \b-L\b is specified then the "
-	"behavior will be determined by the \bgetconf\b parameter "
-	"\bPATH_RESOLVE\b.  If \bPATH_RESOLVE\b is \bphysical\b, "
-	"then the behavior will be as if \b-P\b were specified.  Otherwise, "
-	"the behavior will be as if  \b-L\b were specified.]"
+	"behavior will default to \b-L\b.]"
 "[L?Handle each pathname component \b..\b in a logical fashion by moving "
 	"up one level by name in the present working directory.]"
 "[P?The present working directory is first converted to an absolute pathname "
@@ -1381,10 +1378,7 @@ const char sh_optpwd[] =
 	"\b.\b or \b..\b components.]"
 "[+?If both \b-L\b and \b-P\b are specified, the last one specified will "
 	"be used.  If neither \b-P\b or \b-L\b is specified then the "
-	"behavior will be determined by the \bgetconf\b parameter "
-	"\bPATH_RESOLVE\b.  If \bPATH_RESOLVE\b is \bphysical\b, "
-	"then the behavior will be as if \b-P\b were specified.  Otherwise, "
-	"the behavior will be as if  \b-L\b were specified.]"
+	"behavior will default to \b-L\b.]"
 "[L?The absolute pathname may contains symbolic link components.  This is "
 	"the default.]"
 "[P?The absolute pathname will not contain any symbolic link components.]"

--- a/src/cmd/ksh93/edit/edit.c
+++ b/src/cmd/ksh93/edit/edit.c
@@ -819,6 +819,7 @@ void	ed_setup(register Edit_t *ep, int fd, int reedit)
 			sh_offoption(SH_RESTRICTED);
 			sh_offoption(SH_VERBOSE);
 			sh_offoption(SH_XTRACE);
+			/* get the cursor up sequence from tput */
 #if _tput_terminfo
 			sh_trap(".sh.subscript=$(" _pth_tput " cuu1 2>/dev/null)",0);
 #elif _tput_termcap
@@ -914,6 +915,7 @@ int ed_read(void *context, int fd, char *buff, int size, int reedit)
 		if(0)
 #endif
 		{
+			/* redraw the prompt after receiving SIGWINCH */
 			Edpos_t	lastpos;
 			int	n, rows, newsize;
 			/* move cursor to start of first line */
@@ -1809,10 +1811,8 @@ int ed_histgen(Edit_t *ep,const char *pattern)
 	{
 		l = ac;
 		argv = av  = (char**)stakalloc((ac+1)*sizeof(char*));
-		for(mplast=0; l>=0 && (*av= (char*)mp); mplast=mp,mp=mp->next,av++)
-		{
+		for(; l>=0 && (*av= (char*)mp); mp=mp->next,av++)
 			l--;
-		}
 		*av = 0;
 		strsort(argv,ac,ed_sortdata);
 		mplast = (Histmatch_t*)argv[0];

--- a/src/cmd/ksh93/edit/history.c
+++ b/src/cmd/ksh93/edit/history.c
@@ -116,7 +116,6 @@ static int	hist_exceptf(Sfio_t*, int, void*, Sfdisc_t*);
 
 static int	histinit;
 static mode_t	histmode;
-static History_t *wasopen;
 static History_t *hist_ptr;
 
 #if SHOPT_ACCTFILE

--- a/src/cmd/ksh93/edit/vi.c
+++ b/src/cmd/ksh93/edit/vi.c
@@ -1452,6 +1452,7 @@ static void getline(register Vi_t* vp,register int mode)
 		case '\b':		/** backspace **/
 			if( sh_isoption(SH_VI) && backslash && virtual[cur_virt] == '\\' )
 			{
+				/*** escape backspace/erase char ***/
 				backslash = 0;
 				cdelete(vp,1, BAD);
 				append(vp,usrerase, mode);
@@ -1498,6 +1499,7 @@ static void getline(register Vi_t* vp,register int mode)
 		case UKILL:		/** user kill line char **/
 			if( sh_isoption(SH_VI) && backslash && virtual[cur_virt] == '\\' )
 			{
+				/*** escape kill char ***/
 				backslash = 0;
 				cdelete(vp,1, BAD);
 				append(vp,usrkill, mode);

--- a/src/cmd/ksh93/include/builtins.h
+++ b/src/cmd/ksh93/include/builtins.h
@@ -75,7 +75,6 @@ extern int b_enum(int, char*[],Shbltin_t*);
 extern int b_exec(int, char*[],Shbltin_t*);
 extern int b_eval(int, char*[],Shbltin_t*);
 extern int b_return(int, char*[],Shbltin_t*);
-extern int B_login(int, char*[],Shbltin_t*);
 extern int b_true(int, char*[],Shbltin_t*);
 extern int b_false(int, char*[],Shbltin_t*);
 extern int b_readonly(int, char*[],Shbltin_t*);

--- a/src/cmd/ksh93/include/defs.h
+++ b/src/cmd/ksh93/include/defs.h
@@ -113,9 +113,6 @@ struct limits
 	int		open_max;	/* maximum number of file descriptors */
 	int		clk_tck;	/* number of ticks per second */
 	int		child_max;	/* maximum number of children */
-	int		ngroups_max;	/* maximum number of process groups */
-	unsigned char	posix_version;	/* posix version number */
-	unsigned char	posix_jobcontrol;/* non-zero for job control systems */
 };
 
 #ifndef SH_wait_f_defined
@@ -142,15 +139,10 @@ struct shared
 	char		*shpath;
 	char		*user;
 	char		**sigmsg;
-	char		*rcfile;
 	char		**login_files;
 	void		*ed_context;
-	void		*init_context;
-	void		*job_context;
 	int		*stats;
-	int		bltin_nnodes;	/* number of bltins nodes */ 
 	int		sigmax;
-	int		nforks;
 	Shwait_f	waitevent;
 };
 
@@ -177,7 +169,6 @@ struct shared
 	unsigned int	jobenv;		/* subshell number for jobs */ \
 	int		infd;		/* input file descriptor */ \
 	short		nextprompt;	/* next prompt is PS<nextprompt> */ \
-	short		poolfiles; \
 	Namval_t	*posix_fun;	/* points to last name() function */ \
 	char		*outbuff;	/* pointer to output buffer */ \
 	char		*errbuff;	/* pointer to stderr buffer */ \
@@ -199,7 +190,6 @@ struct shared
 	char		lastbase; \
 	char		forked;	\
 	char		binscript; \
-	char		deftype; \
 	char		funload; \
 	char		used_pos;	/* used positional parameter */\
 	char		universe; \
@@ -238,7 +228,6 @@ struct shared
 	void		*mac_context; \
 	void		*lex_context; \
 	void		*arg_context; \
-	void		*job_context; \
 	void		*pathlist; \
 	void		*defpathlist; \
 	void		*cdpathlist; \
@@ -265,7 +254,6 @@ struct shared
 	Dt_t		*fpathdict; \
 	Dt_t		*typedict; \
 	Dt_t		*inpool; \
-	Dt_t		*transdict; \
 	char		ifstable[256]; \
 	unsigned long	test; \
 	Shopt_t		offoptions;	/* options that were explicitly disabled by the user on the command line */ \

--- a/src/cmd/ksh93/include/nval.h
+++ b/src/cmd/ksh93/include/nval.h
@@ -302,18 +302,4 @@ extern const Namdisc_t	*nv_discfun(int);
 #define nv_size(np)		nv_setsize((np),-1)
 #define nv_stack(np,nf)		nv_disc(np,nf,0)
 
-#if 0
-/*
- * The names of many functions were changed in early '95
- * Here is a mapping to the old names
- */
-#   define nv_istype(np)	nv_isattr(np)
-#   define nv_newtype(np)	nv_newattr(np)
-#   define nv_namset(np,a,b)	nv_open(np,a,b)
-#   define nv_free(np)		nv_unset(np,0)
-#   define nv_settype(np,a,b,c)	nv_setdisc(np,a,b,c)
-#   define nv_search(np,a,b)	nv_open(np,a,((b)?0:NV_NOADD))
-#   define settype	setdisc
-#endif
-
 #endif /* NV_DEFAULT */

--- a/src/cmd/ksh93/sh/args.c
+++ b/src/cmd/ksh93/sh/args.c
@@ -642,7 +642,7 @@ void sh_printopts(Shopt_t oflags,register int mode, Shopt_t *mask)
  */
 char **sh_argbuild(Shell_t *shp,int *nargs, const struct comnod *comptr,int flag)
 {
-	register struct argnod	*argp;
+	register struct argnod	*argp=0;
 	struct argnod *arghead=0;
 	shp->xargmin = 0;
 	{

--- a/src/cmd/ksh93/sh/arith.c
+++ b/src/cmd/ksh93/sh/arith.c
@@ -272,7 +272,7 @@ static Sfdouble_t arith(const char **ptr, struct lval *lvalue, int type, Sfdoubl
 		c = mbchar(str);
 		if(isaletter(c))
 		{
-			register Namval_t *np;
+			register Namval_t *np=0;
 			int dot=0;
 			while(1)
 			{
@@ -297,7 +297,6 @@ static Sfdouble_t arith(const char **ptr, struct lval *lvalue, int type, Sfdoubl
 				int off=stktell(shp->stk);
 				int fsize = str- (char*)(*ptr);
 				const struct mathtab *tp;
-				Namval_t	*np;
 				c = **ptr;
 				lvalue->fun = 0;
 				sfprintf(shp->stk,".sh.math.%.*s%c",fsize,*ptr,0);

--- a/src/cmd/ksh93/sh/array.c
+++ b/src/cmd/ksh93/sh/array.c
@@ -1775,7 +1775,7 @@ void *nv_associative(register Namval_t *np,const char *sp,int mode)
 				if((mode&NV_ADD) && nv_type(np)) 
 					nv_arraychild(np,mp,0);
 				if(sh.subshell)
-					np = sh_assignok(np,1);
+					sh_assignok(np,1);
 				/*
 				 * For enum types (NV_UINT16 with discipline ENUM_disc), nelem should not
 				 * not increased or 'unset' will fail to completely unset such an array.

--- a/src/cmd/ksh93/sh/deparse.c
+++ b/src/cmd/ksh93/sh/deparse.c
@@ -74,7 +74,7 @@ void sh_deparse(Sfio_t *out, const Shnode_t *t,int tflags)
  */
 static void p_tree(register const Shnode_t *t,register int tflags)
 {
-	register char *cp;
+	register char *cp=0;
 	int save = end_line;
 	int needbrace = (tflags&NEED_BRACE);
 	int procsub = (tflags&PROCSUBST);
@@ -390,7 +390,7 @@ static void p_keyword(const char *word,int flag)
 static void p_arg(register const struct argnod *arg,register int endchar,int opts)
 {
 	register const char *cp;
-	register int flag;
+	register int flag=0;
 	do
 	{
 		if(!arg->argnxt.ap)

--- a/src/cmd/ksh93/sh/init.c
+++ b/src/cmd/ksh93/sh/init.c
@@ -1063,16 +1063,6 @@ static char *setdisc_any(Namval_t *np, const char *event, Namval_t *action, Namf
 
 static const Namdisc_t SH_MATH_disc  = { 0, 0, get_math, 0, setdisc_any, create_math, };
 
-#if SHOPT_NAMESPACE
-    static char* get_nspace(Namval_t* np, Namfun_t *fp)
-    {
-	if(sh.namespace)
-		return(nv_name(sh.namespace));
-	return((char*)np->nvalue.cp);
-    }
-    static const Namdisc_t NSPACE_disc	= {  0, 0, get_nspace };
-#endif /* SHOPT_NAMESPACE */
-
 #ifdef _hdr_locale
     static const Namdisc_t LC_disc	= {  sizeof(Namfun_t), put_lang };
 #endif /* _hdr_locale */
@@ -1236,9 +1226,6 @@ Shell_t *sh_init(register int argc,register char *argv[], Shinit_f userinit)
 		shgd->lim.clk_tck = getconf("CLK_TCK");
 		shgd->lim.arg_max = getconf("ARG_MAX");
 		shgd->lim.child_max = getconf("CHILD_MAX");
-		shgd->lim.ngroups_max = getconf("NGROUPS_MAX");
-		shgd->lim.posix_version = getconf("VERSION");
-		shgd->lim.posix_jobcontrol = getconf("JOB_CONTROL");
 		if(shgd->lim.arg_max <=0)
 			shgd->lim.arg_max = ARG_MAX;
 		if(shgd->lim.child_max <=0)
@@ -1310,7 +1297,7 @@ Shell_t *sh_init(register int argc,register char *argv[], Shinit_f userinit)
 	sh_siginit(shp);
 	stakinstall(NIL(Stak_t*),nomemory);
 	/* set up memory for name-value pairs */
-	shp->init_context =  nv_init(shp);
+	shp->init_context = nv_init(shp);
 	/* initialize shell type */
 	if(argc>0)
 	{
@@ -1883,10 +1870,7 @@ Dt_t *sh_inittree(Shell_t *shp,const struct shtable2 *name_vals)
 		n++;
 	np = (Namval_t*)sh_calloc(n,sizeof(Namval_t));
 	if(!shgd->bltin_nodes)
-	{
 		shgd->bltin_nodes = np;
-		shgd->bltin_nnodes = n;
-	}
 	else if(name_vals==(const struct shtable2*)shtab_builtins)
 	{
 		shgd->bltin_cmds = np;

--- a/src/cmd/ksh93/sh/jobs.c
+++ b/src/cmd/ksh93/sh/jobs.c
@@ -317,8 +317,7 @@ int job_reap(register int sig)
 	{
 		if(!(flags&WNOHANG) && !sh.intrap && job.pwlist)
 		{
-			if(!was_ttywait_on)
-				sh_onstate(SH_TTYWAIT);
+			sh_onstate(SH_TTYWAIT);
 			if(waitevent && (*waitevent)(-1,-1L,0))
 				flags |= WNOHANG;
 		}
@@ -1020,8 +1019,8 @@ int job_kill(register struct process *pw,register int sig)
 #endif	/* SIGTSTP */
 	job_lock();
 	errno = ECHILD;
-	if(pw==0)
-		goto error;
+	if(!pw)
+		goto error;  /* not an actual shell job */
 	shp = pw->p_shp;
 	pid = pw->p_pid;
 	if(by_number)

--- a/src/cmd/ksh93/sh/lex.c
+++ b/src/cmd/ksh93/sh/lex.c
@@ -1662,6 +1662,7 @@ done:
 	lp->assignok = (endchar(lp)==RBRACT?assignok:0);
 	if(lp->heredoc && !inheredoc)
 	{
+		/* here-document isn't fully contained in command substitution */
 		errormsg(SH_DICT,ERROR_exit(SYNBAD),e_lexsyntax5,lp->sh->inlineno,lp->heredoc->ioname);
 		UNREACHABLE();
 	}

--- a/src/cmd/ksh93/sh/macro.c
+++ b/src/cmd/ksh93/sh/macro.c
@@ -2156,7 +2156,7 @@ static void comsubst(Mac_t *mp,register Shnode_t* t, int type)
 		{
 			/* special case $(<file) and $(<#file) */
 			register int fd;
-			int r;
+			int r=0;
 			struct checkpt buff;
 			struct ionod *ip=0;
 			sh_pushcontext(mp->shp,&buff,SH_JMPIO);

--- a/src/cmd/ksh93/sh/nvdisc.c
+++ b/src/cmd/ksh93/sh/nvdisc.c
@@ -842,11 +842,8 @@ static void *newnode(const char *name)
 {
 	register int s;
 	register Namval_t *np = sh_newof(0,Namval_t,1,s=strlen(name)+1);
-	if(np)
-	{
-		np->nvname = (char*)np+sizeof(Namval_t);
-		memcpy(np->nvname,name,s);
-	}
+	np->nvname = (char*)np+sizeof(Namval_t);
+	memcpy(np->nvname,name,s);
 	return((void*)np);
 }
 
@@ -1212,6 +1209,7 @@ Namval_t *sh_addbuiltin(const char *path, Shbltin_f bltin, void *extra)
 		{
 			if(nv_isattr(np,BLT_SPC))
 			{
+				/* builtin(1) cannot delete special builtins */
 				errormsg(SH_DICT,ERROR_exit(1),"cannot delete: %s%s",name,is_spcbuiltin);
 				UNREACHABLE();
 			}

--- a/src/cmd/ksh93/sh/parse.c
+++ b/src/cmd/ksh93/sh/parse.c
@@ -2046,7 +2046,7 @@ unsigned long kiaentity(Lex_t *lexp,const char *name,int len,int type,int first,
 		else
 			sfputr(stkp,name,0);
 	}
-	sfputc(stkp,'\0');
+	sfputc(stkp,'\0');  /* terminate name while writing database output */
 	np = nv_search(stakptr(offset),lexp->entity_tree,NV_ADD);
 	stkseek(stkp,offset);
 	np->nvalue.i = pkind;

--- a/src/cmd/ksh93/sh/path.c
+++ b/src/cmd/ksh93/sh/path.c
@@ -1573,7 +1573,9 @@ static int path_chkpaths(Shell_t *shp,Pathcomp_t *first, Pathcomp_t* old,Pathcom
 	if((fd=open(stakptr(offset),O_RDONLY))>=0)
 	{
 		fstat(fd,&statb);
-		if (!S_ISREG(statb.st_mode)) {
+		if(!S_ISREG(statb.st_mode))
+		{
+			/* .paths cannot be a directory */
 			close(fd);
 			return 0;
 		}

--- a/src/cmd/ksh93/sh/shcomp.c
+++ b/src/cmd/ksh93/sh/shcomp.c
@@ -115,7 +115,7 @@ int main(int argc, char *argv[])
 	argc -= opt_info.index;
 	if(argc==0 && tty_check(0))
 	{
-		errormsg(SH_DICT,ERROR_exit(0),"refusing to read script from terminal",cp);
+		errormsg(SH_DICT,ERROR_exit(0),"refusing to read script from terminal");
 		error_info.errors++;
 	}
 	if(error_info.errors || argc>2)
@@ -161,7 +161,7 @@ int main(int argc, char *argv[])
 	if(vflag)
 		sh_onoption(SH_VERBOSE);
 	if(!dflag)
-		sfwrite(out,header,sizeof(header));
+		sfwrite(out,header,sizeof(header));  /* write binary shcomp header */
 	sh_offoption(SH_MULTILINE);
 	shp->inlineno = 1;
 #if SHOPT_BRACEPAT
@@ -174,6 +174,7 @@ int main(int argc, char *argv[])
 		if(t = (Shnode_t*)sh_parse(shp,in,0))
 		{
 			if((t->tre.tretyp&(COMMSK|COMSCAN))==0 && t->com.comnamp && strcmp(nv_name((Namval_t*)t->com.comnamp),"alias")==0)
+				/* Create aliases found in the script to prevent syntax errors */
 				sh_exec(t,0);
 			if(!dflag && sh_tdump(out,t) < 0)
 			{

--- a/src/cmd/ksh93/sh/subshell.c
+++ b/src/cmd/ksh93/sh/subshell.c
@@ -77,7 +77,6 @@ static struct subshell
 	Dt_t		*sfun;	/* function scope for subshell */
 	Dt_t		*strack;/* tracked alias scope for subshell */
 	Pathcomp_t	*pathlist; /* for PATH variable */
-	struct Error_context_s *errcontext;
 	Shopt_t		options;/* save shell options */
 	pid_t		subpid;	/* child process id */
 	Sfio_t*		saveout;/* saved standard output */
@@ -518,7 +517,6 @@ Sfio_t *sh_subshell(Shell_t *shp,Shnode_t *t, volatile int flags, int comsub)
 	sp->shp = shp;
 	sp->sig = 0;
 	subshell_data = sp;
-	sp->errcontext = &buff.err;
 	sp->options = shp->options;
 	sp->jobs = job_subsave();
 	sp->subdup = shp->subdup;

--- a/src/cmd/ksh93/sh/subshell.c
+++ b/src/cmd/ksh93/sh/subshell.c
@@ -73,7 +73,6 @@ static struct subshell
 	Shell_t		*shp;	/* shell interpreter */
 	struct subshell	*prev;	/* previous subshell data */
 	struct subshell	*pipe;	/* subshell where output goes to pipe on fork */
-	Dt_t		*var;	/* variable table at time of subshell */
 	struct Link	*svar;	/* save shell variable table */
 	Dt_t		*sfun;	/* function scope for subshell */
 	Dt_t		*strack;/* tracked alias scope for subshell */
@@ -85,8 +84,8 @@ static struct subshell
 	char		*pwd;	/* present working directory */
 	void		*jobs;	/* save job info */
 	mode_t		mask;	/* saved umask */
-	short		tmpfd;	/* saved tmp file descriptor */
-	short		pipefd;	/* read fd if pipe is created */
+	int		tmpfd;	/* saved tmp file descriptor */
+	int		pipefd;	/* read fd if pipe is created */
 	char		jobcontrol;
 	char		monitor;
 	unsigned char	fdstatus;
@@ -520,7 +519,6 @@ Sfio_t *sh_subshell(Shell_t *shp,Shnode_t *t, volatile int flags, int comsub)
 	sp->sig = 0;
 	subshell_data = sp;
 	sp->errcontext = &buff.err;
-	sp->var = shp->var_tree;
 	sp->options = shp->options;
 	sp->jobs = job_subsave();
 	sp->subdup = shp->subdup;

--- a/src/cmd/ksh93/sh/suid_exec.c
+++ b/src/cmd/ksh93/sh/suid_exec.c
@@ -334,7 +334,10 @@ int eaccess(register const char *name, register int mode)
 			}
 			groups = (gid_t*)malloc((maxgroups+1)*sizeof(gid_t));
 			if(!groups)
-				error(ERROR_PANIC,"out of memory");
+			{
+				error(ERROR_SYSTEM|ERROR_PANIC,"out of memory");
+				UNREACHABLE();
+			}
 			n = getgroups(maxgroups,groups);
 			while(--n >= 0)
 			{

--- a/src/cmd/ksh93/tests/arrays.sh
+++ b/src/cmd/ksh93/tests/arrays.sh
@@ -675,6 +675,8 @@ actual=$("$SHELL" -c 'A[0]="'\''" B[0]=aa C[0]=aa; typeset -a') \
 
 # ======
 # Arrays in virtual/non-forked subshells
+# https://github.com/att/ast/issues/416
+# https://github.com/ksh93/ksh/issues/88
 
 unset foo
 (typeset -a foo)

--- a/src/cmd/ksh93/tests/shtests
+++ b/src/cmd/ksh93/tests/shtests
@@ -385,7 +385,7 @@ do	[[ $i == *.sh ]] || i+='.sh'
 				(( e += $? ))
 			fi
 			if	(( e > 128 && ++total_e ))
-			then	E="(killed by SIG$(kill -l "$e"))"
+			then	E="(killed by SIG$(kill -l "$e"))"  # report signal if test crashes
 			elif	(( e == 1 && ++total_e ))
 			then	E="1 error"
 			else	E="$e errors"
@@ -417,7 +417,7 @@ do	[[ $i == *.sh ]] || i+='.sh'
 			then	echo test $o passed ${time:+"at $(date +%Y-%m-%d+%H:%M:%S)"} "[ $t $T 0 errors ]"
 			else	e=$?
 				if	(( e > 128 && ++total_e ))
-				then	E="(killed by SIG$(kill -l "$e"))"
+				then	E="(killed by SIG$(kill -l "$e"))"  # report signal if test crashes
 				elif	(( e == 1 && ++total_e ))
 				then	E="1 error"
 				else	E="$e errors"

--- a/src/cmd/ksh93/tests/subshell.sh
+++ b/src/cmd/ksh93/tests/subshell.sh
@@ -882,7 +882,7 @@ actual=${ get_value; }
 actual=`get_value`
 [[ $actual == "$expect" ]] || err_exit "\`Comsub\` failed to return output (expected '$expect', got '$actual')"
 
-# more tests from https://github.com/oracle/solaris-userland/blob/master/components/ksh93/patches/285-30771135.patch
+# more tests from https://github.com/att/ast/commit/710342926e6bce2c895833bf2a79a8711fdaa471
 tmpfile=$tmp/1116072.dummy
 touch "$tmpfile"
 exp='return value'

--- a/src/cmd/ksh93/tests/variables.sh
+++ b/src/cmd/ksh93/tests/variables.sh
@@ -700,6 +700,8 @@ exec 2>&3-
 set -- $x
 [[ $2 == b ]] || err_exit '$2 should be b after subshell'
 
+# ======
+# BUG_KBGPID: $! was not updated under certain conditions
 : & pid=$!
 ( : & )
 [[ $pid == $! ]] || err_exit '$! value not preserved across subshells'
@@ -712,6 +714,7 @@ pid=$!
 { : |& } >&2
 [[ $pid == $! ]] && err_exit '$! value not updated after co-process in braces+redir'
 
+# ======
 unset foo
 typeset -A foo
 function foo.set

--- a/src/lib/libast/Mamfile
+++ b/src/lib/libast/Mamfile
@@ -324,8 +324,8 @@ make install
 				exec - esac
 				exec - continue
 				exec - elif test ! -f ${INSTALLROOT}/lib/lib$i.a
-				exec - then case `{ ${CC} ${mam_cc_FLAGS} ${KSH_RELFLAGS} ${CCFLAGS} ${LDFLAGS} -o 1.${COTEMP}.x 1.${COTEMP}.o -l$i 2>&1 || echo '' $x ;} | sed -e 's/[][()+@?]/#/g' || :` in
-				exec - *$x*) case `{ ${CC} ${mam_cc_FLAGS} ${KSH_RELFLAGS} ${CCFLAGS} ${LDFLAGS} -o 1.${COTEMP}.x 1.${COTEMP}.o -l$i 2>&1 || echo '' $x ;} | sed -e 's/[][()+@?]/#/g' || :` in
+				exec - then case `{ ${CC} ${mam_cc_FLAGS} ${KSH_RELFLAGS} ${CCFLAGS} ${LDFLAGS} -o 1.${COTEMP}.x 1.${COTEMP}.o -l$i 2>&1 || echo '' "$x" ;} | sed -e 's/[][()+@?]/#/g' || :` in
+				exec - *$x*) case `{ ${CC} ${mam_cc_FLAGS} ${KSH_RELFLAGS} ${CCFLAGS} ${LDFLAGS} -o 1.${COTEMP}.x 1.${COTEMP}.o -l$i 2>&1 || echo '' "$x" ;} | sed -e 's/[][()+@?]/#/g' || :` in
 				exec - *$x*) continue ;;
 				exec - esac
 				exec - ;;

--- a/src/lib/libast/comp/iconv.c
+++ b/src/lib/libast/comp/iconv.c
@@ -383,9 +383,6 @@ error(DEBUG_TRACE, "AHA#%d _win_iconv from=0x%04x to=0x%04x\n", __LINE__, cc->fr
 #if DEBUG_TRACE
 error(DEBUG_TRACE, "AHA#%d _win_iconv *fn=%u fz=%u[%u] *tn=%u tz=%u\n", __LINE__, *fn, fz, fz * sizeof(WCHAR), *tn, tz);
 #endif
-#if 0
-				fz *= sizeof(WCHAR);
-#endif
 			}
 			if (ub != (LPWSTR)*fb)
 				free(ub);

--- a/src/lib/libast/comp/setlocale.c
+++ b/src/lib/libast/comp/setlocale.c
@@ -548,19 +548,11 @@ sjis_mbtowc(register wchar_t* p, register const char* s, size_t n)
 
 #endif
 
-#if 0
-
-#define utf8_wctomb	wctomb
-
-#else
-
 static int
 utf8_wctomb(char* u, wchar_t w) 
 {
 	return u ? wc2utf8(u, w) : 0;
 }
-
-#endif
 
 static const uint32_t		utf8mask[] =
 {

--- a/src/lib/libast/comp/spawnveg.c
+++ b/src/lib/libast/comp/spawnveg.c
@@ -172,10 +172,6 @@ spawnveg(const char* path, char* const argv[], char* const envv[], pid_t pgid)
 #endif
 #endif
 
-#if 0
-	if (access(path, X_OK))
-		return -1;
-#endif
 	if (!envv)
 		envv = environ;
 #if _lib_spawnve

--- a/src/lib/libast/disc/memfatal.c
+++ b/src/lib/libast/disc/memfatal.c
@@ -55,12 +55,12 @@ nomalloc(Vmalloc_t* region, int type, void* obj, Vmdisc_t* disc)
 	{
 #ifdef VM_BADADDR
 	case VM_BADADDR:
-		error(ERROR_SYSTEM|3, "invalid pointer %p passed to free or realloc", obj);
+		error(ERROR_SYSTEM|ERROR_PANIC, "invalid pointer %p passed to free or realloc", obj);
 		UNREACHABLE();
 #endif
 	case VM_NOMEM:
 		vmstat(region, &st);
-		error(ERROR_SYSTEM|3, "storage allocator out of memory on %lu byte request ( region %lu segments %lu busy %lu:%lu:%lu free %lu:%lu:%lu )", (size_t)obj, st.extent, st.n_seg, st.n_busy, st.s_busy, st.m_busy, st.n_free, st.s_free, st.m_free);
+		error(ERROR_SYSTEM|ERROR_PANIC, "storage allocator out of memory on %lu byte request ( region %lu segments %lu busy %lu:%lu:%lu free %lu:%lu:%lu )", (size_t)obj, st.extent, st.n_seg, st.n_busy, st.s_busy, st.m_busy, st.n_free, st.s_free, st.m_free);
 		UNREACHABLE();
 	}
 	return(0);

--- a/src/lib/libast/misc/fts.c
+++ b/src/lib/libast/misc/fts.c
@@ -828,6 +828,7 @@ fts_read(register FTS* fts)
 	struct stat		sb;
 #endif
 
+	f = 0;
 	for (;;)
 		switch (fts->state)
 		{

--- a/src/lib/libast/path/pathpath.c
+++ b/src/lib/libast/path/pathpath.c
@@ -90,7 +90,6 @@ pathpath_20100601(const char* p, const char* a, int mode, register char* path, s
 		a = 0;
 	else if (s = (char*)a)
 	{
-		x = s;
 		if (strchr(p, '/'))
 		{
 			a = p;

--- a/src/lib/libast/stdio/vfwscanf.c
+++ b/src/lib/libast/stdio/vfwscanf.c
@@ -67,13 +67,6 @@ wideread(Sfio_t* f, Void_t* buf, size_t size, Sfdisc_t* dp)
 {
 	register Wide_t*	w = (Wide_t*)dp;
 	wchar_t			wuf[2];
-
-#if 0
-	if (sfread(w->f, wuf, sizeof(wuf[0])) != sizeof(wuf[0]))
-		return -1;
-	wuf[1] = 0;
-	return wcstombs(buf, wuf, size);
-#else
 	ssize_t	r;
 
 	r = sfread(w->f, wuf, sizeof(wuf[0]));
@@ -82,7 +75,6 @@ wideread(Sfio_t* f, Void_t* buf, size_t size, Sfdisc_t* dp)
 	wuf[1] = 0;
 	r = wcstombs(buf, wuf, size);
 	return r;
-#endif
 }
 
 int

--- a/src/lib/libast/tm/tmxfmt.c
+++ b/src/lib/libast/tm/tmxfmt.c
@@ -356,10 +356,6 @@ tmxfmt(char* buf, size_t len, const char* format, Time_t t)
 		case 'N':	/* (AST|GNU) nanosecond part */
 			cp = number(cp, ep, (long)tm->tm_nsec, 9, width, pad);
 			continue;
-#if 0
-		case 'o':	/* (UNUSED) */
-			continue;
-#endif
 		case 'p':	/* meridian */
 			n = TM_MERIDIAN + (tm->tm_hour >= 12);
 			goto index;
@@ -574,10 +570,6 @@ tmxfmt(char* buf, size_t len, const char* format, Time_t t)
 		case 'U':	/* week number, Sunday as first day */
 			cp = number(cp, ep, (long)tmweek(tm, 0, -1, -1), 2, width, pad);
 			continue;
-#if 0
-		case 'v':	/* (UNUSED) */
-			continue;
-#endif
 		case 'V':	/* ISO week number */
 			cp = number(cp, ep, (long)tmweek(tm, 2, -1, -1), 2, width, pad);
 			continue;

--- a/src/lib/libcmd/Mamfile
+++ b/src/lib/libcmd/Mamfile
@@ -44,8 +44,8 @@ make install
 				exec - esac
 				exec - continue
 				exec - elif test ! -f ${INSTALLROOT}/lib/lib$i.a
-				exec - then case `{ ${CC} ${mam_cc_FLAGS} ${KSH_RELFLAGS} ${CCFLAGS} -L${INSTALLROOT}/lib ${LDFLAGS} -o 1.${COTEMP}.x 1.${COTEMP}.o -l$i 2>&1 || echo '' $x ;} | sed -e 's/[][()+@?]/#/g' || :` in
-				exec - *$x*) case `{ ${CC} ${mam_cc_FLAGS} ${KSH_RELFLAGS} ${CCFLAGS} ${LDFLAGS} -o 1.${COTEMP}.x 1.${COTEMP}.o -l$i 2>&1 || echo '' $x ;} | sed -e 's/[][()+@?]/#/g' || :` in
+				exec - then case `{ ${CC} ${mam_cc_FLAGS} ${KSH_RELFLAGS} ${CCFLAGS} -L${INSTALLROOT}/lib ${LDFLAGS} -o 1.${COTEMP}.x 1.${COTEMP}.o -l$i 2>&1 || echo '' "$x" ;} | sed -e 's/[][()+@?]/#/g' || :` in
+				exec - *$x*) case `{ ${CC} ${mam_cc_FLAGS} ${KSH_RELFLAGS} ${CCFLAGS} ${LDFLAGS} -o 1.${COTEMP}.x 1.${COTEMP}.o -l$i 2>&1 || echo '' "$x" ;} | sed -e 's/[][()+@?]/#/g' || :` in
 				exec - *$x*) continue ;;
 				exec - esac
 				exec - ;;

--- a/src/lib/libcmd/chgrp.c
+++ b/src/lib/libcmd/chgrp.c
@@ -299,7 +299,7 @@ b_chgrp(int argc, char** argv, Shbltin_t* context)
 			mapdisc.size = sizeof(Key_t);
 			if (!(map = dtopen(&mapdisc, Dtset)))
 			{
-				error(ERROR_exit(1), "out of memory [id map]");
+				error(ERROR_SYSTEM|ERROR_PANIC, "out of memory [id map]");
 				UNREACHABLE();
 			}
 			continue;
@@ -383,7 +383,7 @@ b_chgrp(int argc, char** argv, Shbltin_t* context)
 			{
 				if (!(m = (Map_t*)stakalloc(sizeof(Map_t))))
 				{
-					error(ERROR_exit(1), "out of memory [id dictionary]");
+					error(ERROR_SYSTEM|ERROR_PANIC, "out of memory [id dictionary]");
 					UNREACHABLE();
 				}
 				m->key = key;

--- a/src/lib/libcmd/cmp.c
+++ b/src/lib/libcmd/cmp.c
@@ -232,16 +232,6 @@ cmp(const char* file1, Sfio_t* f1, const char* file2, Sfio_t* f2, int flags, Sfo
 							return 1;
 						differences--;
 					}
-#if 0
-					if (!flags)
-						sfprintf(sfstdout, "%s %s differ: char %I*d, line %I*u\n", file1, file2, sizeof(pos), pos - (last - p1), sizeof(lines), lines);
-					else
-					{
-						sfprintf(sfstdout, "%6I*d", sizeof(pos), pos - (last - p1));
-						pretty(sfstdout, c1, -1, flags);
-						pretty(sfstdout, *(p2-1), '\n', flags);
-					}
-#else
 					if (flags & CMP_VERBOSE)
 						sfprintf(sfstdout, "%6I*d", sizeof(pos), pos - (last - p1));
 					else
@@ -254,7 +244,6 @@ cmp(const char* file1, Sfio_t* f1, const char* file2, Sfio_t* f2, int flags, Sfo
 					}
 					else
 						sfputc(sfstdout, '\n');
-#endif
 					if (!differences || differences < 0 && !(flags & CMP_VERBOSE))
 						return 1;
 					ret = 1;

--- a/src/lib/libcmd/cp.c
+++ b/src/lib/libcmd/cp.c
@@ -291,7 +291,7 @@ visit(State_t* state, register FTSENT* ent)
 	{
 		if ((state->postsiz + len) > state->pathsiz && !(state->path = newof(state->path, char, state->pathsiz = roundof(state->postsiz + len, PATH_CHUNK), 0)))
 		{
-			error(ERROR_SYSTEM|3, "out of memory");
+			error(ERROR_SYSTEM|ERROR_PANIC, "out of memory");
 			UNREACHABLE();
 		}
 		if (state->hierarchy && ent->fts_level == 0 && strchr(base, '/'))
@@ -400,15 +400,6 @@ visit(State_t* state, register FTSENT* ent)
 			return 0;
 		}
 		break;
-#if 0
-	case FTS_SL:
-		if (state->op == CP)
-		{
-			error(2, "%s: cannot copy non-terminal symbolic link", ent->fts_path);
-			return 0;
-		}
-		break;
-#endif
 	}
 	if (state->directory)
 		memcpy(state->path + state->postsiz, base, len);
@@ -696,7 +687,7 @@ b_cp(int argc, register char** argv, Shbltin_t* context)
 	{
 		if (!(state = newof(0, State_t, 1, 0)))
 		{
-			error(ERROR_SYSTEM|3, "out of memory");
+			error(ERROR_SYSTEM|ERROR_PANIC, "out of memory");
 			UNREACHABLE();
 		}
 		if (sh)
@@ -874,7 +865,7 @@ b_cp(int argc, register char** argv, Shbltin_t* context)
 			continue;
 		case '?':
 			error(ERROR_USAGE|4, "%s", opt_info.arg);
-			continue;
+			UNREACHABLE();
 		case ':':
 			error(2, "%s", opt_info.arg);
 			continue;
@@ -890,7 +881,7 @@ b_cp(int argc, register char** argv, Shbltin_t* context)
 	}
 	if (!(v = (char**)stkalloc(stkstd, (argc + 2) * sizeof(char*))))
 	{
-		error(ERROR_SYSTEM|3, "out of memory");
+		error(ERROR_SYSTEM|ERROR_PANIC, "out of memory");
 		UNREACHABLE();
 	}
 	memcpy(v, argv, (argc + 1) * sizeof(char*));
@@ -986,7 +977,7 @@ b_cp(int argc, register char** argv, Shbltin_t* context)
 	state->postsiz = strlen(file);
 	if (state->pathsiz < roundof(state->postsiz + 2, PATH_CHUNK) && !(state->path = newof(state->path, char, state->pathsiz = roundof(state->postsiz + 2, PATH_CHUNK), 0)))
 	{
-		error(ERROR_SYSTEM|3, "out of memory");
+		error(ERROR_SYSTEM|ERROR_PANIC, "out of memory");
 		UNREACHABLE();
 	}
 	memcpy(state->path, file, state->postsiz + 1);

--- a/src/lib/libcmd/cut.c
+++ b/src/lib/libcmd/cut.c
@@ -140,7 +140,7 @@ cutinit(int mode, char* str, Delim_t* wdelim, Delim_t* ldelim, size_t reclen)
 
 	if (!(cut = (Cut_t*)stakalloc(sizeof(Cut_t) + strlen(cp) * sizeof(int))))
 	{
-		error(ERROR_exit(1), "out of memory");
+		error(ERROR_SYSTEM|ERROR_PANIC, "out of memory");
 		UNREACHABLE();
 	}
 	if (cut->mb = mbwide())

--- a/src/lib/libcmd/date.c
+++ b/src/lib/libcmd/date.c
@@ -343,7 +343,7 @@ b_date(int argc, register char** argv, Shbltin_t* context)
 		case 'p':
 			if (!(f = newof(0, Fmt_t, 1, 0)))
 			{
-				error(ERROR_SYSTEM|3, "out of memory [format]");
+				error(ERROR_SYSTEM|ERROR_PANIC, "out of memory [format]");
 				UNREACHABLE();
 			}
 			f->next = fmts;

--- a/src/lib/libcmd/expr.c
+++ b/src/lib/libcmd/expr.c
@@ -537,38 +537,31 @@ b_expr(int argc, char** argv, Shbltin_t* context)
 
 	cmdinit(argc, argv, context, ERROR_CATALOG, 0);
 	state.standard = !!conformance(0, 0);
-#if 0
-	if (state.standard)
-		state.arglist = argv+1;
-	else
-#endif
+	while (n=optget(argv, usage))
 	{
-		while (n=optget(argv, usage))
+		/*
+		 * NOTE: this loop ignores all but literal -- and -?
+		 *	 out of kindness for obsolescent usage
+		 *	 (and is ok with the standard) but strict
+		 *	 getopt conformance would give usage for all
+		 *	 unknown - options
+		 */
+		if(n=='?')
 		{
-			/*
-			 * NOTE: this loop ignores all but literal -- and -?
-			 *	 out of kindness for obsolescent usage
-			 *	 (and is ok with the standard) but strict
-			 *	 getopt conformance would give usage for all
-			 *	 unknown - options
-			 */
-			if(n=='?')
-			{
-				error(ERROR_usage(2), "%s", opt_info.arg);
-				UNREACHABLE();
-			}
-			if (opt_info.option[1] != '?')
-				break;
 			error(ERROR_usage(2), "%s", opt_info.arg);
 			UNREACHABLE();
 		}
-		if (error_info.errors)
-		{
-			error(ERROR_usage(2),"%s",optusage((char*)0));
-			UNREACHABLE();
-		}
-		state.arglist = argv+opt_info.index;
+		if (opt_info.option[1] != '?')
+			break;
+		error(ERROR_usage(2), "%s", opt_info.arg);
+		UNREACHABLE();
 	}
+	if (error_info.errors)
+	{
+		error(ERROR_usage(2),"%s",optusage((char*)0));
+		UNREACHABLE();
+	}
+	state.arglist = argv+opt_info.index;
 	if (expr_or(&state, &node))
 	{
 		error(ERROR_exit(2),"syntax error");

--- a/src/lib/libcmd/id.c
+++ b/src/lib/libcmd/id.c
@@ -234,7 +234,7 @@ getids(Sfio_t* sp, const char* name, register int flags)
 				maxgroups = NGROUPS_MAX;
 			if (!(groups = newof(0, gid_t, maxgroups + 1, 0)))
 			{
-				error(ERROR_exit(1), "out of memory [group array]");
+				error(ERROR_SYSTEM|ERROR_PANIC, "out of memory [group array]");
 				UNREACHABLE();
 			}
 		}

--- a/src/lib/libcmd/join.c
+++ b/src/lib/libcmd/join.c
@@ -705,8 +705,9 @@ sfprintf(sfstdout, "[2#%d:0,%lld,%lld]", __LINE__, lo, hi);
 						jp->samesize = roundof(n2, 16);
 						if (!(jp->same = newof(jp->same, char, jp->samesize, 0)))
 						{
-							error(ERROR_SYSTEM|2, "out of memory");
-							return -1;
+							done(jp);
+							error(ERROR_SYSTEM|ERROR_PANIC, "out of memory");
+							UNREACHABLE();
 						}
 					}
 					memcpy(jp->same, cp2, o2 = n2);
@@ -826,7 +827,7 @@ b_join(int argc, char** argv, Shbltin_t* context)
 #endif
 	if (!(jp = init()))
 	{
-		error(ERROR_system(1),"out of memory");
+		error(ERROR_SYSTEM|ERROR_PANIC,"out of memory");
 		UNREACHABLE();
 	}
 	jp->context = context;

--- a/src/lib/libcmd/paste.c
+++ b/src/lib/libcmd/paste.c
@@ -218,7 +218,7 @@ b_paste(int argc, char** argv, Shbltin_t* context)
 	}
 	if (!(delim = strdup(delim)))
 	{
-		error(ERROR_system(1), "out of memory");
+		error(ERROR_SYSTEM|ERROR_PANIC, "out of memory");
 		UNREACHABLE();
 	}
 	dlen = dsiz = stresc(delim);
@@ -238,7 +238,7 @@ b_paste(int argc, char** argv, Shbltin_t* context)
 			if (!(mp = newof(0, Delim_t, dlen, 0)))
 			{
 				free(delim);
-				error(ERROR_system(1), "out of memory");
+				error(ERROR_SYSTEM|ERROR_PANIC, "out of memory");
 				UNREACHABLE();
 			}
 			cp = delim;
@@ -263,7 +263,7 @@ b_paste(int argc, char** argv, Shbltin_t* context)
 	{
 		if (!(streams = (Sfio_t**)stakalloc(n*sizeof(Sfio_t*))))
 		{
-			error(ERROR_exit(1), "out of memory");
+			error(ERROR_SYSTEM|ERROR_PANIC, "out of memory");
 			UNREACHABLE();
 		}
 		n = 0;

--- a/src/lib/libcmd/rev.c
+++ b/src/lib/libcmd/rev.c
@@ -77,8 +77,8 @@ static int rev_char(Sfio_t *in, Sfio_t *out)
 				w = roundof(n + 1, 1024);
 				if (!(wp = newof(wp, wchar_t, w, 0)))
 				{
-					error(ERROR_SYSTEM|2, "out of memory");
-					return 0;
+					error(ERROR_SYSTEM|ERROR_PANIC, "out of memory");
+					UNREACHABLE();
 				}
 			}
 			xp = wp;

--- a/src/lib/libcmd/tail.c
+++ b/src/lib/libcmd/tail.c
@@ -614,12 +614,15 @@ b_tail(int argc, char** argv, Shbltin_t* context)
 		error(ERROR_warn(0), "--log ignored for --notimeout");
 	}
 	if (error_info.errors)
+	{
 		error(ERROR_usage(2), "%s", optusage(NiL));
+		UNREACHABLE();
+	}
 	if (flags & FOLLOW)
 	{
 		if (!(fp = (Tail_t*)stakalloc(argc * sizeof(Tail_t))))
 		{
-			error(ERROR_system(1), "out of memory");
+			error(ERROR_SYSTEM|ERROR_PANIC, "out of memory");
 			UNREACHABLE();
 		}
 		files = 0;

--- a/src/lib/libcmd/tee.c
+++ b/src/lib/libcmd/tee.c
@@ -197,7 +197,10 @@ b_tee(int argc, register char** argv, Shbltin_t* context)
 			}
 		}
 		else
-			error(ERROR_exit(0), "out of memory");
+		{
+			error(ERROR_SYSTEM|ERROR_PANIC, "out of memory");
+			UNREACHABLE();
+		}
 	}
 	if ((sfmove(sfstdin, sfstdout, SF_UNBOUND, -1) < 0 || !sfeof(sfstdin)) && !ERROR_PIPE(errno) && errno != EINTR)
 		error(ERROR_system(0), "read error");

--- a/src/lib/libcmd/wclib.c
+++ b/src/lib/libcmd/wclib.c
@@ -464,10 +464,7 @@ int wc_count(Wc_t *wp, Sfio_t *fd, const char* file)
 						while(mbc(c) && ((c|WC_ERR) || (c&7)==0)) 
 							c=type[*cp++];
 						if(eol(c) && (cp > endbuff))
-						{
-							c = WC_MB|WC_ERR;
 							goto eob;
-						}
 						if(mbc(c))
 							goto mbyte;
 						else if(c&WC_SP)

--- a/src/lib/libdll/Mamfile
+++ b/src/lib/libdll/Mamfile
@@ -44,8 +44,8 @@ make install
 				exec - esac
 				exec - continue
 				exec - elif test ! -f ${INSTALLROOT}/lib/lib$i.a
-				exec - then case `{ ${CC} ${mam_cc_FLAGS} ${KSH_RELFLAGS} ${CCFLAGS} -L${INSTALLROOT}/lib ${LDFLAGS} -o 1.${COTEMP}.x 1.${COTEMP}.o -l$i 2>&1 || echo '' $x ;} | sed -e 's/[][()+@?]/#/g' || :` in
-				exec - *$x*) case `{ ${CC} ${mam_cc_FLAGS} ${KSH_RELFLAGS} ${CCFLAGS} ${LDFLAGS} -o 1.${COTEMP}.x 1.${COTEMP}.o -l$i 2>&1 || echo '' $x ;} | sed -e 's/[][()+@?]/#/g' || :` in
+				exec - then case `{ ${CC} ${mam_cc_FLAGS} ${KSH_RELFLAGS} ${CCFLAGS} -L${INSTALLROOT}/lib ${LDFLAGS} -o 1.${COTEMP}.x 1.${COTEMP}.o -l$i 2>&1 || echo '' "$x" ;} | sed -e 's/[][()+@?]/#/g' || :` in
+				exec - *$x*) case `{ ${CC} ${mam_cc_FLAGS} ${KSH_RELFLAGS} ${CCFLAGS} ${LDFLAGS} -o 1.${COTEMP}.x 1.${COTEMP}.o -l$i 2>&1 || echo '' "$x" ;} | sed -e 's/[][()+@?]/#/g' || :` in
 				exec - *$x*) continue ;;
 				exec - esac
 				exec - ;;

--- a/src/lib/libsum/Mamfile
+++ b/src/lib/libsum/Mamfile
@@ -44,8 +44,8 @@ make install
 				exec - esac
 				exec - continue
 				exec - elif test ! -f ${INSTALLROOT}/lib/lib$i.a
-				exec - then case `{ ${CC} ${mam_cc_FLAGS} ${KSH_RELFLAGS} ${CCFLAGS} -L${INSTALLROOT}/lib ${LDFLAGS} -o 1.${COTEMP}.x 1.${COTEMP}.o -l$i 2>&1 || echo '' $x ;} | sed -e 's/[][()+@?]/#/g' || :` in
-				exec - *$x*) case `{ ${CC} ${mam_cc_FLAGS} ${KSH_RELFLAGS} ${CCFLAGS} ${LDFLAGS} -o 1.${COTEMP}.x 1.${COTEMP}.o -l$i 2>&1 || echo '' $x ;} | sed -e 's/[][()+@?]/#/g' || :` in
+				exec - then case `{ ${CC} ${mam_cc_FLAGS} ${KSH_RELFLAGS} ${CCFLAGS} -L${INSTALLROOT}/lib ${LDFLAGS} -o 1.${COTEMP}.x 1.${COTEMP}.o -l$i 2>&1 || echo '' "$x" ;} | sed -e 's/[][()+@?]/#/g' || :` in
+				exec - *$x*) case `{ ${CC} ${mam_cc_FLAGS} ${KSH_RELFLAGS} ${CCFLAGS} ${LDFLAGS} -o 1.${COTEMP}.x 1.${COTEMP}.o -l$i 2>&1 || echo '' "$x" ;} | sed -e 's/[][()+@?]/#/g' || :` in
 				exec - *$x*) continue ;;
 				exec - esac
 				exec - ;;


### PR DESCRIPTION
Extensive list of changes in this pull request:
- Fixed some `-Wuninitialized` warnings and removed some unused variables.
- Removed the unused extern for `B_login` (re: d8eba9d1).
- The libcmd builtins and the vmalloc `memfatal` function now handle memory errors with `ERROR_SYSTEM|ERROR_PANIC` for consistency with how ksh itself handles out of memory errors.
- Added usage of `UNREACHABLE()` where it was missing from error handling.
- Extend many variables from `short` to `int` to prevent overflows (most variables involve file descriptors).
- Backported a ksh2020 patch to fix unused value Coverity issues (https://github.com/att/ast/pull/740).
- Note in src/cmd/ksh93/README that ksh compiles with Cygwin on Windows 10 and Windows 11, albeit with many test failures.
- Added comments to detail some sections of code. Extensive list of commits related to this change:
  ca2443b5, 7e7f1372, 2db9953a, 7003aba4, 6f50ff64, b1a41311,
  222515bf, a0dcdeea, 0aa9e03f, 61437b27, 352e68da, 88e8fa67,
  bc8b36fa, 6e515f1d, 017d088c, 035a4cb3, 588a1ff7, 6d63b57d,
  a2f13c19, 794d1c86, ab98ec65, 1026006d
- Removed a lot of dead ifdef code.
- edit/emacs.c: Hide an assignment to avoid a `-Wunused` warning. (See also https://github.com/att/ast/pull/753, which removed the assignment because ksh2020 removed the `!SHOPT_MULTIBYTE` code.)
- sh/nvdisc.c: The `sh_newof` macro cannot return a null pointer because it will instead cause the shell to exit if memory cannot be allocated. That makes the `if` statement here a no-op, so remove it.
- sh/xec.c: Fixed one unused variable warning in `sh_funscope()`.
- sh/xec.c: Remove a fallthrough comment added in commit ed478ab7 because the `TFORK` code doesn't fall through (GCC also produces no `-Wimplicit-fallthrough` warning here).
- Mamfiles: Preserve multi-line errors by quoting the `$x` variable. This fix was backported from 93v-. (See also <https://github.com/lkujaw/ast/commit/a7e9cc82>.)
- data/builtins.c: The `cd` and `pwd` man pages state that these builtins default to `-P` if  `PATH_RESOLVE` is 'physical', which isn't accurate. As that behavior isn't specified in the ksh man page or by POSIX, the inaccurate PATH_RESOLVE information has been removed. Example showing `PATH_RESOLVE` has no effect on `cd` and `pwd`:
```sh
$ /opt/ast/bin/getconf PATH_RESOLVE
physical
$ mkdir /tmp/dir; ln -s /tmp/dir /tmp/sym
$ cd /tmp/sym
$ pwd
/tmp/sym
$ cd -P /tmp/sym
$ pwd
/tmp/dir
```