### PR TITLE
Fix ASan heap-buffer-overflow when handling syntax errors

### DIFF
--- a/src/cmd/ksh93/sh/lex.c
+++ b/src/cmd/ksh93/sh/lex.c
@@ -924,10 +924,10 @@ int sh_lex(Lex_t* lp)
 				if(c=='*' || (n=sh_lexstates[ST_BRACE][c])!=S_MOD1 && n!=S_MOD2)
 				{
 					/* see whether inside `...` */
-					mode = oldmode(lp);
-					poplevel(lp);
 					if((n = endchar(lp)) != '`')
 						goto err;
+					mode = oldmode(lp);
+					poplevel(lp);
 					pushlevel(lp,RBRACE,mode);
 				}
 				else


### PR DESCRIPTION
This commit backports a bugfix from ksh2020 to fix an ASan heap-buffer-overflow error in one of the regression tests. See:
https://github.com/att/ast/commit/c57f73984dc9eb0396396bb5e462884f99b7cdb6
https://github.com/att/ast/issues/1261

This explanation comes from the linked issue:
> The poplevel() in this block of code is called when lp->lexd.lex_max
> is zero:
> https://github.com/att/ast/blob/bd94eb56c30dbeb1402d2a8642050f7fe9188175/src/cmd/ksh93/sh/lex.c#L921-L925
> Since poplevel() first decrements lp->lexd.lex_max then uses it as
> an index into lp->lexd.lex_match this causes the word before the
> start of that buffer to be accessed. The buffer is allocated here:
> https://github.com/att/ast/blob/bd94eb56c30dbeb1402d2a8642050f7fe9188175/src/cmd/ksh93/sh/lex.c#L2210-L2218

src/cmd/ksh93/sh/lex.c:
\- Avoid calling `poplevel()` twice when handling syntax errors.