### PR TITLE
Fix `mkservice` compile errors and add `SHOPT_MKSERVICE`

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -20,6 +20,9 @@ Any uppercase BUG_* names are modernish shell bug IDs.
   xtrace (set -x) is on and the $PS4 prompt contains parameter expansions or
   command substitutions.
 
+- The mkservice and eloop builtins can now be built by enabling the
+  new SHOPT_MKSERVICE setting in src/cmd/ksh93/SHOPT.sh.
+
 2021-12-26:
 
 - Listing aliases or tracked aliases in a script no longer corrupts

--- a/src/cmd/ksh93/Mamfile
+++ b/src/cmd/ksh93/Mamfile
@@ -421,6 +421,18 @@ make install
 				prev SHOPT.sh
 				exec - ${CC} ${mam_cc_FLAGS} ${KSH_RELFLAGS} ${KSH_SHOPTFLAGS} ${CCFLAGS} -I. -Iinclude -I${PACKAGE_ast_INCLUDE} -D_API_ast=20100309 -D_PACKAGE_ast -DERROR_CONTEXT_T=Error_context_t -c bltins/misc.c
 			done misc.o generated
+			make mkservice.o
+				make bltins/mkservice.c
+					prev ${PACKAGE_ast_INCLUDE}/cmd.h implicit
+					prev ${PACKAGE_ast_INCLUDE}/error.h implicit
+					prev include/nval.h implicit
+					prev include/defs.h implicit
+				done bltins/mkservice.c
+				meta mkservice.o %.c>%.o bltins/mkservice.c mkservice
+				prev bltins/mkservice.c
+				prev SHOPT.sh
+				exec - ${CC} ${mam_cc_FLAGS} ${KSH_RELFLAGS} ${KSH_SHOPTFLAGS} ${CCFLAGS} -I. -Iinclude -I${PACKAGE_ast_INCLUDE} -DSH_DICT=${SH_DICT} -D_PACKAGE_ast -D_API_ast=20100309 -DERROR_CONTEXT_T=Error_context_t -c bltins/mkservice.c
+			done mkservice.o generated
 			make print.o
 				make bltins/print.c
 					make ${PACKAGE_ast_INCLUDE}/ccode.h implicit
@@ -1364,7 +1376,7 @@ make install
 				prev SHOPT.sh
 				exec - ${CC} ${mam_cc_FLAGS} ${KSH_RELFLAGS} ${KSH_SHOPTFLAGS} ${CCFLAGS} -I. -Iinclude -I${PACKAGE_ast_INCLUDE} -D_PACKAGE_ast -D_API_ast=20100309 -DERROR_CONTEXT_T=Error_context_t -c edit/hexpand.c
 			done hexpand.o generated
-			exec - ${AR} rc libshell.a alarm.o cd_pwd.o cflow.o deparse.o enum.o getopts.o hist.o misc.o print.o read.o sleep.o trap.o test.o typeset.o ulimit.o umask.o whence.o main.o nvdisc.o nvtype.o arith.o args.o array.o completion.o defs.o edit.o expand.o regress.o fault.o fcin.o
+			exec - ${AR} rc libshell.a alarm.o cd_pwd.o cflow.o deparse.o enum.o getopts.o hist.o misc.o mkservice.o print.o read.o sleep.o trap.o test.o typeset.o ulimit.o umask.o whence.o main.o nvdisc.o nvtype.o arith.o args.o array.o completion.o defs.o edit.o expand.o regress.o fault.o fcin.o
 			exec - ${AR} rc libshell.a history.o init.o io.o jobs.o lex.o macro.o name.o nvtree.o parse.o path.o string.o streval.o subshell.o tdump.o timers.o trestore.o waitevent.o xec.o limits.o msg.o strdata.o testops.o keywords.o options.o signals.o aliases.o builtins.o variables.o lexstates.o emacs.o vi.o hexpand.o
 			exec - (ranlib libshell.a) >/dev/null 2>&1 || true
 		done libshell.a generated

--- a/src/cmd/ksh93/README
+++ b/src/cmd/ksh93/README
@@ -106,6 +106,11 @@ The options have the following defaults and meanings:
                      .ExampleSpace.function or ${.ExampleSpace.variable}.
                      Name spaces within name spaces are also supported.
 
+    MKSERVICE    off Enables the 'mkservice' builtin which creates a TCP or UDP
+                     server that is implemented by shell functions, and the
+                     'eloop' builtin which causes the shell to block waiting for
+                     events to process. Experimental and probably insecure.
+
     NOECHOE      off Disable the '-e' option to the 'echo' command,
                      unless SHOPT_ECHOPRINT is enabled.
 

