### PR TITLE
Fix precision bug in times(3) fallback

### DIFF
--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -225,7 +225,7 @@ static void l_time(Sfio_t *outfile,register clock_t t,int precision)
 	if(precision)
 	{
 		frac = t%sh.lim.clk_tck;
-		frac = (frac*100)/sh.lim.clk_tck;
+		frac = (frac*(int)pow(10,precision))/sh.lim.clk_tck;
 	}
 	t /= sh.lim.clk_tck;
 	sec = t%60;

--- a/src/cmd/ksh93/tests/builtins.sh
+++ b/src/cmd/ksh93/tests/builtins.sh
@@ -1519,8 +1519,7 @@ fi
 # ======
 # ksh93v- accidentally broke the sleep builtin's support for
 # using microseconds in the form of <num>U.
-sleep 1U
-(($? == 0)) || err_exit 'sleep builtin cannot handle microseconds in the form of <num>U'
+got=$(sleep 1U 2>&1) || err_exit "sleep builtin cannot handle microseconds in the form of <num>U (got $(printf %q "$got"))"
 
 # ======
 exit $((Errors<125?Errors:125))

--- a/src/cmd/ksh93/tests/builtins.sh
+++ b/src/cmd/ksh93/tests/builtins.sh
@@ -1517,4 +1517,10 @@ if builtin tail 2> /dev/null; then
 fi
 
 # ======
+# ksh93v- accidentally broke the sleep builtin's support for
+# using microseconds in the form of <num>U.
+sleep 1U
+(($? == 0)) || err_exit 'sleep builtin cannot handle microseconds in the form of <num>U'
+
+# ======
 exit $((Errors<125?Errors:125))


### PR DESCRIPTION
This was originally going to be part of a patch for a future feature addition, but since this fixes a bug I've separated the bugfix part of it into its own pull request.

In the `times(3)` fallback for the `time` keyword (which can be enabled in `xec.c` by undefining `_lib_getrusage` and `timeofday`), ksh will print the obtained time incorrectly if `TIMEFORMAT` is set to use a precision level of three:
```sh
$ TIMEFORMAT=$'\nreal\t%3lR'
$ time sleep .080
real	0m00.008s  # Should be '00.080s'
```
This commit corrects that issue by using 10<sup>precision</sup> to get the correct fractional scaling. Note that the fallback still doesn't support a true precision level of three (`times(3)` alone doesn't support it), so this in effect pads a zero to the end of the output when the precision level is three.

Additional change to tests/builtins.sh:
\- While fixing the above issue I found out that ksh93v- broke support for passing microseconds to the sleep builtin in the form of \<num\>U. I've added a regression test for that bug to ensure it isn't backported to ksh93u+m by accident.