### PR TITLE
Fix ASan buffer overflow errors caused by `memcmp`

### DIFF
--- a/src/cmd/ksh93/sh/name.c
+++ b/src/cmd/ksh93/sh/name.c
@@ -192,7 +192,7 @@ Namval_t *nv_addnode(Namval_t* np, int remove)
 	{
 		name = (sp->nodes[0])->nvname;
 		i = strlen(name);
-		if(memcmp(np->nvname,name,i))
+		if(strncmp(np->nvname,name,i))
 			return(np);
 	}
 	if(sp->rp && sp->numnodes)

--- a/src/cmd/ksh93/sh/nvtree.c
+++ b/src/cmd/ksh93/sh/nvtree.c
@@ -860,7 +860,7 @@ static char **genvalue(char **argv, const char *prefix, int n, struct Walk *wp)
 					continue;
 				break;
 			}
-			else if(outfile && !wp->nofollow && argv[1] && memcmp(arg,argv[1],l=strlen(arg))==0 && argv[1][l]=='[')
+			else if(outfile && !wp->nofollow && argv[1] && strncmp(arg,argv[1],l=strlen(arg))==0 && argv[1][l]=='[')
 			{
 				int	k=1;
 				Namarr_t *ap=0;

--- a/src/cmd/ksh93/sh/nvtype.c
+++ b/src/cmd/ksh93/sh/nvtype.c
@@ -1053,7 +1053,7 @@ Namval_t *nv_mktype(Namval_t **nodes, int numnodes)
 			np->nvenv = 0;
 		}
 		nq->nvname = cp;
-		if(name && memcmp(name,&np->nvname[m],n)==0 && np->nvname[m+n]=='.')
+		if(name && strncmp(name,&np->nvname[m],n)==0 && np->nvname[m+n]=='.')
 			offset -= sizeof(char*);
 		dsize = nv_datasize(np,&offset);
 		cp = strcopy(name=cp, &np->nvname[m]);

--- a/src/cmd/ksh93/sh/path.c
+++ b/src/cmd/ksh93/sh/path.c
@@ -1526,7 +1526,7 @@ static Pathcomp_t *path_addcomp(Shell_t *shp,Pathcomp_t *first, Pathcomp_t *old,
 		len = strlen(name);
 	for(pp=first; pp; pp=pp->next)
 	{
-		if(len == pp->len && memcmp(name,pp->name,len)==0)
+		if(len == pp->len && strncmp(name,pp->name,len)==0)
 		{
 			pp->flags |= flag;
 			return(first);
@@ -1817,7 +1817,7 @@ Pathcomp_t *path_dirfind(Pathcomp_t *first,const char *name,int c)
 	register Pathcomp_t *pp=first;
 	while(pp)
 	{
-		if(memcmp(name,pp->name,pp->len)==0 && name[pp->len]==c) 
+		if(strncmp(name,pp->name,pp->len)==0 && name[pp->len]==c)
 			return(pp);
 		pp = pp->next;
 	}


### PR DESCRIPTION
This pull request replaces more instances of `memcmp` with `strncmp` to fix some more heap-buffer-overflow errors in ASan, some of which can occur when running the regression tests with xtrace enabled. It combines two existing patches plus another fix in name.c for xtrace:
https://www.mail-archive.com/ast-developers@lists.research.att.com/msg00877.html
https://github.com/oracle/solaris-userland/blob/master/components/ksh93/patches/035-CR7036535.patch