### PR TITLE
Accumulated fixes for minor issues

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -858,7 +858,7 @@ Any uppercase BUG_* names are modernish shell bug IDs.
   the parent environment was corrupted or the shell crashed.
   When a redirection was used in a DEBUG trap action, the trap was disabled.
   DEBUG traps were also incorrectly inherited by subshells and ksh functions.
-  All this was caused by a bug introduced in ksh 93t 2008-07-25.
+  All this was caused by a bug introduced in ksh 93t 2008-06-24.
 
 2021-01-22:
 
@@ -869,7 +869,7 @@ Any uppercase BUG_* names are modernish shell bug IDs.
 
 - Fixed: executing a DEBUG trap in a command substitution had side effects
   on the exit status ($?) of non-trap commands.
-  This bug was introduced in ksh 93t 2008-11-04.
+  This bug was introduced in ksh 93t 2008-09-21.
 
 - The typeset builtin command now gives an informative error message if an
   incompatible combination of options is given.

--- a/src/cmd/ksh93/bltins/print.c
+++ b/src/cmd/ksh93/bltins/print.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1982-2014 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2021 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 1.0                  *
 *                    by AT&T Intellectual Property                     *

--- a/src/cmd/ksh93/bltins/print.c
+++ b/src/cmd/ksh93/bltins/print.c
@@ -21,7 +21,7 @@
 /*
  * echo [arg...]
  * print [-enprsvC] [-f format] [-u fd] [string ...]
- * printf format [string ...]
+ * printf [-v var] format [string ...]
  *
  *   David Korn
  *   AT&T Labs

--- a/src/cmd/ksh93/bltins/typeset.c
+++ b/src/cmd/ksh93/bltins/typeset.c
@@ -699,13 +699,15 @@ static int     setall(char **argv,register int flag,Dt_t *troot,struct tdata *tp
 						np = sh_fsearch(name,HASH_NOSCOPE);
 					if(!np)
 #endif /* SHOPT_NAMESPACE */
-					if(np=nv_search(name,troot,0))
 					{
-						if(!is_afunction(np))
-							np = 0;
+						if(np=nv_search(name,troot,0))
+						{
+							if(!is_afunction(np))
+								np = 0;
+						}
+						else if(memcmp(name,".sh.math.",9)==0 && sh_mathstd(name+9))
+							continue;
 					}
