### PR TITLE
Fix build error on AIX 64-bit

### DIFF
--- a/src/cmd/INIT/ar.ibm.risc
+++ b/src/cmd/INIT/ar.ibm.risc
@@ -1,4 +1,4 @@
-: stupid stupid stupid to require a non-standard option for ar to work : 2009-10-06 :
+: ar requires a non-standard option to work : 2009-10-06 :
 
 op=$1
 shift

--- a/src/cmd/INIT/ar.ibm.risc-64
+++ b/src/cmd/INIT/ar.ibm.risc-64
@@ -1,0 +1,9 @@
+: still stupid to require a non-standard option for ar to work : 2022-01-14 :
+
+op=$1
+shift
+case $op in
+-*)	;;
+*)	op=-$op ;;
+esac
+/usr/bin/ar -X64 "$op" "$@"

--- a/src/cmd/INIT/ar.ibm.risc-64
+++ b/src/cmd/INIT/ar.ibm.risc-64
@@ -1,4 +1,4 @@
-: still stupid to require a non-standard option for ar to work : 2022-01-14 :
+: ar requires a non-standard option to work : 2022-01-14 :
 
 op=$1
 shift


### PR DESCRIPTION
This commit adds a wrapper for the AIX `ar` command that uses the `-X64` flag
to (hopefully) avoid build errors on that platform.

Resolves: https://github.com/ksh93/ksh/issues/385