### PR TITLE
Include <unistd.h> in "fd is * arg to poll" tests

### DIFF
--- a/src/lib/libast/features/lib
+++ b/src/lib/libast/features/lib
@@ -75,6 +75,7 @@ tst	tst_errno note{ errno can be assigned }end link{
 
 tst	lib_poll_fd_1 note{ fd is first arg to poll() }end execute{
 	#include <poll.h>
+	#include <unistd.h>
 	_BEGIN_EXTERNS_
 	extern int	pipe _ARG_((int*));
 	_END_EXTERNS_
@@ -95,6 +96,7 @@ tst	lib_poll_fd_1 note{ fd is first arg to poll() }end execute{
 
 tst	lib_poll_fd_2 note{ fd is second arg to poll() }end execute{
 	#include <poll.h>
+	#include <unistd.h>
 	_BEGIN_EXTERNS_
 	extern int	pipe _ARG_((int*));
 	_END_EXTERNS_


### PR DESCRIPTION
The test that tries to determine whether `fd` is the first or second argument to `poll()` fails on macOS Catalina, not because `poll` doesn't have what it's looking for, but because it forgot to `#include <unistd.h>` for `write`:

```
iffe: test: fd is first arg to poll() ...
./unti69875.c:212:6: error: implicit declaration of function 'write' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
        if (write(rw[1], "x", 1) != 1) return 1;
            ^
./unti69875.c:212:6: note: did you mean 'fwrite'?
/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/usr/include/stdio.h:165:9: note: 'fwrite' declared here
size_t   fwrite(const void * __restrict __ptr, size_t __size, size_t __nitems, FILE * __restrict __stream) __DARWIN_ALIAS(fwrite);
         ^
1 error generated.
iffe: ... no
iffe: test: fd is second arg to poll() ...
./unti69875.c:211:14: warning: incompatible integer to pointer conversion passing 'int' to parameter of type 'struct pollfd *' [-Wint-conversion]
        return poll(1, &fd, 0) < 0;
                    ^
/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/usr/include/sys/poll.h:113:32: note: passing argument to parameter here
extern int poll(struct pollfd *, nfds_t, int) __DARWIN_ALIAS_C(poll);
                               ^
./unti69875.c:211:17: warning: incompatible pointer to integer conversion passing 'struct pollfd *' to parameter of type 'nfds_t' (aka 'unsigned int') [-Wint-conversion]
        return poll(1, &fd, 0) < 0;
                       ^~~
/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/usr/include/sys/poll.h:113:40: note: passing argument to parameter here
extern int poll(struct pollfd *, nfds_t, int) __DARWIN_ALIAS_C(poll);
                                       ^
./unti69875.c:212:11: warning: incompatible integer to pointer conversion passing 'int' to parameter of type 'struct pollfd *' [-Wint-conversion]
        if (poll(1, &fd, 0) < 0 || fd.revents != 0) return 1;
                 ^
/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/usr/include/sys/poll.h:113:32: note: passing argument to parameter here
extern int poll(struct pollfd *, nfds_t, int) __DARWIN_ALIAS_C(poll);
                               ^
./unti69875.c:212:14: warning: incompatible pointer to integer conversion passing 'struct pollfd *' to parameter of type 'nfds_t' (aka 'unsigned int') [-Wint-conversion]
        if (poll(1, &fd, 0) < 0 || fd.revents != 0) return 1;
                    ^~~
/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/usr/include/sys/poll.h:113:40: note: passing argument to parameter here
extern int poll(struct pollfd *, nfds_t, int) __DARWIN_ALIAS_C(poll);
                                       ^
./unti69875.c:213:6: error: implicit declaration of function 'write' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
        if (write(rw[1], "x", 1) != 1) return 1;
            ^
./unti69875.c:213:6: note: did you mean 'fwrite'?
/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/usr/include/stdio.h:165:9: note: 'fwrite' declared here
size_t   fwrite(const void * __restrict __ptr, size_t __size, size_t __nitems, FILE * __restrict __stream) __DARWIN_ALIAS(fwrite);
         ^
./unti69875.c:214:11: warning: incompatible integer to pointer conversion passing 'int' to parameter of type 'struct pollfd *' [-Wint-conversion]
        if (poll(1, &fd, 0) < 0 || fd.revents == 0) return 1;
                 ^
/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/usr/include/sys/poll.h:113:32: note: passing argument to parameter here
extern int poll(struct pollfd *, nfds_t, int) __DARWIN_ALIAS_C(poll);
                               ^
./unti69875.c:214:14: warning: incompatible pointer to integer conversion passing 'struct pollfd *' to parameter of type 'nfds_t' (aka 'unsigned int') [-Wint-conversion]
        if (poll(1, &fd, 0) < 0 || fd.revents == 0) return 1;
                    ^~~
/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/usr/include/sys/poll.h:113:40: note: passing argument to parameter here
extern int poll(struct pollfd *, nfds_t, int) __DARWIN_ALIAS_C(poll);
                                       ^
6 warnings and 1 error generated.
iffe: ... no
iffe: test: is _lib_poll_fd_1||_lib_poll_fd_2 true ...
iffe: ... no
```

As of Xcode 12, implicit declaration of functions is an error.

After fixing this by including the right header, the test is able to determine that `fd` is in fact the first argument of `poll()` on my system:

```
iffe: test: fd is first arg to poll() ...
iffe: ... yes
iffe: test: fd is second arg to poll() ...
iffe: ... no
iffe: test: is _lib_poll_fd_1||_lib_poll_fd_2 true ...
iffe: ... yes
```