### PR TITLE
Fix arrays.sh test failure under ASan

### DIFF
--- a/src/cmd/ksh93/sh/name.c
+++ b/src/cmd/ksh93/sh/name.c
@@ -519,8 +519,9 @@ void nv_setlist(register struct argnod *arg,register int flags, Namval_t *typ)
 					}
 					else if(((np->nvalue.cp && np->nvalue.cp!=Empty)||nv_isvtree(np)|| nv_arrayptr(np)) && !nv_type(np))
 					{
-						_nv_unset(np,NV_EXPORT);
-						if(ap && ap->fun)
+						int was_assoc_array = ap && ap->fun;
+						_nv_unset(np,NV_EXPORT);  /* this can free ap */
+						if(was_assoc_array)
 							 nv_setarray(np,nv_associative);
 				
 					}


### PR DESCRIPTION
This backports a ksh2020 fix for an ASan heap-use-after-free error in arrays.sh. The arrays regression tests were failing with a heap-use-after-free error under ASan because the `ap` pointer was used after the memory allocated to it was freed by `_nv_unset()`. ksh2020 commit: https://github.com/att/ast/commit/f1e5119e315fa5e7ed9651177d15256e86ccf046