### PR TITLE
Minor improvements to the regression tests

### DIFF
--- a/src/cmd/ksh93/tests/basic.sh
+++ b/src/cmd/ksh93/tests/basic.sh
@@ -832,7 +832,7 @@ actual=$($SHELL --verson 2>&1)
 actual_status=$?
 expect='ksh: verson: bad option(s)'
 expect_status=2
-[[ "$actual" == ${expect}* ]] || err_exit "failed to get version string" \
+[[ "$actual" == *${expect}* ]] || err_exit "failed to handle invalid flag" \
 	"(expected $(printf %q ${expect}*), got $(printf %q "$actual"))"
 [[ $actual_status == $expect_status ]] ||
 	err_exit "wrong exit status (expected '$expect_status', got '$actual_status')"

--- a/src/cmd/ksh93/tests/builtins.sh
+++ b/src/cmd/ksh93/tests/builtins.sh
@@ -1031,22 +1031,25 @@ EOF
 
 # ======
 # Builtins should handle unrecognized options correctly
-while IFS= read -r bltin <&3
-do	case $bltin in
-	echo | test | true | false | \[ | : | getconf | */getconf | uname | */uname | catclose | catgets | catopen | Dt* | _Dt* | X* | login | newgrp )
-		continue ;;
-	/*/*)	expect="Usage: ${bltin##*/} "
-		actual=$({ PATH=${bltin%/*}; "${bltin##*/}" --this-option-does-not-exist; } 2>&1) ;;
-	*/*)	err_exit "strange path name in 'builtin' output: $(printf %q "$bltin")"
-		continue ;;
-	autoload | compound | float | functions | integer | nameref)
-		bltin=typeset ;&
-	*)	expect="Usage: $bltin "
-		actual=$({ "${bltin}" --this-option-does-not-exist; } 2>&1) ;;
-	esac
-	[[ $actual == *"$expect"* ]] || err_exit "$bltin should show usage info on unrecognized options" \
-			"(expected string containing $(printf %q "$expect"), got $(printf %q "$actual"))"
-done 3< <(builtin)
+function test_usage
+{
+	while IFS= read -r bltin <&3
+	do	case $bltin in
+		echo | test | true | false | \[ | : | expr | */expr | getconf | */getconf | uname | */uname | catclose | catgets | catopen | Dt* | _Dt* | X* | login | newgrp )
+			continue ;;
+		/*/*)	expect="Usage: ${bltin##*/} "
+			actual=$({ PATH=${bltin%/*}; "${bltin##*/}" --this-option-does-not-exist; } 2>&1) ;;
+		*/*)	err_exit "strange path name in 'builtin' output: $(printf %q "$bltin")"
+			continue ;;
+		autoload | compound | float | functions | integer | nameref)
+			bltin=typeset ;&
+		*)	expect="Usage: $bltin "
+			actual=$({ "${bltin}" --this-option-does-not-exist; } 2>&1) ;;
+		esac
+		[[ $actual == *"$expect"* ]] || err_exit "$bltin should show usage info on unrecognized options" \
+				"(expected string containing $(printf %q "$expect"), got $(printf %q "$actual"))"
+	done 3< <(builtin)
+}; test_usage
 
 # ======
 # The 'alarm' builtin could make 'read' crash due to IFS table corruption caused by unsafe asynchronous execution.

--- a/src/cmd/ksh93/tests/io.sh
+++ b/src/cmd/ksh93/tests/io.sh
@@ -241,7 +241,12 @@ then	[[ $(3<#) -eq 0 ]] || err_exit "not at position 0"
 	read -u3 && err_exit "not found pattern not positioning at eof"
 	cat $tmp/seek | read -r <# *WWW*
 	[[ $REPLY == *WWWWW* ]] || err_exit '<# not working for pipes'
-	{ < $tmp/seek <# ((2358336120)) ;} 2> /dev/null || err_exit 'long seek not working'
+	# The next test seeks past a 2 GiB boundary, which may fail on 32-bit systems. To prevent
+	# a test failure, the long seek test is only run on 64-bit systems.
+	# https://github.com/att/ast/commit/a5c692e1bd0d800e3f19be249d3170e69cbe001d
+	if [[ $(builtin getconf 2> /dev/null; getconf LONG_BIT 2>&1) == 64 ]]; then
+		{ < $tmp/seek <# ((2358336120)) ;} 2> /dev/null || err_exit 'long seek not working'
+	fi
 else	err_exit "$tmp/seek: cannot open for reading"
 fi
 redirect 3<&- || 'cannot close 3'

--- a/src/cmd/ksh93/tests/substring.sh
+++ b/src/cmd/ksh93/tests/substring.sh
@@ -681,4 +681,8 @@ exit $Errors
 Errors=$?
 
 # ======
+# Test for a crash after unsetting ${.sh.match} then matching a pattern
+$SHELL -c 'unset .sh.match; [[ bar == ba* ]]' || err_exit 'crash after unsetting .sh.match then trying to match a pattern'
+
+# ======
 exit $((Errors<125?Errors:125))


### PR DESCRIPTION
- tests/basic.sh: Fix a regression test that was failing under `dtksh` by allowing the error message to name ksh `lt-dtksh`. Additionally, fix the test's inaccurate failure message (a version string is not what the regression test expects).

- test/builtins.sh: Exclude the `expr` builtin from the unrecognized options test because it's incompatible. Additionally, put the unrecognized options test inside of a function to ensure that it works with the future `local` builtin (https://github.com/ksh93/ksh/issues/123).

- tests/io.sh: The long seek test may fail to seek past the 2 GiB boundary on 32-bit systems, so only allow it to run on 64-bit. References:
  https://src.fedoraproject.org/rpms/ksh/blob/3222ac2b59c042bb60413bdc53e2301b7ecc1555/f/ksh-1.0.0-beta.1-regre-tests.patch
  https://github.com/att/ast/commit/a5c692e1bd0d800e3f19be249d3170e69cbe001d

- tests/substring.sh: Add a regression test for the `${.sh.match}` crashing bug fixed in commit 1bf1d2f8.