### PR TITLE
Add three options to `ulimit`

### DIFF
--- a/ANNOUNCE
+++ b/ANNOUNCE
@@ -118,6 +118,15 @@ New features in built-in commands:
         builtin
         file
 
+- Added three options to the ulimit builtin with the same names and
+  functionality as in Bash:
+  - 'ulimit -k' sets the maximum number of kqueues.
+  - 'ulimit -P' sets the maximum number of pseudo-terminals.
+  - 'ulimit -R' sets the maximum time in microseconds a real-time process
+    can run before blocking.
+  Note that to use these options the operating system must support the
+  corresponding resource limit.
+
 New features in shell options:
 
 - A new --globcasedetect shell option is added on OSs where we can

--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,17 @@ For full details, see the git log at: https://github.com/ksh93/ksh
 
 Any uppercase BUG_* names are modernish shell bug IDs.
 
+2021-12-28:
+
+- Added three options to the ulimit builtin with the same names and
+  functionality as in Bash:
+  - 'ulimit -k' sets the maximum number of kqueues.
+  - 'ulimit -P' sets the maximum number of pseudo-terminals.
+  - 'ulimit -R' sets the maximum time in microseconds a real-time process
+    can run before blocking.
+  Note that to use these options the operating system must support the
+  corresponding resource limit.
+
 2021-12-27:
 
 - Two bash-like flags for 'whence' were backported from ksh 93v-:

--- a/src/cmd/ksh93/bltins/ulimit.c
+++ b/src/cmd/ksh93/bltins/ulimit.c
@@ -78,7 +78,7 @@ int	b_ulimit(int argc,char *argv[],Shbltin_t *context)
 	char* conf;
 	int label, unit, nosupport;
 	rlim_t i;
-	char tmp[42];
+	char tmp[41];
         Optdisc_t disc;
         memset(&disc, 0, sizeof(disc));
         disc.version = OPT_VERSION;