--- a/src/cmd/ksh93/SHOPT.sh
+++ b/src/cmd/ksh93/SHOPT.sh
@@ -25,6 +25,7 @@ SHOPT FIXEDARRAY=1			# fixed dimension indexed array
 SHOPT GLOBCASEDET=			# -o globcasedetect: adapt globbing/completion to case-insensitive file systems
 SHOPT HISTEXPAND=1			# csh-style history file expansions
 SHOPT KIA=				# ksh -R <outfile> <script> generates cross-ref database from script
+SHOPT MKSERVICE=0			# enable the mkservice and eloop builtins
 SHOPT MULTIBYTE=1			# multibyte character handling
 SHOPT NAMESPACE=1			# allow namespaces
 SHOPT NOECHOE=0				# turn off 'echo -e' when SHOPT_ECHOPRINT is disabled

--- a/src/cmd/ksh93/bltins/mkservice.c
+++ b/src/cmd/ksh93/bltins/mkservice.c
@@ -25,6 +25,8 @@
  * AT&T Labs
  */
 
+#if SHOPT_MKSERVICE
+
 static const char mkservice_usage[] =
 "[-?\n@(#)$Id: mkservice (AT&T Research) 2001-06-13 $\n]"
 "[--catalog?" SH_DICT "]"
@@ -258,7 +260,8 @@ static int waitnotify(int fd, long timeout, int rw)
 
 static int service_init(void)
 {
-	file_list = sh_newof(NULL,short,n,0);
+	int n = 20;
+	file_list = (int*)sh_newof(NULL,short,n,0);
 	poll_list = sh_newof(NULL,Sfio_t*,n,0);
 	service_list = sh_newof(NULL,Service_t*,n,0);
 	covered_fdnotify = sh_fdnotify(fdnotify);
@@ -377,7 +380,7 @@ static void putval(Namval_t* np, const char* val, int flag, Namfun_t* fp)
 	if (!val)
 	{
 		register int i;
-		for(i=0; i< sh.lim.open_max; i++)
+		for(i=0; i< sh.gd->lim.open_max; i++)
 		{
 			if(service_list[i]==sp)
 			{
@@ -409,7 +412,6 @@ int	b_mkservice(int argc, char** argv, Shbltin_t *context)
 	register int		fd;
 
 	NOT_USED(argc);
-	NOT_USED(context);
 	for (;;)
 	{
 		switch (optget(argv, mkservice_usage))
@@ -494,3 +496,5 @@ int	b_eloop(int argc, char** argv, Shbltin_t *context)
 	}
 	return(errno != 0);
 }
+
+#endif /* SHOPT_MKSERVICE */

--- a/src/cmd/ksh93/data/builtins.c
+++ b/src/cmd/ksh93/data/builtins.c
@@ -114,6 +114,10 @@ const struct shtable3 shtab_builtins[] =
 #endif	/* JOBS */
 	"false",	NV_BLTIN|BLT_ENV,		bltin(false),
 	"getopts",	NV_BLTIN|BLT_ENV,		bltin(getopts),
+#if SHOPT_MKSERVICE
+	"mkservice",	NV_BLTIN|BLT_ENV,		bltin(mkservice),
+	"eloop",	NV_BLTIN|BLT_ENV,		bltin(eloop),
+#endif /* SHOPT_MKSERVICE */
 	"print",	NV_BLTIN|BLT_ENV,		bltin(print),
 	"printf",	NV_BLTIN|BLT_ENV,		bltin(printf),
 	"pwd",		NV_BLTIN,			bltin(pwd),

--- a/src/cmd/ksh93/include/builtins.h
+++ b/src/cmd/ksh93/include/builtins.h
@@ -101,6 +101,10 @@ extern int b_builtin(int, char*[],Shbltin_t*);
 extern int b_cd(int, char*[],Shbltin_t*);
 extern int b_command(int, char*[],Shbltin_t*);
 extern int b_getopts(int, char*[],Shbltin_t*);
+#if SHOPT_MKSERVICE
+extern int b_mkservice(int, char*[],Shbltin_t*);
+extern int b_eloop(int, char*[],Shbltin_t*);
+#endif /* SHOPT_MKSERVICE */
 extern int b_hist(int, char*[],Shbltin_t*);
 extern int b_let(int, char*[],Shbltin_t*);
 extern int b_read(int, char*[],Shbltin_t*);


### PR DESCRIPTION
The unused `mkservice` and `eloop` builtins are currently not built, and if an attempt to compile them is made the build ends in failure. This commit backports a few build fixes from ksh93v- 2012-08-24 that allow `mkservice` and `eloop` to build (plus an additional compiler warning fix not in ksh93v-). I've also added a new `SHOPT_MKSERVICE` setting (turned off by default) so that `mkservice` and `eloop` can be built if the user chooses to include them in their build of ksh.