### PR TITLE
Fix buggy `bin/package environment` behavior

### DIFF
--- a/bin/package
+++ b/bin/package
@@ -5628,9 +5628,9 @@ make|view)
 				$t*)	;;
 				$b*)	cc=$b
 					;;
-				$s*)	cd $INSTALLROOT/lib/package/gen
+				$s*)	$exec cd $INSTALLROOT/lib/package/gen
 					tmp=pkg$$
-					eval '$'exec echo "'int main(){return 0;}' > $tmp.c"
+					$exec eval "echo 'int main(){return 0;}' > $tmp.c"
 					if	$exec $s -o $tmp.exe $tmp.c >/dev/null 2>&1 &&
 						test -x $tmp.exe
 					then	case $HOSTTYPE in
@@ -5863,7 +5863,7 @@ cat $j $k
 				echo "$command: $var changed from $old to $new" >&2
 				err=y ;;
 			esac
-		else	case $new in
+		else	[ -d $INSTALLROOT/lib/package/gen ] && case $new in
 			'')	;;
 			*)	echo "$new" ;;
 			esac > $store
@@ -5882,7 +5882,7 @@ cat $j $k
 
 	# record the build host name
 
-	case $noexec in
+	case $exec in
 	'')	hostinfo name
 		echo "$_hostinfo_" | sed 's,\..*,,' > $PACKAGEBIN/gen/host
 		;;

--- a/bin/package
+++ b/bin/package
@@ -5863,7 +5863,7 @@ cat $j $k
 				echo "$command: $var changed from $old to $new" >&2
 				err=y ;;
 			esac
-		else	[ -d $INSTALLROOT/lib/package/gen ] && case $new in
+		else	test -d $INSTALLROOT/lib/package/gen && case $new in
 			'')	;;
 			*)	echo "$new" ;;
 			esac > $store

--- a/src/cmd/INIT/package.sh
+++ b/src/cmd/INIT/package.sh
@@ -5628,9 +5628,9 @@ make|view)
 				$t*)	;;
 				$b*)	cc=$b
 					;;
-				$s*)	cd $INSTALLROOT/lib/package/gen
+				$s*)	$exec cd $INSTALLROOT/lib/package/gen
 					tmp=pkg$$
-					eval '$'exec echo "'int main(){return 0;}' > $tmp.c"
+					$exec eval "echo 'int main(){return 0;}' > $tmp.c"
 					if	$exec $s -o $tmp.exe $tmp.c >/dev/null 2>&1 &&
 						test -x $tmp.exe
 					then	case $HOSTTYPE in
@@ -5863,7 +5863,7 @@ cat $j $k
 				echo "$command: $var changed from $old to $new" >&2
 				err=y ;;
 			esac
-		else	case $new in
+		else	[ -d $INSTALLROOT/lib/package/gen ] && case $new in
 			'')	;;
 			*)	echo "$new" ;;
 			esac > $store
@@ -5882,7 +5882,7 @@ cat $j $k
 
 	# record the build host name
 
-	case $noexec in
+	case $exec in
 	'')	hostinfo name
 		echo "$_hostinfo_" | sed 's,\..*,,' > $PACKAGEBIN/gen/host
 		;;

--- a/src/cmd/INIT/package.sh
+++ b/src/cmd/INIT/package.sh
@@ -5863,7 +5863,7 @@ cat $j $k
 				echo "$command: $var changed from $old to $new" >&2
 				err=y ;;
 			esac
-		else	[ -d $INSTALLROOT/lib/package/gen ] && case $new in
+		else	test -d $INSTALLROOT/lib/package/gen && case $new in
 			'')	;;
 			*)	echo "$new" ;;
 			esac > $store


### PR DESCRIPTION
Running `bin/package environment` should only show what will happen during the build process, but in its current state the feature has some bugs:

1. Errors can occur relating to the failed creation of files and a failed attempt to change the directory. Various errors from `bin/package environment make` and `bin/package environment make CC=tcc`:
```
bin/package[5632]: cd: /home/johno/GitRepos/KornShell/ksh/arch/linux.i386-64/lib/package/gen: [No such file or directory]
bin/package: line 5869: /home/johno/GitRepos/KornShell/ksh/arch/linux.i386-64/lib/package/gen/CC: cannot create [No such file or directory]
bin/package: line 5869: /home/johno/GitRepos/KornShell/ksh/arch/linux.i386-64/lib/package/gen/CCFLAGS: cannot create [No such file or directory]
bin/package: line 5869: /home/johno/GitRepos/KornShell/ksh/arch/linux.i386-64/lib/package/gen/CCLDFLAGS: cannot create [No such file or directory]
bin/package: line 5869: /home/johno/GitRepos/KornShell/ksh/arch/linux.i386-64/lib/package/gen/LDFLAGS: cannot create [No such file or directory]
bin/package: line 5869: /home/johno/GitRepos/KornShell/ksh/arch/linux.i386-64/lib/package/gen/KSH_RELFLAGS: cannot create [No such file or directory]
bin/package[5888]: /home/johno/GitRepos/KornShell/ksh/arch/linux.i386-64/lib/package/gen/host: cannot create [No such file or directory]
```
2. The `package` script may in some scenarios create a temporary file at the root of the repository, such as `pkg77213.c`.

bin/package + src/cmd/INIT/package.sh:
\- Avoid creating files or changing the directory while the `environment` qualifier is on (this also affects the `debug` qualifier). Part of this fix is based on a patch from Marcin Cieślak (https://repo.or.cz/INIT.git/commit/9e0ad0d6), with other fixes applied for similar problems the environment qualifier had.