--- a/src/cmd/ksh93/bltins/ulimit.c
+++ b/src/cmd/ksh93/bltins/ulimit.c
@@ -19,7 +19,7 @@
 *                                                                      *
 ***********************************************************************/
 /*
- * ulimit [-HSaMctdfxlqenupmrbiswTv] [limit]
+ * ulimit [-HSaMctdfkxlqenuPpmrRbiswTv] [limit]
  *
  *   David Korn
  *   AT&T Labs

--- a/src/cmd/ksh93/bltins/ulimit.c
+++ b/src/cmd/ksh93/bltins/ulimit.c
@@ -78,7 +78,7 @@ int	b_ulimit(int argc,char *argv[],Shbltin_t *context)
 	char* conf;
 	int label, unit, nosupport;
 	rlim_t i;
-	char tmp[32];
+	char tmp[42];
         Optdisc_t disc;
         memset(&disc, 0, sizeof(disc));
         disc.version = OPT_VERSION;
@@ -218,7 +218,7 @@ int	b_ulimit(int argc,char *argv[],Shbltin_t *context)
 					sfsprintf(tmp,sizeof(tmp),"%s (%ss)", tp->description, e_units[tp->type]);
 				else
 					sfsprintf(tmp,sizeof(tmp),"%s", tp->name);
-				sfprintf(sfstdout,"%-30s (-%c)  ",tmp,tp->option);
+				sfprintf(sfstdout,"%-39s (-%c)  ",tmp,tp->option);
 			}
 			if(nosupport)
 			{

--- a/src/cmd/ksh93/data/builtins.c
+++ b/src/cmd/ksh93/data/builtins.c
@@ -1902,7 +1902,7 @@ const char sh_opttypeset[] =
 ;
 
 const char sh_optulimit[] =
-"[-1c?@(#)$Id: ulimit (AT&T Research) 2003-06-21 $\n]"
+"[-1c?@(#)$Id: ulimit (ksh 93u+m) 2021-12-28 $\n]"
 "[--catalog?" SH_DICT "]"
 "[+NAME?ulimit - set or display resource limits]"
 "[+DESCRIPTION?\bulimit\b sets or displays resource limits.  These "

--- a/src/cmd/ksh93/data/limits.c
+++ b/src/cmd/ksh93/data/limits.c
@@ -30,7 +30,7 @@
 #ifndef _no_ulimit 
 
 const char	e_unlimited[] = "unlimited";
-const char*	e_units[] = { 0, "block", "byte", "Kibyte", "second" };
+const char*	e_units[] = { 0, "block", "byte", "Kibyte", "second", "microsecond" };
 
 const int	shtab_units[] = { 1, 512, 1, 1024, 1 };
 
@@ -41,15 +41,18 @@ const Limit_t	shtab_limits[] =
 "cpu",		"cpu time",		RLIMIT_CPU,	0,		't',	LIM_SECOND,
 "data",		"data size",		RLIMIT_DATA,	0,		'd',	LIM_KBYTE,
 "fsize",	"file size",		RLIMIT_FSIZE,	0,		'f',	LIM_BLOCK,
+"kqueues",	"number of kqueues",	RLIMIT_KQUEUES,	0,		'k',	LIM_COUNT,
 "locks",	"number of file locks",	RLIMIT_LOCKS,	0,		'x',	LIM_COUNT,
 "memlock",	"locked address space",	RLIMIT_MEMLOCK,	0,		'l',	LIM_KBYTE,
 "msgqueue",	"message queue size",	RLIMIT_MSGQUEUE,0,		'q',	LIM_KBYTE,
 "nice",		"scheduling priority",	RLIMIT_NICE,	0,		'e',	LIM_COUNT,
 "nofile",	"number of open files",	RLIMIT_NOFILE,	"OPEN_MAX",	'n',	LIM_COUNT,
 "nproc",	"number of processes",	RLIMIT_NPROC,	"CHILD_MAX",	'u',	LIM_COUNT,
+"npts",		"number of pseudo-terminals",	RLIMIT_NPTS,	0,	'P',	LIM_COUNT,
 "pipe",		"pipe buffer size",	RLIMIT_PIPE,	"PIPE_BUF",	'p',	LIM_BYTE,
 "rss",		"max memory size",	RLIMIT_RSS,	0,		'm',	LIM_KBYTE,
 "rtprio",	"max real-time priority",RLIMIT_RTPRIO,	0,		'r',	LIM_COUNT,
+"rttime",	"time a real-time process can run before blocking,",	RLIMIT_RTTIME,	0,		'R',	LIM_MICROSECOND,
 "sbsize",	"socket buffer size",	RLIMIT_SBSIZE,	"PIPE_BUF",	'b',	LIM_BYTE,
 "sigpend",	"signal queue size",	RLIMIT_SIGPENDING,"SIGQUEUE_MAX",'i',	LIM_COUNT,
 "stack",	"stack size",		RLIMIT_STACK,	0,		's',	LIM_KBYTE,

--- a/src/cmd/ksh93/data/limits.c
+++ b/src/cmd/ksh93/data/limits.c
@@ -32,7 +32,7 @@
 const char	e_unlimited[] = "unlimited";
 const char*	e_units[] = { 0, "block", "byte", "Kibyte", "second", "microsecond" };
 
-const int	shtab_units[] = { 1, 512, 1, 1024, 1 };
+const int	shtab_units[] = { 1, 512, 1, 1024, 1, 1 };
 
 const Limit_t	shtab_limits[] =
 {
@@ -52,7 +52,7 @@ const Limit_t	shtab_limits[] =
 "pipe",		"pipe buffer size",	RLIMIT_PIPE,	"PIPE_BUF",	'p',	LIM_BYTE,
 "rss",		"max memory size",	RLIMIT_RSS,	0,		'm',	LIM_KBYTE,
 "rtprio",	"max real-time priority",RLIMIT_RTPRIO,	0,		'r',	LIM_COUNT,
-"rttime",	"time a real-time process can run before blocking,",	RLIMIT_RTTIME,	0,		'R',	LIM_MICROSECOND,
+"rttime",	"max time before blocking",	RLIMIT_RTTIME,	0,		'R',	LIM_MICROSECOND,
 "sbsize",	"socket buffer size",	RLIMIT_SBSIZE,	"PIPE_BUF",	'b',	LIM_BYTE,
 "sigpend",	"signal queue size",	RLIMIT_SIGPENDING,"SIGQUEUE_MAX",'i',	LIM_COUNT,
 "stack",	"stack size",		RLIMIT_STACK,	0,		's',	LIM_KBYTE,

--- a/src/cmd/ksh93/include/ulimit.h
+++ b/src/cmd/ksh93/include/ulimit.h
@@ -103,6 +103,9 @@
 #ifndef RLIMIT_FSIZE
 #define RLIMIT_FSIZE	RLIMIT_UNKNOWN
 #endif
+#ifndef RLIMIT_KQUEUES
+#define RLIMIT_KQUEUES	RLIMIT_UNKNOWN
+#endif
 #ifndef RLIMIT_LOCKS
 #define RLIMIT_LOCKS	RLIMIT_UNKNOWN
 #endif
@@ -121,6 +124,9 @@
 #ifndef RLIMIT_NPROC
 #define RLIMIT_NPROC	RLIMIT_UNKNOWN
 #endif
+#ifndef RLIMIT_NPTS
+#define RLIMIT_NPTS	RLIMIT_UNKNOWN
+#endif
 #ifndef RLIMIT_PIPE
 #define RLIMIT_PIPE	RLIMIT_UNKNOWN
 #endif
@@ -132,6 +138,9 @@
 #endif
 #ifndef RLIMIT_RTPRIO
 #define RLIMIT_RTPRIO	RLIMIT_UNKNOWN
+#endif
+#ifndef RLIMIT_RTTIME
+#define RLIMIT_RTTIME	RLIMIT_UNKNOWN
 #endif
 #ifndef RLIMIT_SBSIZE
 #define RLIMIT_SBSIZE	RLIMIT_UNKNOWN
@@ -154,6 +163,7 @@
 #define LIM_BYTE	2
 #define LIM_KBYTE	3
 #define LIM_SECOND	4
+#define LIM_MICROSECOND	5
 
 typedef struct Limit_s
 {

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -21,7 +21,7 @@
 
 #define SH_RELEASE_FORK	"93u+m"		/* only change if you develop a new ksh93 fork */
 #define SH_RELEASE_SVER	"1.1.0-alpha"	/* semantic version number: https://semver.org */
