### PR TITLE
Fix the `defpath` memory leak ASan keeps complaining about

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,6 +9,9 @@ Any uppercase BUG_* names are modernish shell bug IDs.
   shell when suspending (Ctrl+Z) an external command invoked by a dot script
   or POSIX shell function, or via 'eval'.
 
+- Fixed a memory leak that occurred when running a command that was found on
+  the PATH.
+
 2022-01-26:
 
 - On Cygwin, ksh now executes scripts that do not have a #! path itself,

--- a/src/cmd/ksh93/sh/path.c
+++ b/src/cmd/ksh93/sh/path.c
@@ -58,14 +58,21 @@ static int		checkdotpaths(Pathcomp_t*,Pathcomp_t*,Pathcomp_t*,int);
 static void		checkdup(register Pathcomp_t*);
 static Pathcomp_t	*defpathinit(void);
 
-static const char	*defpath;	/* default path that finds standard utilities */
+static const char *std_path(void)
+{
+	static const char *defpath;		/* default path that finds standard utilities */
+	if(!defpath)
+	{
+		if(!(defpath = astconf("PATH",NIL(char*),NIL(char*))))
+			abort();
+		defpath = sh_strdup(defpath);   /* the value returned by astconf() is short-lived */
+	}
+	return(defpath);
+}
 
 static int ondefpath(const char *name)
 {
-	const char *cp;
-	if(!defpath)
-		defpathinit();
-	cp = defpath;
+	const char *cp = std_path();
 	if(cp)
 	{
 		const char *sp;
@@ -433,13 +440,7 @@ Pathcomp_t *path_nextcomp(register Pathcomp_t *pp, const char *name, Pathcomp_t 
 
 static Pathcomp_t* defpathinit(void)
 {
-	if(!defpath)
-	{
-		if(!(defpath = astconf("PATH",NIL(char*),NIL(char*))))
-			abort();
-		defpath = sh_strdup(defpath);	/* the value returned by astconf() is short-lived */
-	}
-	return(path_addpath((Pathcomp_t*)0,(defpath),PATH_PATH));
+	return(path_addpath((Pathcomp_t*)0,std_path(),PATH_PATH));
 }
 
 static void pathinit(void)


### PR DESCRIPTION
Currently, running ksh under ASan without the `ASAN_OPTIONS` variable set to `detect_leaks=0` usually ends with ASan complaining about a memory leak in `defpathinit()` (this leak doesn't grow in a loop, so no regression test was added to leaks.sh). Reproducer:
```
$ ENV=/dev/null arch/*/bin/ksh
$ cp -?
cp: invalid option -- '?'
Try 'cp --help' for more information.
$ exit

=================================================================
==225132==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 85 byte(s) in 1 object(s) allocated from:
    #0 0x7f6dab42d459 in __interceptor_calloc /build/gcc/src/gcc/libsanitizer/asan/asan_malloc_linux.cpp:154
    #1 0x5647b77fe144 in sh_calloc /home/johno/GitRepos/KornShell/ksh/src/cmd/ksh93/sh/init.c:265
    #2 0x5647b788fea9 in path_addcomp /home/johno/GitRepos/KornShell/ksh/src/cmd/ksh93/sh/path.c:1567
    #3 0x5647b78911ed in path_addpath /home/johno/GitRepos/KornShell/ksh/src/cmd/ksh93/sh/path.c:1705
    #4 0x5647b7888e82 in defpathinit /home/johno/GitRepos/KornShell/ksh/src/cmd/ksh93/sh/path.c:442
    #5 0x5647b78869f3 in ondefpath /home/johno/GitRepos/KornShell/ksh/src/cmd/ksh93/sh/path.c:67
    #6 0x5647b7888225 in checkdup /home/johno/GitRepos/KornShell/ksh/src/cmd/ksh93/sh/path.c:365
    #7 0x5647b7888714 in path_nextcomp /home/johno/GitRepos/KornShell/ksh/src/cmd/ksh93/sh/path.c:403
    #8 0x5647b788b2c0 in path_absolute /home/johno/GitRepos/KornShell/ksh/src/cmd/ksh93/sh/path.c:785
    #9 0x5647b788ad8d in path_search /home/johno/GitRepos/KornShell/ksh/src/cmd/ksh93/sh/path.c:727
    #10 0x5647b78b5549 in sh_exec /home/johno/GitRepos/KornShell/ksh/src/cmd/ksh93/sh/xec.c:1204
    #11 0x5647b77b8032 in exfile /home/johno/GitRepos/KornShell/ksh/src/cmd/ksh93/sh/main.c:591
    #12 0x5647b77b5c26 in sh_main /home/johno/GitRepos/KornShell/ksh/src/cmd/ksh93/sh/main.c:352
    #13 0x5647b77b3ffd in main /home/johno/GitRepos/KornShell/ksh/src/cmd/ksh93/sh/pmain.c:45
    #14 0x7f6dab0ae6cd in __libc_start_call_main (/usr/lib/libc.so.6+0x2d6cd)

Indirect leak of 89 byte(s) in 1 object(s) allocated from:
    #0 0x7f6dab42d459 in __interceptor_calloc /build/gcc/src/gcc/libsanitizer/asan/asan_malloc_linux.cpp:154
    #1 0x5647b77fe144 in sh_calloc /home/johno/GitRepos/KornShell/ksh/src/cmd/ksh93/sh/init.c:265
    #2 0x5647b788fea9 in path_addcomp /home/johno/GitRepos/KornShell/ksh/src/cmd/ksh93/sh/path.c:1567
    #3 0x5647b78911ed in path_addpath /home/johno/GitRepos/KornShell/ksh/src/cmd/ksh93/sh/path.c:1705
    #4 0x5647b7888e82 in defpathinit /home/johno/GitRepos/KornShell/ksh/src/cmd/ksh93/sh/path.c:442
    #5 0x5647b78869f3 in ondefpath /home/johno/GitRepos/KornShell/ksh/src/cmd/ksh93/sh/path.c:67
    #6 0x5647b7888225 in checkdup /home/johno/GitRepos/KornShell/ksh/src/cmd/ksh93/sh/path.c:365
    #7 0x5647b7888714 in path_nextcomp /home/johno/GitRepos/KornShell/ksh/src/cmd/ksh93/sh/path.c:403
    #8 0x5647b788b2c0 in path_absolute /home/johno/GitRepos/KornShell/ksh/src/cmd/ksh93/sh/path.c:785
    #9 0x5647b788ad8d in path_search /home/johno/GitRepos/KornShell/ksh/src/cmd/ksh93/sh/path.c:727
    #10 0x5647b78b5549 in sh_exec /home/johno/GitRepos/KornShell/ksh/src/cmd/ksh93/sh/xec.c:1204
    #11 0x5647b77b8032 in exfile /home/johno/GitRepos/KornShell/ksh/src/cmd/ksh93/sh/main.c:591
    #12 0x5647b77b5c26 in sh_main /home/johno/GitRepos/KornShell/ksh/src/cmd/ksh93/sh/main.c:352
    #13 0x5647b77b3ffd in main /home/johno/GitRepos/KornShell/ksh/src/cmd/ksh93/sh/pmain.c:45
    #14 0x7f6dab0ae6cd in __libc_start_call_main (/usr/lib/libc.so.6+0x2d6cd)

SUMMARY: AddressSanitizer: 174 byte(s) leaked in 2 allocation(s).
```

src/cmd/ksh93/sh/path.c:
\- Move the code for allocating `defpath` from `defpathinit()` into its own dedicated function called `std_path()`. This function is called by `defpathinit()` and `ondefpath()` to obtain the current string stored in the `defpath` variable. This bugfix is adapted from a fork of ksh2020: https://github.com/l0stman/ksh/commit/db5c83a63e595dcee96b2bb7aac96f1e24a543d5