### PR TITLE
Include <string.h> in "mmap is worth using" test

### DIFF
--- a/src/lib/libast/features/mmap
+++ b/src/lib/libast/features/mmap
@@ -219,7 +219,7 @@ tst	mmap_devzero note{ use mmap on /dev/zero to get raw memory }end execute{
 	}
 }end
 
-tst	note{ mmap is worth using }end output{
+tst	note{ mmap is fast enough to be worth using }end output{
 	#if !_lib_mmap
 	(
 	#endif

--- a/src/lib/libast/features/mmap
+++ b/src/lib/libast/features/mmap
@@ -225,6 +225,7 @@ tst	note{ mmap is worth using }end output{
 	#endif
 	#include <unistd.h>
 	#include <fcntl.h>
+	#include <string.h>
 	#include <sys/types.h>
 	#include <sys/mman.h>
 	#include <sys/stat.h>


### PR DESCRIPTION
@McDutchie mentioned in #373 that:

> The '[mmap is worth using](https://github.com/ksh93/ksh/blob/dfb699b5caeac31494886de5fe0151bd7456446a/src/lib/libast/features/mmap#L222-L324)' test returns negative on macOS for some reason – at least macOS 10.14.6 x86_64. (sigh)

It looks like there are two reasons. First, it uses the `memcpy` function but doesn't `#include <string.h>` where that function is declared. Implicit declaration of functions is an error as of Xcode 12.

```
iffe: test: mmap is worth using ...
./unti77022.c:101:12: warning: using the result of an assignment as a condition without parentheses [-Wparentheses]
        while (*t = *f++)
               ~~~^~~~~~
./unti77022.c:101:12: note: place parentheses around the assignment to silence this warning
        while (*t = *f++)
                  ^
               (        )
./unti77022.c:101:12: note: use '==' to turn this assignment into an equality comparison
        while (*t = *f++)
                  ^
                  ==
./unti77022.c:149:5: error: implicitly declaring library function 'memcpy' with type 'void *(void *, const void *, unsigned long)' [-Werror,-Wimplicit-function-declaration]
                                memcpy(buf,t,(3*BUFSIZE)/4);
                                ^
./unti77022.c:149:5: note: include the header <string.h> or explicitly provide a declaration for 'memcpy'
1 warning and 1 error generated.
iffe: ... no
```

Once that's fixed, it still says (at least on my 2016 MacBook Pro with macOS Catalina) that `mmap` is not worth using, but at least now that determination is based on running the test, rather than on not being able to compile and run the test.

The test seems to time using `mmap` and another method and only picks `mmap` if it's faster. Editing the test to print out timing information on a few runs, I see that `mmap` is 2–3✕ slower than the other method:

```
$ for i in $(seq 1 5); do ./mmap_worth_using; done
/* mmtm=11 rdtm=3 */
/* 4*mmtm=44 3*rdtm=9 */
/* 4*mmtm=44 5*rdtm=15 */
/* mmtm=9 rdtm=5 */
/* 4*mmtm=36 3*rdtm=15 */
/* 4*mmtm=36 5*rdtm=25 */
/* mmtm=10 rdtm=4 */
/* 4*mmtm=40 3*rdtm=12 */
/* 4*mmtm=40 5*rdtm=20 */
/* mmtm=12 rdtm=4 */
/* 4*mmtm=48 3*rdtm=12 */
/* 4*mmtm=48 5*rdtm=20 */
/* mmtm=12 rdtm=4 */
/* 4*mmtm=48 3*rdtm=12 */
/* 4*mmtm=48 5*rdtm=20 */
```