-#define SH_RELEASE_DATE	"2021-12-27"	/* must be in this format for $((.sh.version)) */
+#define SH_RELEASE_DATE	"2021-12-28"	/* must be in this format for $((.sh.version)) */
 #define SH_RELEASE_CPYR	"(c) 2020-2021 Contributors to ksh " SH_RELEASE_FORK
 
 /* Scripts sometimes field-split ${.sh.version}, so don't change amount of whitespace. */

--- a/src/cmd/ksh93/sh.1
+++ b/src/cmd/ksh93/sh.1
@@ -8079,7 +8079,7 @@ that have attributes
 are printed.
 .RE
 .TP
-\f3ulimit\fP \*(OK \f3\-HSaMctdfxlqenupmrbiswTv\fP \*(CK \*(OK \f2limit\^\fP \*(CK
+\f3ulimit\fP \*(OK \f3\-HSaMctdfkxlqenuPpmrRbiswTv\fP \*(CK \*(OK \f2limit\^\fP \*(CK
 Set or display a resource limit.
 The available resource limits are listed below.
 Many systems do not support one or more of these limits.
@@ -8137,6 +8137,9 @@ current process or by child processes (files of any size may be read).
 .B \-i
 The signal queue size.
 .TP
+.B \-k
+The max number of kqueues created by the current user.
+.TP
 .B \-l
 The locked address space in K-bytes.
 .TP
@@ -8149,11 +8152,20 @@ The number of K-bytes on the size of physical memory.
 .B \-n
 The number of file descriptors plus 1.
 .TP
+.B \-P
+The max number of pseudo-terminals created by the current user.
+.TP
 .B \-p
 The number of 512-byte blocks for pipe buffering.
 .TP
 .B \-q
 The message queue size in K-bytes.
+.TP
+.B \-R
+The max time a real-time process can run before blocking, in microseconds. If this limit is exceeded
+the process is sent a
+.B SIGXCPU
+signal.
 .TP
 .B \-r
 The max real-time priority.


### PR DESCRIPTION
This patch adds a few extra options to the `ulimit` command (although these can only be used if the OS supports them). These options are also present in Bash, although in ksh additional long forms of each option are available:
- `ulimit -k/--kqueues`: This is the maximum number of kqueues.
- `ulimit -P/--npts`: This is the maximum number of pseudo-terminals.
- `ulimit -R/--rttime`: This is the maximum time a real-time process can run before blocking, in microseconds. When the limit is exceeded, the process is sent `SIGXCPU`.

Other changes:
\- `bltins/ulimit.c`: Change the formatting from `sfprintf` and increase the size of the `tmp` buffer to prevent text from being cut off in `ulimit -a` (this was required to add `ulimit -R`).
\- `data/limits.c`: Add support for using microseconds as a unit.