### PR TITLE
Fix process substitutions printing PIDs in profile scripts

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,11 @@ For full details, see the git log at: https://github.com/ksh93/ksh
 
 Any uppercase BUG_* names are modernish shell bug IDs.
 
+2021-12-22:
+
+- Process substitutions run in a profile script no longer print their
+  process ID when run.
+
 2021-12-21:
 
 - Fixed a bug that caused subshells (such as code blocks in parentheses) to

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -21,7 +21,7 @@
 
 #define SH_RELEASE_FORK	"93u+m"		/* only change if you develop a new ksh93 fork */
 #define SH_RELEASE_SVER	"1.1.0-alpha"	/* semantic version number: https://semver.org */
-#define SH_RELEASE_DATE	"2021-12-21"	/* must be in this format for $((.sh.version)) */
+#define SH_RELEASE_DATE	"2021-12-22"	/* must be in this format for $((.sh.version)) */
 #define SH_RELEASE_CPYR	"(c) 2020-2021 Contributors to ksh " SH_RELEASE_FORK
 
 /* Scripts sometimes field-split ${.sh.version}, so don't change amount of whitespace. */

--- a/src/cmd/ksh93/sh/args.c
+++ b/src/cmd/ksh93/sh/args.c
@@ -761,6 +761,7 @@ struct argnod *sh_argprocsub(Shell_t *shp,struct argnod *argp)
 	/* turn off job control */
 	sh_offstate(SH_INTERACTIVE);
 	sh_offstate(SH_MONITOR);
+	sh_offstate(SH_PROFILE);
 	job.jobcontrol = 0;
 	/* run the process substitution */
 	shp->subshell = 0;

--- a/src/cmd/ksh93/sh/subshell.c
+++ b/src/cmd/ksh93/sh/subshell.c
@@ -666,7 +666,7 @@ Sfio_t *sh_subshell(Shell_t *shp,Shnode_t *t, volatile int flags, int comsub)
 			{
 				if(comsub)
 					sigblock(SIGTSTP);
-				else if(!sh_isstate(SH_PROFILE))
+				else
 					sh_subfork();
 			}
 #endif

--- a/src/cmd/ksh93/tests/io.sh
+++ b/src/cmd/ksh93/tests/io.sh
@@ -590,10 +590,11 @@ result=$("$SHELL" -c 'echo ok > >(sed s/ok/good/); wait' 2>&1)
 [[ $result == good ]] || err_exit 'process substitution does not work with redirections' \
 				"(expected 'good', got $(printf %q "$result"))"
 
-# Process substitution in an interactive shell shouldn't print the
-# process ID of the asynchronous process.
-result=$("$SHELL" -ic 'echo >(true) >/dev/null' 2>&1)
-[[ -z $result ]] || err_exit 'interactive shells print a PID during process substitution' \
+# Process substitution in an interactive shell or profile script shouldn't
+# print the process ID of the asynchronous process.
+echo 'false >(false)' > "$tmp/procsub-envtest"
+result=$(ENV=$tmp/procsub-envtest "$SHELL" -ic 'true >(true)' 2>&1)
+[[ -z $result ]] || err_exit 'interactive shells and/or profile scripts print a PID during process substitution' \
 				"(expected '', got $(printf %q "$result"))"
 
 # ======


### PR DESCRIPTION
\- sh/args.c: A process substitution run in a profile script may print its PID as if it was a command spawned with `&`. Reproducer:
```sh
$ cat /tmp/env
true >(false)
$ ENV=/tmp/env ksh
[1]	730227
$
```
This bug is fixed by turning off the `SH_PROFILE` state while running a process substitution.

\- sh/subshell.c: The `SH_INTERACTIVE` fix in 35b02626 renders the extra check for `SH_PROFILE` redundant, so it has been removed.

\- tests/io.sh: Update the procsub PIDs test to also check the result after using process substitution in a profile script.