### PR TITLE
Fix use after free bug in discipline functions

### DIFF
--- a/src/cmd/ksh93/sh/nvdisc.c
+++ b/src/cmd/ksh93/sh/nvdisc.c
@@ -409,6 +409,7 @@ static char*	lookup(Namval_t *np, int type, Sfdouble_t *dp,Namfun_t *handle)
 			nv_setsize(SH_VALNOD,10);
 		}
 		block(bp,type);
+		block(bp, UNASSIGN);   /* make sure nv_setdisc doesn't invalidate 'vp' by freeing it */
 		sh_pushcontext(&sh, &checkpoint, 1);
 		jmpval = sigsetjmp(checkpoint.buff, 0);
 		if(!jmpval)
@@ -416,6 +417,7 @@ static char*	lookup(Namval_t *np, int type, Sfdouble_t *dp,Namfun_t *handle)
 		sh_popcontext(&sh, &checkpoint);
 		if(sh.topfd != checkpoint.topfd)
 			sh_iorestore(checkpoint.topfd, jmpval);
+		unblock(bp,UNASSIGN);
 		unblock(bp,type);
 		if(!vp->disc[type])
 			chktfree(np,vp);


### PR DESCRIPTION
This fixes one of the ASan failures in the variables.sh regression tests. The explanation comes from https://github.com/att/ast/issues/1268:
> The problem is caused by this block of code freeing the `Namfun_t*` (via the
> call to `chktfree()`):
> https://github.com/att/ast/blob/4a4f4709d2a572b82151e2bacf05d63c3484540c/src/cmd/ksh93/sh/nvdisc.c#L479-L485
> That invalidates the value stored in `vp` which is dereferenced here:
> https://github.com/att/ast/blob/4a4f4709d2a572b82151e2bacf05d63c3484540c/src/cmd/ksh93/sh/nvdisc.c#L354-L357

ksh2020 commit:
https://github.com/att/ast/commit/df1e8165fa4b56c737b8fbc8c567bcc5ef02424f

src/cmd/ksh93/sh/nvdisc.c:
\- Block `nv_setdisc` from freeing the memory associated with the `vp` pointer.