### PR TITLE
Allow the regression tests to pass without any `/opt/ast/bin` builtins

### DIFF
--- a/src/cmd/ksh93/tests/builtins.sh
+++ b/src/cmd/ksh93/tests/builtins.sh
@@ -25,29 +25,30 @@ bincat=$(whence -p cat)
 
 # ======
 # These are regression tests for the getconf builtin.
-builtin getconf
-bingetconf=$(getconf GETCONF)
-bad_result=$(getconf --version 2>&1)
+if builtin getconf 2> /dev/null; then
+	bingetconf=$(getconf GETCONF)
+	bad_result=$(getconf --version 2>&1)
 
-# The -l option should convert all variable names to lowercase.
-# https://github.com/att/ast/issues/1171
-got=$(getconf -lq | awk '{ gsub(/=.*/, "") } /[[:upper:]]/ { print }')
-[[ -n $got ]] && err_exit "'getconf -l' doesn't convert all variable names to lowercase" \
-	"(got $(printf %q "$got"))"
+	# The -l option should convert all variable names to lowercase.
+	# https://github.com/att/ast/issues/1171
+	got=$(getconf -lq | awk '{ gsub(/=.*/, "") } /[[:upper:]]/ { print }')
+	[[ -n $got ]] && err_exit "'getconf -l' doesn't convert all variable names to lowercase" \
+		"(got $(printf %q "$got"))"
 
-# The -q option should quote all string values.
-# https://github.com/att/ast/issues/1173
-exp="GETCONF=\"$bingetconf\""
-got=$(getconf -q | grep 'GETCONF=')
-[[ $exp == "$got" ]] || err_exit "'getconf -q' fails to quote string values" \
-	"(expected $(printf %q "$exp"), got $(printf %q "$got"))"
+	# The -q option should quote all string values.
+	# https://github.com/att/ast/issues/1173
+	exp="GETCONF=\"$bingetconf\""
+	got=$(getconf -q | grep 'GETCONF=')
+	[[ $exp == "$got" ]] || err_exit "'getconf -q' fails to quote string values" \
+		"(expected $(printf %q "$exp"), got $(printf %q "$got"))"
 
-# The -n option should only return matching names.
-# https://github.com/ksh93/ksh/issues/279
-exp="GETCONF=$bingetconf"
-got=$(getconf -n GETCONF)
-[[ $exp == "$got" ]] || err_exit "'getconf -n' doesn't match names correctly" \
-	"(expected $(printf %q "$exp"), got $(printf %q "$got"))"
+	# The -n option should only return matching names.
+	# https://github.com/ksh93/ksh/issues/279
+	exp="GETCONF=$bingetconf"
+	got=$(getconf -n GETCONF)
+	[[ $exp == "$got" ]] || err_exit "'getconf -n' doesn't match names correctly" \
+		"(expected $(printf %q "$exp"), got $(printf %q "$got"))"
+fi
 
 # ======
 # Test shell builtin commands
@@ -411,14 +412,16 @@ wait $pid1
 wait $pid2
 (( $? == 127 )) || err_exit "subshell job known to parent"
 env=
