### PR TITLE
Further robustify .get and .set discipline functions

### DIFF
--- a/src/cmd/ksh93/Mamfile
+++ b/src/cmd/ksh93/Mamfile
@@ -669,6 +669,8 @@ make install
 			done main.o generated
 			make nvdisc.o
 				make sh/nvdisc.c
+					prev include/shlex.h implicit
+					prev include/io.h implicit
 					prev include/path.h implicit
 					prev include/builtins.h implicit
 					prev include/variables.h implicit

--- a/src/cmd/ksh93/sh/io.c
+++ b/src/cmd/ksh93/sh/io.c
@@ -2186,8 +2186,15 @@ static int	io_prompt(Shell_t *shp,Sfio_t *iop,register int flag)
 			goto done;
 		}
 		case 2:
+		{
+			/* PS2 prompt. Save stack state to avoid corrupting command substitutions
+			 * in case we're executing a PS2.get discipline function at parse time. */
+			int	savestacktop = staktell();
+			char	*savestackptr = stakfreeze(0);
 			cp = nv_getval(sh_scoped(shp,PS2NOD));
+			stakset(savestackptr, savestacktop);
 			break;
+		}
 		case 3:
 			cp = nv_getval(sh_scoped(shp,PS3NOD));
 			break;

--- a/src/cmd/ksh93/tests/pty.sh
+++ b/src/cmd/ksh93/tests/pty.sh
@@ -907,5 +907,27 @@ w true); echo "Exit status is $?"
 u Exit status is 0
 !
 
+# err_exit #
+tst $LINENO <<"!"
+L interrupted PS2 discipline function
+# https://github.com/ksh93/ksh/issues/347
+
+d 15
+p :test-1:
+w PS2.get() { trap --bad-option 2>/dev/null; .sh.value="NOT REACHED"; }
+p :test-2:
+w echo \$\(
+r :test-2: echo \$\(
+w echo one \\
+r > echo one \\
+w two three
+r > two three
+w echo end
+r > echo end
+w \)
+r > \)
+r one two three end
+!
+
 # ======
 exit $((Errors<125?Errors:125))


### PR DESCRIPTION
This should fix various crashes that remain, at least:
* when running a PS2 discipline at parse time
* when pressing Ctrl+C on a PS2 prompt
* when a special builtin within a discipline throws an error within a virtual subshell

src/cmd/ksh93/sh/nvdisc.c:
- In both assign() which handles .set disciplines and lookup() which handles .get disciplines, to stop errors in discipline functions from wreaking havoc:
  - Save, reinitialise and restore the lexer state in case the discipline is run at parse time. This happens with PS2; I'm not currently aware of other contexts but that doesn't mean there aren't any or that there won't be any. Plus, I determined by experimenting that doing this here seems to be the only way to make it work reliably. Thankfully the overhead is low.
  - Check the topfd redirection state and run sh_iorestore() if needed. Without this, if a special builtin with a redirection throws an error in a discipline function, its redirection(s) remain permanent. For example, `trap --bad-option 2>/dev/null` in a PS2.get() discipline would kill standard error, including all your prompts.

src/cmd/ksh93/sh/io.c: io_prompt():
- Before getting the value of the PS2 prompt, save the stack state and restore it after. This stops a PS2.get discipline function from corrupting a command substitution that the user is typing. Doing this in assign()/lookup() is ineffective, so do it here.

Fixes: https://github.com/ksh93/ksh/issues/347