### PR TITLE
Use `POSIX_SPAWN_SETSID` in `spawnveg` when needed

### DIFF
--- a/src/lib/libast/man/spawnveg.3
+++ b/src/lib/libast/man/spawnveg.3
@@ -68,7 +68,7 @@ are as in
 .L pgid
 controls the new process group and session:
 .TP
-.L <0
+.L -1
 The new process becomes a session leader.
 It is called in the child context.
 .TP
@@ -86,5 +86,12 @@ The
 .L spawnveg
 function cannot set the terminal process group.
 As a result, it is incompatible with job control when used with terminals.
+Additionally, if the
+.L POSIX_SPAWN_SETSID
+attribute is not supported, then
+.L spawnveg
+cannot make the new process a session leader when using the
+.I posix_spawn
+API.
 .SH "SEE ALSO"
-fork(2), exec(2), setpgid(2), setsid(2), spawnve(2)
+fork(2), posix_spawn(3), exec(2), setpgid(2), setsid(2), spawnve(2)


### PR DESCRIPTION
This commit implements support for `POSIX_SPAWN_SETSID` in `spawnveg`(3). The `fork`/`vfork` fallback for `spawnveg` already attempts to use `setsid` in the manner described by the man page, so the `posix_spawn` implementation should also do so.

src/lib/libast/comp/spawnveg.c:
\- Add support for `POSIX_SPAWN_SETSID` to the `posix_spawn` version of `spawnveg`.
\- Minor extra: Remove dead code that's never used (the `_lib_posix_spawn < 2` code block is inside of `_lib_posix_spawn > 1`, plus when it's manually enabled by changing the previous `#if` condition you'll find it causes many regression test failures (at least on OpenBSD)).

src/lib/libast/man/spawnveg.3:
\- Document that `spawnveg` cannot make the new process a session leader if the operating system doesn't support `POSIX_SPAWN_SETSID` and the new process was created using `posix_spawn`.