-					else if(memcmp(name,".sh.math.",9)==0 && sh_mathstd(name+9))
-						continue;
 				}
 				if(np && ((flag&NV_LTOU) || !nv_isnull(np) || nv_isattr(np,NV_LTOU)))
 				{

--- a/src/cmd/ksh93/bltins/typeset.c
+++ b/src/cmd/ksh93/bltins/typeset.c
@@ -1094,10 +1094,7 @@ int	b_builtin(int argc,char *argv[],Shbltin_t *context)
 	Stk_t	*stkp;
 	char *errmsg;
 #if SHOPT_DYNAMIC
-	void *library=0;
-	unsigned long ver;
 	int list = 0;
-	char path[1024];
 #endif
 	NOT_USED(argc);
 	memset(&tdata,0,sizeof(tdata));
@@ -1158,6 +1155,9 @@ int	b_builtin(int argc,char *argv[],Shbltin_t *context)
 #if SHOPT_DYNAMIC
 	if(arg)
 	{
+		unsigned long ver;
+		char path[PATH_MAX];
+		void *library;
 		if(!(library = dllplugin(SH_ID, arg, NiL, SH_PLUGIN_VERSION, &ver, RTLD_LAZY, path, sizeof(path))))
 		{
 			errormsg(SH_DICT,ERROR_exit(0),"%s: %s",arg,dllerror(0));

--- a/src/cmd/ksh93/bltins/typeset.c
+++ b/src/cmd/ksh93/bltins/typeset.c
@@ -1090,9 +1090,9 @@ int	b_builtin(int argc,char *argv[],Shbltin_t *context)
 	struct tdata tdata;
 	Shbltin_f addr;
 	Stk_t	*stkp;
-	void *library=0;
 	char *errmsg;
 #if SHOPT_DYNAMIC
+	void *library=0;
 	unsigned long ver;
 	int list = 0;
 	char path[1024];
@@ -1354,8 +1354,8 @@ static int unall(int argc, char **argv, register Dt_t *troot)
 			isfun = is_afunction(np);
 			if(troot==sh.var_tree)
 			{
-				Namarr_t *ap;
 #if SHOPT_FIXEDARRAY
+				Namarr_t *ap;
 				if((ap=nv_arrayptr(np)) && !ap->fixed  && name[strlen(name)-1]==']' && !nv_getsub(np))
 #else
 				if(nv_isarray(np) && name[strlen(name)-1]==']' && !nv_getsub(np))

--- a/src/cmd/ksh93/bltins/typeset.c
+++ b/src/cmd/ksh93/bltins/typeset.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1982-2012 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2021 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 1.0                  *
 *                    by AT&T Intellectual Property                     *

--- a/src/cmd/ksh93/data/msg.c
+++ b/src/cmd/ksh93/data/msg.c
@@ -70,7 +70,7 @@ const char e_restricted[]	= "%s: restricted";
 #if SHOPT_PFSH
 const char e_pfsh[]		= "%s: disabled in profile shell";
 #endif
-const char e_pexists[]		= "process already exists";
+const char e_copexists[]	= "coprocess is running; cannot create a new coprocess";
 const char e_exists[]		= "%s: file already exists";
 const char e_pipe[]		= "cannot create pipe";
 const char e_alarm[]		= "cannot set alarm";

--- a/src/cmd/ksh93/data/msg.c
+++ b/src/cmd/ksh93/data/msg.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1982-2012 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2021 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 1.0                  *
 *                    by AT&T Intellectual Property                     *

--- a/src/cmd/ksh93/edit/vi.c
+++ b/src/cmd/ksh93/edit/vi.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1982-2012 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2021 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 1.0                  *
 *                    by AT&T Intellectual Property                     *
@@ -2737,10 +2737,12 @@ yankeol:
 #if SHOPT_MULTIBYTE
 				if((c&~STRIP)==0)
 #endif /* SHOPT_MULTIBYTE */
-				if( isupper(c) )
-					c = tolower(c);
-				else if( islower(c) )
-					c = toupper(c);
+				{
+					if( isupper(c) )
+						c = tolower(c);
+					else if( islower(c) )
+						c = toupper(c);
+				}
 				replace(vp,c, 1);
 			}
 			return(GOOD);

--- a/src/cmd/ksh93/include/io.h
+++ b/src/cmd/ksh93/include/io.h
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1982-2012 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2021 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 1.0                  *
 *                    by AT&T Intellectual Property                     *

--- a/src/cmd/ksh93/include/io.h
+++ b/src/cmd/ksh93/include/io.h
@@ -76,7 +76,7 @@ extern int	sh_devtofd(const char*);
 extern int	sh_isdevfd(const char*);
 
 /* the following are readonly */
-extern const char	e_pexists[];
+extern const char	e_copexists[];
 extern const char	e_query[];
 extern const char	e_history[];
 extern const char	e_argtype[];

--- a/src/cmd/ksh93/include/ulimit.h
+++ b/src/cmd/ksh93/include/ulimit.h
@@ -29,7 +29,7 @@
 #if defined(_sys_resource) && defined(_lib_getrlimit)
 #   include	<sys/resource.h>
 #   if !defined(RLIMIT_FSIZE) && defined(_sys_vlimit)
-	/* This handles hp/ux problem */ 
+	/* This handles HP/UX problem */
 #	include	<sys/vlimit.h>
 #	define RLIMIT_FSIZE	(LIM_FSIZE-1)
 #	define RLIMIT_DATA	(LIM_DATA-1)

--- a/src/cmd/ksh93/include/ulimit.h
+++ b/src/cmd/ksh93/include/ulimit.h
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1982-2012 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2021 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 1.0                  *
 *                    by AT&T Intellectual Property                     *
@@ -29,7 +29,7 @@
 #if defined(_sys_resource) && defined(_lib_getrlimit)
 #   include	<sys/resource.h>
 #   if !defined(RLIMIT_FSIZE) && defined(_sys_vlimit)
-	/* This handles HP/UX problem */
+	/* This handles HP-UX problem */
 #	include	<sys/vlimit.h>
 #	define RLIMIT_FSIZE	(LIM_FSIZE-1)
 #	define RLIMIT_DATA	(LIM_DATA-1)

--- a/src/cmd/ksh93/sh/macro.c
+++ b/src/cmd/ksh93/sh/macro.c
@@ -2268,10 +2268,8 @@ static void comsubst(Mac_t *mp,register Shnode_t* t, int type)
 			str[c] = 0;
 		else
 		{
-			ssize_t len = 1;
-
 			/* can't write past buffer so save last character */
-			c -= len;
+			c -= 1;
 			lastc = str[c];
 			str[c] = 0;
 		}

--- a/src/cmd/ksh93/sh/macro.c
+++ b/src/cmd/ksh93/sh/macro.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1982-2012 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2021 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 1.0                  *
 *                    by AT&T Intellectual Property                     *

--- a/src/cmd/ksh93/sh/nvtree.c
+++ b/src/cmd/ksh93/sh/nvtree.c
@@ -744,7 +744,9 @@ static void outval(char *name, const char *vname, struct Walk *wp)
 	{
 		if(*name!='.')
 		{
+#if SHOPT_FIXEDARRAY
 			Namarr_t *ap;
+#endif
 			nv_attribute(np,wp->out,"typeset",'=');
 #if SHOPT_FIXEDARRAY
 			if((ap=nv_arrayptr(np)) && ap->fixed)

--- a/src/cmd/ksh93/sh/nvtree.c
+++ b/src/cmd/ksh93/sh/nvtree.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1982-2012 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2021 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 1.0                  *
 *                    by AT&T Intellectual Property                     *

--- a/src/cmd/ksh93/sh/nvtype.c
+++ b/src/cmd/ksh93/sh/nvtype.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1982-2012 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2021 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 1.0                  *
 *                    by AT&T Intellectual Property                     *

--- a/src/cmd/ksh93/sh/nvtype.c
+++ b/src/cmd/ksh93/sh/nvtype.c
@@ -430,11 +430,11 @@ static Namfun_t *clone_type(Namval_t* np, Namval_t *mp, int flags, Namfun_t *fp)
 						nv_putsub(nq,cp,ARRAY_ADD|ARRAY_NOSCOPE);
 						if(array_assoc(ap))
 						{
-							Namval_t *mp = (Namval_t*)((*ap->fun)(nr,NIL(char*),NV_ACURRENT));
+							Namval_t *mr = (Namval_t*)((*ap->fun)(nr,NIL(char*),NV_ACURRENT));
 							Namval_t *mq = (Namval_t*)((*ap->fun)(nq,NIL(char*),NV_ACURRENT));
-							nv_clone(mp,mq,NV_MOVE);
+							nv_clone(mr,mq,NV_MOVE);
 							ap->nelem--;
-							nv_delete(mp,ap->table,0);
+							nv_delete(mr,ap->table,0);
 						}
 						else
 						{

--- a/src/cmd/ksh93/sh/path.c
+++ b/src/cmd/ksh93/sh/path.c
@@ -770,7 +770,9 @@ Pathcomp_t *path_absolute(register const char *name, Pathcomp_t *pp, int flag)
 	Pathcomp_t	*oldpp;
 	Namval_t	*np;
 	char		*cp;
+#if SHOPT_DYNAMIC
 	char		*bp;
+#endif
 	sh.path_err = ENOENT;
 	if(!pp && !(pp=path_get(Empty)))
 		return(0);
@@ -885,7 +887,10 @@ Pathcomp_t *path_absolute(register const char *name, Pathcomp_t *pp, int flag)
 		{
 			*cp = 0;
 			if(nv_open(name,sh_subfuntree(1),NV_NOARRAY|NV_IDENT|NV_NOSCOPE))
+			{
+				sh_close(f);
 				f = -1;
+			}
 			*cp = '.';
 		}
 		if(isfun && f>=0)
@@ -895,7 +900,7 @@ Pathcomp_t *path_absolute(register const char *name, Pathcomp_t *pp, int flag)
 				nv_onattr(nv_open(name,sh_subfuntree(1),NV_NOARRAY|NV_IDENT|NV_NOSCOPE),NV_LTOU|NV_FUNCTION);
 				funload(f,name);
 			}
-			close(f);
+			sh_close(f);
 			return(0);
 		}
 		else if(f>=0 && (oldpp->flags & PATH_STD_DIR))

--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -3396,7 +3396,7 @@ static void coproc_init(int pipes[])
 	int outfd;
 	if(sh.coutpipe>=0 && sh.cpid)
 	{
-		errormsg(SH_DICT,ERROR_exit(1),e_pexists);
+		errormsg(SH_DICT,ERROR_exit(1),e_copexists);
 		UNREACHABLE();
 	}
 	sh.cpid = 0;

--- a/src/cmd/ksh93/tests/bracket.sh
+++ b/src/cmd/ksh93/tests/bracket.sh
@@ -2,7 +2,7 @@
 #                                                                      #
 #               This software is part of the ast package               #
 #          Copyright (c) 1982-2012 AT&T Intellectual Property          #
-#          Copyright (c) 2020-2021 Contributors to ksh 93u+m           #
+#          Copyright (c) 2020-2022 Contributors to ksh 93u+m           #
 #                      and is licensed under the                       #
 #                 Eclipse Public License, Version 1.0                  #
 #                    by AT&T Intellectual Property                     #

--- a/src/cmd/ksh93/tests/bracket.sh
+++ b/src/cmd/ksh93/tests/bracket.sh
@@ -239,9 +239,9 @@ if	rm -rf "$file" && ln -s / "$file"
 then	[[ -L "$file" ]] || err_exit '-L not working'
 	[[ -L "$file"/ ]] && err_exit '-L with file/ not working'
 fi
-$SHELL -c 't=1234567890; [[ $t == @({10}(\d)) ]]' 2> /dev/null || err_exit ' @({10}(\d)) pattern not working'
-$SHELL -c '[[ att_ == ~(E)(att|cus)_.* ]]' 2> /dev/null || err_exit ' ~(E)(att|cus)_* pattern not working'
-$SHELL -c '[[ att_ =~ (att|cus)_.* ]]' 2> /dev/null || err_exit ' =~ ere not working'
+$SHELL -c 't=1234567890; [[ $t == @({10}(\d)) ]]' 2> /dev/null || err_exit '@({10}(\d)) pattern not working'
+$SHELL -c '[[ att_ == ~(E)(att|cus)_.* ]]' 2> /dev/null || err_exit '~(E)(att|cus)_* pattern not working'
+$SHELL -c '[[ att_ =~ (att|cus)_.* ]]' 2> /dev/null || err_exit '=~ ere not working'
 $SHELL -c '[[ abc =~ a(b)c ]]' 2> /dev/null || err_exit '[[ abc =~ a(b)c ]] fails'
 $SHELL -xc '[[ abc =~  \babc\b ]]' 2> /dev/null || err_exit '[[ abc =~ \babc\b ]] fails'
 [[ abc == ~(E)\babc\b ]] || err_exit '\b not preserved for ere when not in ()'

--- a/src/cmd/ksh93/tests/builtins.sh
+++ b/src/cmd/ksh93/tests/builtins.sh
@@ -1454,6 +1454,14 @@ if builtin rm 2> /dev/null; then
 	[[ $? == 0 ]] || err_exit 'rm builtin fails to remove non-empty directory and file with -rd options' \
 		"(got $(printf %q "$got"))"
 	[[ -f $tmp/nonemptydir2/shouldexist || -d $tmp/nonemptydir2 ]] && err_exit 'rm builtin fails to remove all folders and files with -rd options'
+
+	# Additional test: 'rm -f' without additional arguments should act
+	# as a no-op command. This bug was fixed in ksh93u+ 2012-02-14.
+	got=$(rm -f 2>&1)
+	if (($? != 0)) || [[ ! -z $got ]]
+	then	err_exit 'rm -f without additional arguments does not work correctly' \
+		"(got $(printf %q "$got"))"
+	fi
 fi
 
 # ======

--- a/src/lib/libast/cdt/dtdisc.c
+++ b/src/lib/libast/cdt/dtdisc.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2012 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2021 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 1.0                  *
 *                    by AT&T Intellectual Property                     *

--- a/src/lib/libast/cdt/dtdisc.c
+++ b/src/lib/libast/cdt/dtdisc.c
@@ -34,6 +34,8 @@ static void* dtmemory(Dt_t* 	dt,	/* dictionary			*/
 		      size_t	size,	/* size to obtain		*/
 		      Dtdisc_t* disc)	/* discipline			*/
 {
+	NOT_USED(dt);
+	NOT_USED(disc);
 	if(addr)
 	{	if(size == 0)
 		{	free(addr);

--- a/src/lib/libast/comp/system.c
+++ b/src/lib/libast/comp/system.c
@@ -43,14 +43,13 @@
 extern int
 system(const char* cmd)
 {
-	char*	sh[5];
+	char*	sh[4];
 
 	if (!cmd)
 		return !eaccess(pathshell(), X_OK);
 	sh[0] = "sh";
 	sh[1] = "-c";
-	sh[2] = "--";
-	sh[3] = (char*)cmd;
-	sh[4] = 0;
+	sh[2] = (char*)cmd;
+	sh[3] = 0;
 	return procrun(NiL, sh, 0);
 }

--- a/src/lib/libast/comp/system.c
+++ b/src/lib/libast/comp/system.c
@@ -43,13 +43,14 @@
 extern int
 system(const char* cmd)
 {
-	char*	sh[4];
+	char*	sh[5];
 
 	if (!cmd)
 		return !eaccess(pathshell(), X_OK);
 	sh[0] = "sh";
 	sh[1] = "-c";
-	sh[2] = (char*)cmd;
-	sh[3] = 0;
+	sh[2] = "--";
+	sh[3] = (char*)cmd;
+	sh[4] = 0;
 	return procrun(NiL, sh, 0);
 }

--- a/src/lib/libast/man/spawnveg.3
+++ b/src/lib/libast/man/spawnveg.3
@@ -94,4 +94,4 @@ cannot make the new process a session leader when using the
 .I posix_spawn
 API.
 .SH "SEE ALSO"
-fork(2), posix_spawn(3), exec(2), setpgid(2), setsid(2), spawnve(2)
+fork(2), vfork(2), posix_spawn(3), exec(2), setpgid(2), setsid(2), spawnve(2)

--- a/src/lib/libast/misc/optget.c
+++ b/src/lib/libast/misc/optget.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2012 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2021 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 1.0                  *
 *                    by AT&T Intellectual Property                     *

--- a/src/lib/libast/misc/optget.c
+++ b/src/lib/libast/misc/optget.c
@@ -1111,6 +1111,7 @@ init(register char* s, Optpass_t* p)
 	}
 	s = next(s, 0);
 	if (*s != '[')
+	{
 		for (t = s, a = 0; *t; t++)
 			if (!a && *t == '-')
 			{
@@ -1121,6 +1122,7 @@ init(register char* s, Optpass_t* p)
 				a++;
 			else if (*t == ']')
 				a--;
+	}
 	if (!p->version && (t = strchr(s, '(')) && strchr(t, ')') && (state.cp || (state.cp = sfstropen())))
 	{
 		/*

--- a/src/lib/libast/port/astconf.c
+++ b/src/lib/libast/port/astconf.c
@@ -1351,10 +1351,10 @@ print(Sfio_t* sp, register Lookup_t* look, const char* name, const char* path, i
  * return read stream to native getconf utility
  */
 
+#ifdef _pth_getconf_a
 static Sfio_t*
 nativeconf(Proc_t** pp, const char* operand)
 {
-#ifdef _pth_getconf
 	Sfio_t*		sp;
 	char*		cmd[3];
 	long		ops[2];
@@ -1376,9 +1376,9 @@ nativeconf(Proc_t** pp, const char* operand)
 		}
 		procclose(*pp);
 	}
-#endif
 	return 0;
 }
+#endif
 
 /*
  * value==0 gets value for name

--- a/src/lib/libast/port/astconf.c
+++ b/src/lib/libast/port/astconf.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2012 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2021 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 1.0                  *
 *                    by AT&T Intellectual Property                     *

--- a/src/lib/libast/sfio/sfmode.c
+++ b/src/lib/libast/sfio/sfmode.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2012 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2021 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 1.0                  *
 *                    by AT&T Intellectual Property                     *

--- a/src/lib/libast/sfio/sfmode.c
+++ b/src/lib/libast/sfio/sfmode.c
@@ -59,7 +59,9 @@ static char*	Version = "\n@(#)$Id: sfio (AT&T Labs - Research) 2009-09-15 $\0\n"
 #include		<signal.h>
 typedef void(*		Sfsignal_f)(int);
 #endif
+#ifdef SIGPIPE
 static int		_Sfsigp = 0; /* # of streams needing SIGPIPE protection */ 
+#endif
 
 /* done at exiting time */
 static void _sfcleanup(void)

--- a/src/lib/libast/sfio/sfpopen.c
+++ b/src/lib/libast/sfio/sfpopen.c
@@ -119,7 +119,7 @@ do_interp:
 	for(s = interp+strlen(interp)-1; s >= interp; --s)
 		if(*s == '/')
 			break;
-	execl(interp, s+1, "-c", "--", argcmd, NIL(char*));
+	execl(interp, s+1, "-c", argcmd, NIL(char*));
 	_exit(EXIT_NOTFOUND);
 }
 
@@ -134,7 +134,7 @@ Sfio_t*	sfpopen(Sfio_t*		f,
 	reg int		sflags;
 	reg long	flags;
 	reg int		pflags;
-	char*		av[5];
+	char*		av[4];
 
 	if (!command || !command[0] || !mode)
 		return 0;
@@ -154,9 +154,8 @@ Sfio_t*	sfpopen(Sfio_t*		f,
 		flags |= PROC_WRITE;
 	av[0] = "sh";
 	av[1] = "-c";
-	av[2] = "--";
-	av[3] = (char*)command;
-	av[4] = 0;
+	av[2] = (char*)command;
+	av[3] = 0;
 	if (!(proc = procopen(0, av, 0, 0, flags)))
 		return 0;
 	if (!(f = sfnew(f, NIL(void*), (size_t)SF_UNBOUND,

--- a/src/lib/libast/sfio/sfpopen.c
+++ b/src/lib/libast/sfio/sfpopen.c
@@ -62,9 +62,8 @@ static void execute(const char* argcmd)
 			goto do_interp;
 
 	/* try to construct argv */
-	if(!(cmd = (char*)malloc(strlen(argcmd)+1)) )
+	if(!(cmd = strdup(argcmd)) )
 		goto do_interp;
-	strcpy(cmd,argcmd);
 	if(!(argv = (char**)malloc(16*sizeof(char*))) )
 		goto do_interp;
 	for(n = 0, s = cmd;; )
@@ -120,7 +119,7 @@ do_interp:
 	for(s = interp+strlen(interp)-1; s >= interp; --s)
 		if(*s == '/')
 			break;
-	execl(interp, s+1, "-c", argcmd, NIL(char*));
+	execl(interp, s+1, "-c", "--", argcmd, NIL(char*));
 	_exit(EXIT_NOTFOUND);
 }
 
@@ -135,7 +134,7 @@ Sfio_t*	sfpopen(Sfio_t*		f,
 	reg int		sflags;
 	reg long	flags;
 	reg int		pflags;
-	char*		av[4];
+	char*		av[5];
 
 	if (!command || !command[0] || !mode)
 		return 0;
@@ -155,8 +154,9 @@ Sfio_t*	sfpopen(Sfio_t*		f,
 		flags |= PROC_WRITE;
 	av[0] = "sh";
 	av[1] = "-c";
-	av[2] = (char*)command;
-	av[3] = 0;
+	av[2] = "--";
+	av[3] = (char*)command;
+	av[4] = 0;
 	if (!(proc = procopen(0, av, 0, 0, flags)))
 		return 0;
 	if (!(f = sfnew(f, NIL(void*), (size_t)SF_UNBOUND,

--- a/src/lib/libast/sfio/sfpopen.c
+++ b/src/lib/libast/sfio/sfpopen.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2012 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2021 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 1.0                  *
 *                    by AT&T Intellectual Property                     *

--- a/src/lib/libast/sfio/sftmp.c
+++ b/src/lib/libast/sfio/sftmp.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2012 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2021 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 1.0                  *
 *                    by AT&T Intellectual Property                     *

--- a/src/lib/libast/sfio/sftmp.c
+++ b/src/lib/libast/sfio/sftmp.c
@@ -159,11 +159,10 @@ char** _sfgetpath(char* path)
 	}
 	if(n == 0 || !(dirs = (char**)malloc((n+1)*sizeof(char*))) )
 		return NIL(char**);
-	if(!(p = (char*)malloc(strlen(path)+1)) )
+	if(!(p = strdup(path)) )
 	{	free(dirs);
 		return NIL(char**);
 	}
-	strcpy(p,path);
 	for(n = 0;; ++n)
 	{	while(*p == ':')
 			++p;
@@ -218,12 +217,11 @@ static int _tmpfd(Sfio_t* f)
 			return -1;
 		if(!(file = getenv("TMPDIR")) )
 			file = TMPDFLT;
-		if(!(Tmppath[0] = (char*)malloc(strlen(file)+1)) )
+		if(!(Tmppath[0] = strdup(file)) )
 		{	free(Tmppath);
 			Tmppath = NIL(char**);
 			return -1;
 		}
-		strcpy(Tmppath[0],file);
 		Tmppath[1] = NIL(char*);
 	}
 

--- a/src/lib/libast/tm/tmxfmt.c
+++ b/src/lib/libast/tm/tmxfmt.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2012 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2021 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 1.0                  *
 *                    by AT&T Intellectual Property                     *

--- a/src/lib/libast/tm/tmxfmt.c
+++ b/src/lib/libast/tm/tmxfmt.c
@@ -137,7 +137,6 @@ tmxfmt(char* buf, size_t len, const char* format, Time_t t)
 	{
 		if ((c = *format++) == delimiter)
 		{
-			delimiter = 0;
 			if (sp <= &stack[0])
 				break;
 			sp--;

--- a/src/lib/libast/tm/tmxscan.c
+++ b/src/lib/libast/tm/tmxscan.c
@@ -173,7 +173,6 @@ scan(register const char* s, char** e, const char* format, char** f, Time_t t, l
 	register char*	p;
 	register Tm_t*	tm;
 	const char*	b;
-	char*		u;
 	char*		stack[4];
 	int		m;
 	int		hi;
@@ -184,6 +183,7 @@ scan(register const char* s, char** e, const char* format, char** f, Time_t t, l
 	Tm_zone_t*	zp;
 	Tm_t		ts;
 
+	char*		u = 0;
 	char**		sp = &stack[0];
 
 	while (isspace(*s))
@@ -397,7 +397,7 @@ scan(register const char* s, char** e, const char* format, char** f, Time_t t, l
 				s = b;
 				goto again;
 			case '&':
-				x = gen(tm, &set);
+				(void)gen(tm, &set);
 				x = tmxdate(s, e, t);
 				if (s == (const char*)*e)
 					goto next;


### PR DESCRIPTION
This commit applies various accumulated bugfixes. Details below:
- Applied some fixes for compiler warnings based off of the following pull requests (with whitespace changes excluded to avoid inflating the size of the diff):
https://github.com/att/ast/pull/281
https://github.com/att/ast/pull/283
https://github.com/att/ast/pull/303
https://github.com/att/ast/pull/304

- `clone_type()`: Two separate variables in this function share the same name. A bugfix from ksh93v- 2013-05-24 was backported to avoid conflict issues.

- Backported a minor error message improvement from ksh2020 for when the user attempts to run too many coprocesses.

- Backported a ksh2020 bugfix for a file descriptor leak: https://github.com/att/ast/commit/58bc8b569d0686439155b3f77e052f773e337367

- Backported ksh2020 bugfixes for unused variables and pointless assignment lint warnings:
https://github.com/att/ast/commit/47650fe0dfa51f25aa90fbb33d734620f705781c
https://github.com/att/ast/commit/df209c0d62af49f236a035a6ee46d73d96abac5d
https://github.com/att/ast/commit/5e417b00bba9ca8e5ce8b245153e916e3cfab81c

- Applied a few minor improvements to libast from graphviz:
https://gitlab.com/graphviz/graphviz/-/commit/e7c0354185cb2af3800ce702804829af1c3e6577
https://gitlab.com/graphviz/graphviz/-/commit/969a7cdeba64342cc4b23852db91b7a0465ae4e9

- `dtmemory()`: Mark unused parameters with `NOT_USED()`. Based on:
https://gitlab.com/graphviz/graphviz/-/commit/6ac3ad99e624d59a786daa3fa7fa0a253f17fff9

- ~libast: Call the shell interpreter with `sh -c --` where applicable. This prevents issues when executing commands whose names start with a dash. Reference:
https://austingroupbugs.net/view.php?id=1440~

- Applied a few documentation/comment tweaks for the NEWS file, `printf -v` and `spawnveg`.

- Added a missing regression test for using the `rm` builtin's `-f` option without additional arguments (this was fixed in ksh93u+ 2012-02-14).