-v=$(getconf LIBPATH)
-for v in ${v//,/ }
-do	v=${v#*:}
-	v=${v%%:*}
-	eval [[ \$$v ]] && env="$env $v=\"\$$v\""
-done
-if	[[ $(foo=bar; eval foo=\$foo $env exec -c \$SHELL -c \'print \$foo\') != bar ]]
-then	err_exit '"name=value exec -c ..." not working'
+if builtin getconf 2> /dev/null; then
+	v=$(getconf LIBPATH)
+	for v in ${v//,/ }
+	do	v=${v#*:}
+		v=${v%%:*}
+		eval [[ \$$v ]] && env="$env $v=\"\$$v\""
+	done
+	if	[[ $(foo=bar; eval foo=\$foo $env exec -c \$SHELL -c \'print \$foo\') != bar ]]
+	then	err_exit '"name=value exec -c ..." not working'
+	fi
 fi
 $SHELL -c 'OPTIND=-1000000; getopts a opt -a' 2> /dev/null
 [[ $? == 1 ]] || err_exit 'getopts with negative OPTIND not working'
@@ -583,8 +586,10 @@ fi
 	while (( i <2))
 	do	(( i++))
 	done) == $'0\n0\n1\n1\n2' ]]  || err_exit  "DEBUG trap not working"
-getconf UNIVERSE - ucb
-[[ $($SHELL -c 'echo -3') == -3 ]] || err_exit "echo -3 not working in ucb universe"
+if builtin getconf 2> /dev/null; then
+	getconf UNIVERSE - ucb
+	[[ $($SHELL -c 'echo -3') == -3 ]] || err_exit "echo -3 not working in ucb universe"
+fi
 typeset -F3 start_x=SECONDS total_t delay=0.02
 typeset reps=50 leeway=5
 sleep $(( 2 * leeway * reps * delay )) |
@@ -635,11 +640,11 @@ t=$(ulimit -t)
 $SHELL 2> /dev/null -c 'cd ""' && err_exit 'cd "" not producing an error'
 [[ $($SHELL 2> /dev/null -c 'cd "";print hi') != hi ]] && err_exit 'cd "" should not terminate script'
 
-builtin cat
-out=$tmp/seq.out
-for ((i=1; i<=11; i++)); do print "$i"; done >$out
-cmp -s <(print -- "$($bincat<( $bincat $out ) )") <(print -- "$(cat <( cat $out ) )") || err_exit "builtin cat differs from $bincat"
-builtin -d cat
+if builtin cat 2> /dev/null; then
+	out=$tmp/seq.out
+	for ((i=1; i<=11; i++)); do print "$i"; done >$out
+	cmp -s <(print -- "$($bincat<( $bincat $out ) )") <(print -- "$(cat <( cat $out ) )") || err_exit "builtin cat differs from $bincat"
+fi
 
 [[ $($SHELL -c '{ printf %R "["; print ok;}' 2> /dev/null) == ok ]] || err_exit $'\'printf %R "["\' causes shell to abort'
 
@@ -859,7 +864,7 @@ for w in 'whence -t' 'type -t' 'whence -t -v'; do
 	got=$($w export)
 	[[ $exp == "$got" ]] || err_exit "'$w' has the wrong output for special builtins" \
 		"(expected $(printf %q "$exp"); got $(printf %q "$got"))"
-	if [[ $(PATH=/opt/ast/bin type cat) != "cat is a shell builtin version of /opt/ast/bin/cat" ]]
+	if [[ $(PATH=/opt/ast/bin type cat 2>&1) != "cat is a shell builtin version of /opt/ast/bin/cat" ]]
 	then	warning "/opt/ast/bin/cat isn't a builtin; skipping path-bound builtin tests"
 	else
 		got=$(PATH=/opt/ast/bin $w cat)
@@ -899,15 +904,17 @@ for w in 'whence -t' 'type -t' 'whence -t -v'; do
 		"(expected $(printf %q "$exp"); got $(printf %q "$got"))"
 
 	# The final few tests are for '-t -a'
-	exp="alias
+	if [[ $(PATH=/opt/ast/bin type cat 2>&1) == "cat is a shell builtin version of /opt/ast/bin/cat" ]]
+	then	exp="alias
 function
 builtin
 $($w -pa cat)"
-	got=$(alias cat=false
-		autoload cat
-		PATH=/opt/ast/bin:$PATH $w -a cat)
-	[[ $exp == "$got" ]] || err_exit "'$w -a' output is incorrect (cat command)" \
-		"(expected $(printf %q "$exp"); got $(printf %q "$got"))"
+		got=$(alias cat=false
+			autoload cat
+			PATH=/opt/ast/bin:$PATH $w -a cat)
+		[[ $exp == "$got" ]] || err_exit "'$w -a' output is incorrect (cat command)" \
+			"(expected $(printf %q "$exp"); got $(printf %q "$got"))"
+	fi
 	if [[ -n $($w -pa time) ]]
 	then	exp="keyword
 alias

--- a/src/cmd/ksh93/tests/coprocess.sh
+++ b/src/cmd/ksh93/tests/coprocess.sh
@@ -39,9 +39,9 @@ function ping # id
 }
 
 bincat=$(whence -p cat)
-builtin cat
+builtin cat 2> /dev/null && builtincat=cat
 
-for cat in cat $bincat
+for cat in $builtincat $bincat
 do
 
 	$cat |&

--- a/src/cmd/ksh93/tests/exit.sh
+++ b/src/cmd/ksh93/tests/exit.sh
@@ -30,28 +30,29 @@ function abspath
         print $newdir/$base
 }
 # test for proper exit of shell
-builtin getconf
-ABSHELL=$(abspath)
-print exit 0 >.profile
-${ABSHELL}  <<!
-HOME=$PWD \
-PATH=$PATH \
-SHELL=$ABSSHELL \
-$(
-	v=$(getconf LIBPATH)
-	for v in ${v//,/ }
-	do	v=${v#*:}
-		v=${v%%:*}
-		eval [[ \$$v ]] && eval print -n \" \"\$v=\"\$$v\"
-	done
-) \
-exec -c -a -ksh ${ABSHELL} -c "exit 1" 1>/dev/null 2>&1
+if builtin getconf 2> /dev/null; then
+	ABSHELL=$(abspath)
+	print exit 0 >.profile
+	${ABSHELL}  <<!
+	HOME=$PWD \
+	PATH=$PATH \
+	SHELL=$ABSSHELL \
+	$(
+		v=$(getconf LIBPATH)
+		for v in ${v//,/ }
+		do	v=${v#*:}
+			v=${v%%:*}
+			eval [[ \$$v ]] && eval print -n \" \"\$v=\"\$$v\"
+		done
+	) \
+	exec -c -a -ksh ${ABSHELL} -c "exit 1" 1>/dev/null 2>&1
 !
-status=$(echo $?)
-if	[[ -o noprivileged && $status != 0 ]]
-then	err_exit 'exit in .profile is ignored'
-elif	[[ -o privileged && $status == 0 ]]
-then	err_exit 'privileged .profile not ignored'
+	status=$(echo $?)
+	if	[[ -o noprivileged && $status != 0 ]]
+	then	err_exit 'exit in .profile is ignored'
+	elif	[[ -o privileged && $status == 0 ]]
+	then	err_exit 'privileged .profile not ignored'
+	fi
 fi
 if	[[ $(trap 'code=$?; echo $code; trap 0; exit $code' 0; exit 123) != 123 ]]
 then	err_exit 'exit not setting $?'
@@ -65,7 +66,9 @@ then	err_exit 'subshell trap on exit overwrites parent trap'
 fi
 cd /
 cd ~- || err_exit "cd back failed"
-$SHELL -c 'builtin -f cmd getconf; getconf --"?-version"; exit 0' >/dev/null 2>&1 || err_exit 'ksh plugin exit failed -- was ksh built with CCFLAGS+=$(CC.EXPORT.DYNAMIC)?'
+if builtin getconf 2> /dev/null; then
+	$SHELL -c 'builtin -f cmd getconf; getconf --"?-version"; exit 0' >/dev/null 2>&1 || err_exit 'ksh plugin exit failed -- was ksh built with CCFLAGS+=$(CC.EXPORT.DYNAMIC)?'
+fi
 
 # ======
 # Verify the 'exit' command behaves as expected

--- a/src/cmd/ksh93/tests/heredoc.sh
+++ b/src/cmd/ksh93/tests/heredoc.sh
@@ -100,17 +100,19 @@ do	((x = x+1))
 EOF
 done
 ' 2> /dev/null  || err_exit '100 empty here docs fails'
-{
-	print 'builtin -d cat
-	cat <<- EOF'
-	for ((i=0; i < 100; i++))
-	do print XXXXXXXXXXXXXXXXXXXX
-	done
-	print ' XXX$(date)XXXX
-	EOF'
-} > $f
-chmod +x "$f"
-$SHELL "$f" > /dev/null  || err_exit "large here-doc with command substitution fails"
+if (builtin cat) 2> /dev/null; then
+	{
+		print 'builtin -d cat
+		cat <<- EOF'
+		for ((i=0; i < 100; i++))
+		do print XXXXXXXXXXXXXXXXXXXX
+		done
+		print ' XXX$(date)XXXX
+		EOF'
+	} > $f
+	chmod +x "$f"
+	$SHELL "$f" > /dev/null  || err_exit "large here-doc with command substitution fails"
+fi
 x=$("$bincat" <<!
 $0
 !
@@ -138,35 +140,37 @@ abc
 EOF) != $'#abc\nabc' ]]
 then	err_exit 'comments not preserved in here-documents'
 fi
-cat  > "$f" <<- '!!!!'
-	builtin cat
-	: << EOF
-	$PWD
-	xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-	xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-	xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-	xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-	xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-	xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-	xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-	xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-	xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-	xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-	xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-	xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-	xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-	xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-	xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-	EOF
-	command exec 3>&- 4>&- 5>&- 6>&- 7>&- 8>&- 9>&-
-	x=abc
-	cat << EOF
-	$x
-	EOF
-!!!!
-chmod 755 "$f"
-if	[[ $($SHELL  "$f") != abc ]]
-then	err_exit	'here document descriptor was closed'
+if (builtin cat) 2> /dev/null; then
+	cat  > "$f" <<- '!!!!'
+		builtin cat
+		: << EOF
+		$PWD
+		xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+		xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+		xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+		xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+		xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+		xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+		xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+		xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+		xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+		xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+		xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+		xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+		xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+		xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+		xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+		EOF
+		command exec 3>&- 4>&- 5>&- 6>&- 7>&- 8>&- 9>&-
+		x=abc
+		cat << EOF
+		$x
+		EOF
+	!!!!
+	chmod 755 "$f"
+	if	[[ $($SHELL  "$f") != abc ]]
+	then	err_exit	'here document descriptor was closed'
+	fi
 fi
 cat  > "$f" <<- '!!!!'
 	exec 0<&-

--- a/src/cmd/ksh93/tests/locale.sh
+++ b/src/cmd/ksh93/tests/locale.sh
@@ -234,19 +234,21 @@ do	exp=$1
 	shift 4
 done
 
-# setocale(LC_ALL,"") after setlocale() initialization
+# setlocale(LC_ALL,"") after setlocale() initialization
 
-printf 'f1\357\274\240f2\n' > input1
-printf 't2\357\274\240f1\n' > input2
-printf '\357\274\240\n' > delim
-print "export LC_ALL=$locale
-builtin cut || exit
-cut -f 1 -d \$(cat delim) input1 input2 > out" > script
-$SHELL -c 'unset LANG ${!LC_*}; $SHELL ./script' ||
-err_exit "'cut' builtin failed -- exit code $?"
-exp=$'f1\nt2'
-got="$(<out)"
-[[ $got == "$exp" ]] || err_exit "LC_ALL test script failed -- expected '$exp', got '$got'"
+if builtin cut 2> /dev/null; then
+	printf 'f1\357\274\240f2\n' > input1
+	printf 't2\357\274\240f1\n' > input2
+	printf '\357\274\240\n' > delim
+	print "export LC_ALL=$locale
+	builtin cut
+	cut -f 1 -d \$(cat delim) input1 input2 > out" > script
+	$SHELL -c 'unset LANG ${!LC_*}; $SHELL ./script' || err_exit "'cut' builtin failed -- exit code $?"
+	exp=$'f1\nt2'
+	got="$(<out)"
+	[[ $got == "$exp" ]] || err_exit "LC_ALL test script failed" \
+		"(expected $(printf %q "$exp"), got $(printf %q "$got"))"
+fi
 
 # multibyte identifiers
 

--- a/src/cmd/ksh93/tests/subshell.sh
+++ b/src/cmd/ksh93/tests/subshell.sh
@@ -23,7 +23,7 @@
 
 typeset -F SECONDS  # for fractional seconds in PS4
 
-builtin getconf
+builtin getconf 2> /dev/null
 bincat=$(PATH=$(getconf PATH) whence -p cat)
 binecho=$(PATH=$(getconf PATH) whence -p echo)
 # make an external 'sleep' command that supports fractional seconds
@@ -340,54 +340,54 @@ actual=$(
 #
 # the tests and timeouts are done in async subshells to prevent
 # the test harness from hanging
+if builtin cat 2> /dev/null; then
+	SUB=(
+		( BEG='$( '	END=' )'	)
+		( BEG='${ '	END='; }'	)
+	)
+	CAT=(  cat  $bincat  )
+	INS=(  ""  "builtin cat; "  "builtin -d cat $bincat; "  ": > /dev/null; "  )
+	APP=(  ""  "; :"  )
+	TST=(
+		( CMD='print foo | $cat'			EXP=3		)
+		( CMD='$cat < $tmp/lin'						)
+		( CMD='cat $tmp/lin | $cat'					)
+		( CMD='read v < $tmp/buf; print $v'		LIM=4*1024	)
+		( CMD='cat $tmp/buf | read v; print $v'		LIM=4*1024	)
+	)
 
-SUB=(
-	( BEG='$( '	END=' )'	)
-	( BEG='${ '	END='; }'	)
-)
-CAT=(  cat  $bincat  )
-INS=(  ""  "builtin cat; "  "builtin -d cat $bincat; "  ": > /dev/null; "  )
-APP=(  ""  "; :"  )
-TST=(
-	( CMD='print foo | $cat'			EXP=3		)
-	( CMD='$cat < $tmp/lin'						)
-	( CMD='cat $tmp/lin | $cat'					)
-	( CMD='read v < $tmp/buf; print $v'		LIM=4*1024	)
-	( CMD='cat $tmp/buf | read v; print $v'		LIM=4*1024	)
-)
+	if	cat /dev/fd/3 3</dev/null >/dev/null 2>&1 || whence mkfifo > /dev/null
+	then	T=${#TST[@]}
+		TST[T].CMD='$cat <(print foo)'
+		TST[T].EXP=3
+	fi
 
-if	cat /dev/fd/3 3</dev/null >/dev/null 2>&1 || whence mkfifo > /dev/null
-then	T=${#TST[@]}
-	TST[T].CMD='$cat <(print foo)'
-	TST[T].EXP=3
-fi
+	# prime the two data files to 512 bytes each
+	# $tmp/lin has newlines every 16 bytes and $tmp/buf has no newlines
+	# the outer loop doubles the file size at top
 
-# prime the two data files to 512 bytes each
-# $tmp/lin has newlines every 16 bytes and $tmp/buf has no newlines
-# the outer loop doubles the file size at top
+	buf=$'1234567890abcdef'
+	lin=$'\n1234567890abcde'
+	for ((i=0; i<5; i++))
+	do	buf=$buf$buf
+		lin=$lin$lin
+	done
+	print -n "$buf" > $tmp/buf
+	print -n "$lin" > $tmp/lin
 
-buf=$'1234567890abcdef'
-lin=$'\n1234567890abcde'
-for ((i=0; i<5; i++))
-do	buf=$buf$buf
-	lin=$lin$lin
-done
-print -n "$buf" > $tmp/buf
-print -n "$lin" > $tmp/lin
-
-unset SKIP
-for ((n=1024; n<=1024*1024; n*=2))
-do	cat $tmp/buf $tmp/buf > $tmp/tmp
-	mv $tmp/tmp $tmp/buf
-	cat $tmp/lin $tmp/lin > $tmp/tmp
-	mv $tmp/tmp $tmp/lin
-	for ((S=0; S<${#SUB[@]}; S++))
-	do	for ((C=0; C<${#CAT[@]}; C++))
-		do	cat=${CAT[C]}
-			for ((I=0; I<${#INS[@]}; I++))
-			do	for ((A=0; A<${#APP[@]}; A++))
-				do	for ((T=0; T<${#TST[@]}; T++))
-					do	#undent...#
+	unset SKIP
+	for ((n=1024; n<=1024*1024; n*=2))
+	do	cat $tmp/buf $tmp/buf > $tmp/tmp
+		mv $tmp/tmp $tmp/buf
+		cat $tmp/lin $tmp/lin > $tmp/tmp
+		mv $tmp/tmp $tmp/lin
+		for ((S=0; S<${#SUB[@]}; S++))
+		do	for ((C=0; C<${#CAT[@]}; C++))
+			do	cat=${CAT[C]}
+				for ((I=0; I<${#INS[@]}; I++))
+				do	for ((A=0; A<${#APP[@]}; A++))
+					do	for ((T=0; T<${#TST[@]}; T++))
+						do	#undent...#
 
 	if	[[ ! ${SKIP[S][C][I][A][T]} ]]
 	then	eval "{ x=${SUB[S].BEG}${INS[I]}${TST[T].CMD}${APP[A]}${SUB[S].END}; print \${#x}; } >\$tmp/out &"
@@ -419,13 +419,14 @@ do	cat $tmp/buf $tmp/buf > $tmp/tmp
 		fi
 	fi
 
-						#...indent#
+							#...indent#
+						done
 					done
 				done
 			done
 		done
 	done
-done
+fi
 
 # specifics -- there's more?
 
@@ -602,7 +603,7 @@ trap ERR ERR
 [[ $(trap -p) == *ERR* ]] || err_exit 'trap -p in subshell does not contain ERR'
 trap - USR1 ERR
 
-( builtin getconf && PATH=$(getconf PATH)
+( builtin getconf 2> /dev/null && PATH=$(getconf PATH)
 dot=$(cat <<-EOF
 		$(ls -d .)
 	EOF


### PR DESCRIPTION
This commit primarily makes changes that allow the regression tests to run without any of the `/opt/ast/bin` builtins compiled into ksh. It also improves a test in locale.sh by shellquoting an error message.

~alias.sh: Unset the `$i` variable to fix an error (`$i` is used earlier in the script for something else.)~