### PR TITLE
Backport ksh93v- bugfix for `[[ 1<2 ]]`

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -10,6 +10,9 @@ Any uppercase BUG_* names are modernish shell bug IDs.
   a subshell. Types can now safely be defined in subshells and defined
   conditionally as in 'if condition; then enum ...; fi'.
 
+- Single digits can now be compared lexically in [[ ... ]] with the
+  < and > operators.
+
 2021-12-16:
 
 - Changed the default selection of compiled-in /opt/ast/bin built-in libcmd

--- a/src/cmd/ksh93/sh/lex.c
+++ b/src/cmd/ksh93/sh/lex.c
@@ -1264,7 +1264,7 @@ breakloop:
 	{
 		/* check for numbered redirection */
 		n = state[0];
-		if((c=='<' || c=='>') && isadigit(n))
+		if(!lp->lex.intest && (c=='<' || c=='>') && isadigit(n))
 		{
 			c = sh_lex(lp);
 			lp->digits = (n-'0'); 

--- a/src/cmd/ksh93/tests/bracket.sh
+++ b/src/cmd/ksh93/tests/bracket.sh
@@ -462,4 +462,58 @@ do	e=${c%%:*}
 done
 
 # ======
+# [[ ... ]] shouldn't error out when using '>' and '<' with or without a
+# space in between strings (including when a number is handled as a string).
+exp=0
+$SHELL -c '[[ 3>2 ]]'; got=$?
+((exp == got)) || err_exit "[[ ... ]] cannot handle '3>2'" \
+	"(expected $exp, got $got)"
+$SHELL -c '[[ 3 > 2 ]]'; got=$?
+((exp == got)) || err_exit "[[ ... ]] cannot handle '3 > 2'" \
+	"(expected $exp, got $got)"
+$SHELL -c '[[ 1<2 ]]'; got=$?
+((exp == got)) || err_exit "[[ ... ]] cannot handle '1<2'" \
+	"(expected $exp, got $got)"
+$SHELL -c '[[ 1 < 2 ]]'; got=$?
+((exp == got)) || err_exit "[[ ... ]] cannot handle '1 < 2'" \
+	"(expected $exp, got $got)"
+$SHELL -c '[[ a<b ]]'; got=$?
+((exp == got)) || err_exit "[[ ... ]] cannot handle 'a<b'" \
+	"(expected $exp, got $got)"
+$SHELL -c '[[ a < b ]]'; got=$?
+((exp == got)) || err_exit "[[ ... ]] cannot handle 'a < b'" \
+	"(expected $exp, got $got)"
+$SHELL -c '[[ c>b ]]'; got=$?
+((exp == got)) || err_exit "[[ ... ]] cannot handle 'c>b'" \
+	"(expected $exp, got $got)"
+$SHELL -c '[[ c > b ]]'; got=$?
+((exp == got)) || err_exit "[[ ... ]] cannot handle 'c > b'" \
+	"(expected $exp, got $got)"
+exp=1
+$SHELL -c '[[ 3<2 ]]' || got=$?
+((exp == got )) || err_exit "[[ ... ]] cannot handle '3<2'" \
+	"(expected $exp, got $got)"
+$SHELL -c '[[ 3 < 2 ]]' || got=$?
+((exp == got )) || err_exit "[[ ... ]] cannot handle '3 < 2'" \
+	"(expected $exp, got $got)"
+$SHELL -c '[[ 1>2 ]]'; got=$?
+((exp == got )) || err_exit "[[ ... ]] cannot handle '1>2'" \
+	"(expected $exp, got $got)"
+$SHELL -c '[[ 1 > 2 ]]'; got=$?
+((exp == got )) || err_exit "[[ ... ]] cannot handle '1 > 2'" \
+	"(expected $exp, got $got)"
+$SHELL -c '[[ a>b ]]'; got=$?
+((exp == got)) || err_exit "[[ ... ]] cannot handle 'a>b'" \
+	"(expected $exp, got $got)"
+$SHELL -c '[[ a > b ]]'; got=$?
+((exp == got)) || err_exit "[[ ... ]] cannot handle 'a > b'" \
+	"(expected $exp, got $got)"
+$SHELL -c '[[ c<b ]]'; got=$?
+((exp == got)) || err_exit "[[ ... ]] cannot handle 'c<b'" \
+	"(expected $exp, got $got)"
+$SHELL -c '[[ c < b ]]'; got=$?
+((exp == got)) || err_exit "[[ ... ]] cannot handle 'c < b'" \
+	"(expected $exp, got $got)"
+
+# ======
 exit $((Errors<125?Errors:125))


### PR DESCRIPTION
Strings compared in `[[ ... ]]` with the `>` and `<` operators should be compared lexically. This does not work when the strings are single digits, as the parser interprets it as a syntax error:
```sh
$ [[ 10<2 ]]   # 10 lexically sorts before 2
$ echo $?
0
$ [[ 1<2 ]]
/usr/bin/ksh: syntax error: `<' unexpected
$ echo $?
3
```

src/cmd/ksh93/sh/lex.c:
\- Don't interpret numbers next to `>` and `<` as a redirection while inside of `[[ ... ]]`. This bugfix was backported from ksh93v- 2014-06-25.

src/cmd/ksh93/tests/bracket.sh:
\- Add regression tests for the `>` and `<` operators.