### PR TITLE
Fix history expansion buffer overflow

### DIFF
--- a/src/cmd/ksh93/edit/hexpand.c
+++ b/src/cmd/ksh93/edit/hexpand.c
@@ -592,7 +592,7 @@ getsel:
 						char *sbuf = sfsetbuf(wm, (void*)1, 0);
 						int n = sftell(wm);
 						sb.str[0] = sh_malloc(n + 1);
-						sb.str[n] = '\0';
+						sb.str[0][n] = '\0';
 						memcpy(sb.str[0], sbuf, n);
 					}
 					cp = parse_subst(cp, &sb);

--- a/src/cmd/ksh93/edit/hexpand.c
+++ b/src/cmd/ksh93/edit/hexpand.c
@@ -591,7 +591,7 @@ getsel:
 					{
 						char *sbuf = sfsetbuf(wm, (void*)1, 0);
 						int n = sftell(wm);
-						sb.str[0] = malloc(n + 1);
+						sb.str[0] = sh_malloc(n + 1);
 						sb.str[n] = '\0';
 						memcpy(sb.str[0], sbuf, n);
 					}

--- a/src/cmd/ksh93/edit/hexpand.c
+++ b/src/cmd/ksh93/edit/hexpand.c
@@ -156,9 +156,11 @@ int hist_expand(const char *ln, char **xp)
 	Histloc_t hl;	/* history location */
 	static Namval_t *np = 0;	/* histchars variable */
 	static struct subst	sb = {0,0};	/* substitution strings */
-	static Sfio_t	*wm;	/* word match from !?string? event designator */
+	static Sfio_t	*wm=0;	/* word match from !?string? event designator */
 
-	wm = sfopen(NULL, NULL, "swr");
+	if(!wm)
+		wm = sfopen(NULL, NULL, "swr");
+
 	hc[0] = '!';
 	hc[1] = '^';
 	hc[2] = 0;

--- a/src/cmd/ksh93/edit/hexpand.c
+++ b/src/cmd/ksh93/edit/hexpand.c
@@ -156,11 +156,9 @@ int hist_expand(const char *ln, char **xp)
 	Histloc_t hl;	/* history location */
 	static Namval_t *np = 0;	/* histchars variable */
 	static struct subst	sb = {0,0};	/* substitution strings */
-	static Sfio_t	*wm=0;	/* word match from !?string? event designator */
+	static Sfio_t	*wm;	/* word match from !?string? event designator */
 
-	if(!wm)
-		wm = sfopen(NULL, NULL, "swr");
-
+	wm = sfopen(NULL, NULL, "swr");
 	hc[0] = '!';
 	hc[1] = '^';
 	hc[2] = 0;
@@ -590,7 +588,13 @@ getsel:
 				{
 					/* preset old with match from !?string? */
 					if(!sb.str[0] && wm)
-						sb.str[0] = sh_strdup(sfsetbuf(wm, (void*)1, 0));
+					{
+						char *sbuf = sfsetbuf(wm, (void*)1, 0);
+						int n = sftell(wm);
+						sb.str[0] = malloc(n + 1);
+						sb.str[n] = '\0';
+						memcpy(sb.str[0], sbuf, n);
+					}
 					cp = parse_subst(cp, &sb);
 				}
 


### PR DESCRIPTION
History expansion currently crashes under ASan due to a buffer overflow. Reproducer:
```sh
$ set -H
$ !!:s/old/new/
```

The explanation for this bugfix comes from https://github.com/att/ast/issues/1369:
> The problem is the code assumes the buffer allocated for a string stream is zero initialized. But the SFIO code uses `malloc()` to allocate the buffer and does not explicitly initialize it with `memset()`. That it works at all, even without ASAN enabled, is purely accidental. It will fail if that `malloc()` returns a block that had been previously allocated, used, and freed. Under ASAN the buffer is initialized (at least on my system) to a sequence of 0xBE bytes. So the `strdup()` happily tries to duplicate a string that is the size of that buffer and fails when it reads past the end of the buffer looking for the terminating zero byte.

src/cmd/ksh93/edit/hexpand.c:
\- Backport ksh2020 bugfix that avoids assuming the string stream has been initialized to zeros: https://github.com/att/ast/commit/cf16bccad887716ef2ca66e26c666590d72e9e3b