### PR TITLE
`sh_close()`: Set `errno` to `EBADF` for invalid file descriptors

### DIFF
--- a/src/cmd/ksh93/sh/io.c
+++ b/src/cmd/ksh93/sh/io.c
@@ -708,7 +708,10 @@ int sh_close(register int fd)
 	register Sfio_t *sp;
 	register int r = 0;
 	if(fd<0)
+	{
+		errno = EBADF;
 		return(-1);
+	}
 	if(fd >= shp->gd->lim.open_max)
 		sh_iovalidfd(shp,fd);
 	if(!(sp=shp->sftable[fd]) || sfclose(sp) < 0)


### PR DESCRIPTION
The `sh_close()` function fails to set `errno` to `EBADF` when passed a negative (invalid) file descriptor. This commit fixes the issue by setting `errno` if the file descriptor is a negative value (backported from ksh93v- 2012-08-24).