### PR TITLE
Fix yet more minor bugs related to the regression tests

### DIFF
--- a/src/cmd/ksh93/tests/builtins.sh
+++ b/src/cmd/ksh93/tests/builtins.sh
@@ -31,7 +31,7 @@ bad_result=$(getconf --version 2>&1)
 
 # The -l option should convert all variable names to lowercase.
 # https://github.com/att/ast/issues/1171
-got=$(getconf -l | awk '{ gsub(/=.*/, "") } /[[:upper:]]/ { print }')
+got=$(getconf -lq | awk '{ gsub(/=.*/, "") } /[[:upper:]]/ { print }')
 [[ -n $got ]] && err_exit "'getconf -l' doesn't convert all variable names to lowercase" \
 	"(got $(printf %q "$got"))"
 
@@ -1363,9 +1363,10 @@ fi
 
 # ======
 # These are regression tests for the cd command's -e and -P flags
-mkdir -p "$tmp/failpwd1"
+mkdir -p "$tmp/failpwd"
+ln -s "$tmp/failpwd" "$tmp/failpwd1"
 cd "$tmp/failpwd1"
-rmdir ../failpwd1
+rm ../failpwd1
 cd -P .
 got=$?; exp=0
 (( got == exp )) || err_exit "cd -P without -e exits with error status if \$PWD doesn't exist (expected $exp, got $got)"

--- a/src/cmd/ksh93/tests/types.sh
+++ b/src/cmd/ksh93/tests/types.sh
@@ -125,9 +125,9 @@ X_t x
 [[ ${x.s} == ${x.x} ]] || err_exit 'x.s should be x.x'
 typeset -T Y_t=( X_t r )
 Y_t z
-[[ ${z.r.x} == foo ]] || err_exit 'z.r.x should be foo'
-[[ ${z.r.y} == bam ]] || err_exit 'z.r.y should be bam'
-[[ ${z.r.s} == ${z.r.x} ]] || err_exit 'z.r.s should be z.r.x'
+[[ ${z.r.x} == foo ]] || err_exit "z.r.x should be foo (got $(printf %q "${z.r.x}"))"
+[[ ${z.r.y} == bam ]] || err_exit "z.r.y should be bam (got $(printf %q "${z.r.y}"))"
+[[ ${z.r.s} == ${z.r.x} ]] || err_exit "z.r.s should be z.r.x (expected $(printf %q "${z.r.x}"), got $(printf %q "${z.r.s}"))"
 
 unset xx yy
 typeset -T xx=(typeset yy=zz)

--- a/src/cmd/ksh93/tests/variables.sh
+++ b/src/cmd/ksh93/tests/variables.sh
@@ -100,16 +100,16 @@ done
 [[ $got == "$exp" ]] || err_exit 'Using $RANDOM in subshell influences reproducible sequence in parent environment' \
 	"(expected $(printf %q "$exp"), got $(printf %q "$got"))"
 # Forking a subshell shouldn't throw away the $RANDOM seed in the main shell
-exp=$(ulimit -t unlimited; RANDOM=123; echo $RANDOM)
+exp=$(ulimit -t unlimited 2> /dev/null; RANDOM=123; echo $RANDOM)
 RANDOM=123
-(ulimit -t unlimited; true)
+(ulimit -t unlimited 2> /dev/null; true)
 got=${ echo $RANDOM ;}
 [[ $got == "$exp" ]] || err_exit "Forking a subshell resets the parent shell's \$RANDOM seed" \
 	"(expected $(printf %q "$exp"), got $(printf %q "$got"))"
 # Similarly, forking a subshell shouldn't throw away a seed
 # previously set inside of the subshell
-exp=$(ulimit -t unlimited; RANDOM=789; echo $RANDOM)
-got=$(RANDOM=789; ulimit -t unlimited; echo $RANDOM)
+exp=$(ulimit -t unlimited 2> /dev/null; RANDOM=789; echo $RANDOM)
+got=$(RANDOM=789; ulimit -t unlimited 2> /dev/null; echo $RANDOM)
 [[ $got == "$exp" ]] || err_exit "Forking a subshell resets the subshell's \$RANDOM seed" \
 	"(expected $(printf %q "$exp"), got $(printf %q "$got"))"
 unset N i rand1 rand2

--- a/src/lib/libast/port/astconf.c
+++ b/src/lib/libast/port/astconf.c
@@ -1664,7 +1664,7 @@ astconflist(Sfio_t* sp, const char* path, int flags, const char* pattern)
 						sfprintf(sp, "%*s %*s %d %2s %4d %5s %s\n", sizeof(conf[0].name), f, sizeof(prefix[look.standard].name), prefix[look.standard].name, look.section, call, 0, "N", s);
 					}
 					else if (flags & ASTCONF_parse)
-						sfprintf(sp, "%s %s - %s\n", state.id, (flags & ASTCONF_lower) ? fmtlower(f) : f, fmtquote(s, "\"", "\"", strlen(s), FMT_SHELL|FMT_ALWAYS));
+						sfprintf(sp, "%s %s - %s\n", state.id, (flags & ASTCONF_lower) ? fmtlower(f) : f, (flags & ASTCONF_quote) ? fmtquote(s, "\"", "\"", strlen(s), FMT_SHELL|FMT_ALWAYS) : s);
 					else
 						sfprintf(sp, "%s=%s\n", (flags & ASTCONF_lower) ? fmtlower(f) : f, (flags & ASTCONF_quote) ? fmtquote(s, "\"", "\"", strlen(s), FMT_SHELL|FMT_ALWAYS) : s);
 				}
@@ -1712,7 +1712,7 @@ astconflist(Sfio_t* sp, const char* path, int flags, const char* pattern)
 				sfprintf(sp, "%*s %*s %d %2s %4d %5s %s\n", sizeof(conf[0].name), fp->name, sizeof(prefix[fp->standard].name), prefix[fp->standard].name, 1, call, 0, flg, s);
 			}
 			else if (flags & ASTCONF_parse)
-				sfprintf(sp, "%s %s - %s\n", state.id, (flags & ASTCONF_lower) ? fmtlower(fp->name) : fp->name, fmtquote(s, "\"", "\"", strlen(s), FMT_SHELL|FMT_ALWAYS));
+				sfprintf(sp, "%s %s - %s\n", state.id, (flags & ASTCONF_lower) ? fmtlower(fp->name) : fp->name, (flags & ASTCONF_quote) ? fmtquote(s, "\"", "\"", strlen(s), FMT_SHELL|FMT_ALWAYS) : s);
 			else
 				sfprintf(sp, "%s=%s\n", (flags & ASTCONF_lower) ? fmtlower(fp->name) : fp->name, (flags & ASTCONF_quote) ? fmtquote(s, "\"", "\"", strlen(s), FMT_SHELL|FMT_ALWAYS) : s);
 		}


### PR DESCRIPTION
Changes:
\- Redirect error output from the `ulimit` builtin (re: 3e58851f).
\- Improved the error messages from some tests in types.sh that may intermittently fail (https://github.com/ksh93/ksh/issues/344#issuecomment-997335589).
\- Fix the test failure for `cd -eP` on illumos by making a directory symlink first, then removing the symlink after `cd`.
\- On illumos the test for `getconf -l` fails because one of the printed strings has newlines. Fix that by shellquoting strings with the `-q` option.
\- astconf.c: Only quote strings if the `-q` option was passed.