### PR TITLE
Backport bugfix for extra array zero element from ksh93v- 2012-10-04

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,11 +5,8 @@ Any uppercase BUG_* names are modernish shell bug IDs.
 
 2022-02-04:
 
-- Adding a .unset discipline function to an indexed array no longer adds
-  an extra '[0]' element to the array.
-
-- Unsetting all elements of an indexed array no longer adds a spurious
-  '[0]' element to the array.
+- Fixed a bug in 'typeset -p': for an indexed array variable that is set
+  but empty, it will no longer output a nonexistent '[0]=' element.
 
 2022-02-02:
 

--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,14 @@ For full details, see the git log at: https://github.com/ksh93/ksh
 
 Any uppercase BUG_* names are modernish shell bug IDs.
 
+2022-02-04:
+
+- Adding a .unset discipline function to an indexed array no longer adds
+  an extra '[0]' element to the array.
+
+- Unsetting all elements of an indexed array no longer adds a spurious
+  '[0]' element to the array.
+
 2022-02-02:
 
 - Fixed the -a/allexport option to export all variables that are assigned

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -21,7 +21,7 @@
 
 #define SH_RELEASE_FORK	"93u+m"		/* only change if you develop a new ksh93 fork */
 #define SH_RELEASE_SVER	"1.1.0-alpha"	/* semantic version number: https://semver.org */
-#define SH_RELEASE_DATE	"2022-02-02"	/* must be in this format for $((.sh.version)) */
+#define SH_RELEASE_DATE	"2022-02-04"	/* must be in this format for $((.sh.version)) */
 #define SH_RELEASE_CPYR	"(c) 2020-2022 Contributors to ksh " SH_RELEASE_FORK
 
 /* Scripts sometimes field-split ${.sh.version}, so don't change amount of whitespace. */

--- a/src/cmd/ksh93/sh/nvtree.c
+++ b/src/cmd/ksh93/sh/nvtree.c
@@ -556,9 +556,11 @@ void nv_outnode(Namval_t *np, Sfio_t* out, int indent, int special)
 	Indent = indent;
 	if(ap)
 	{
+		sfputc(out,'(');
+		if(array_elem(ap)==0)
+			return;
 		if(!(ap->nelem&ARRAY_SCAN))
 			nv_putsub(np,NIL(char*),ARRAY_SCAN);
-		sfputc(out,'(');
 		if(indent>=0)
 		{
 			sfputc(out,'\n');

--- a/src/cmd/ksh93/tests/arrays.sh
+++ b/src/cmd/ksh93/tests/arrays.sh
@@ -755,4 +755,33 @@ got=$("$SHELL" -c 'test -z ${foo[${bar}..${baz}]}' 2>&1)
 	"(got $(printf %q "$got"))"
 
 # ======
+# Empty arrays shouldn't have a spurious [0] element added to them.
+# https://github.com/ksh93/ksh/issues/420
+# https://github.com/att/ast/issues/69#issuecomment-325435618
+exp='len=0: typeset -a Y_ARR=()'
+got=$("$SHELL" -c '
+	typeset -a Y_ARR
+	function Y_ARR.unset {
+		:
+	}
+	print -n len="${#arr[@]}: "
+	typeset -p Y_ARR
+')
+[[ $exp == $got ]] || err_exit 'Giving an array a .unset discipline function adds a spurious [0] element' \
+	"(expected $(printf %q "$exp"), got $(printf %q "$got"))"
+
+# https://github.com/att/ast/issues/69#issuecomment-325551035
+exp='len=0: typeset -a X_ARR=()'
+got=$("$SHELL" -c '
+	typeset -a X_ARR=(aa bb cc)
+	unset X_ARR[2]
+	unset X_ARR[1]
+	unset X_ARR[0]
+	print -n len="${#arr[@]}: "
+	typeset -p X_ARR
+')
+[[ $exp == $got ]] || err_exit 'Unsetting all elements of an array adds a spurious [0] element' \
+	"(expected $(printf %q "$exp"), got $(printf %q "$got"))"
+
+# ======
 exit $((Errors<125?Errors:125))

--- a/src/cmd/ksh93/tests/arrays.sh
+++ b/src/cmd/ksh93/tests/arrays.sh
@@ -755,7 +755,7 @@ got=$("$SHELL" -c 'test -z ${foo[${bar}..${baz}]}' 2>&1)
 	"(got $(printf %q "$got"))"
 
 # ======
-# Empty arrays shouldn't have a spurious [0] element added to them.
+# Spurious '[0]=' element in 'typeset -p' output for indexed array variable that is set but empty
 # https://github.com/ksh93/ksh/issues/420
 # https://github.com/att/ast/issues/69#issuecomment-325435618
 exp='len=0: typeset -a Y_ARR=()'

--- a/src/cmd/ksh93/tests/arrays.sh
+++ b/src/cmd/ksh93/tests/arrays.sh
@@ -764,7 +764,7 @@ got=$("$SHELL" -c '
 	function Y_ARR.unset {
 		:
 	}
-	print -n "len=${#arr[@]}: "
+	print -n "len=${#Y_ARR[@]}: "
 	typeset -p Y_ARR
 ')
 [[ $exp == $got ]] || err_exit 'Giving an array a .unset discipline function adds a spurious [0] element' \
@@ -777,7 +777,7 @@ got=$("$SHELL" -c '
 	unset X_ARR[2]
 	unset X_ARR[1]
 	unset X_ARR[0]
-	print -n "len=${#arr[@]}: "
+	print -n "len=${#X_ARR[@]}: "
 	typeset -p X_ARR
 ')
 [[ $exp == $got ]] || err_exit 'Unsetting all elements of an array adds a spurious [0] element' \

--- a/src/cmd/ksh93/tests/arrays.sh
+++ b/src/cmd/ksh93/tests/arrays.sh
@@ -764,7 +764,7 @@ got=$("$SHELL" -c '
 	function Y_ARR.unset {
 		:
 	}
-	print -n len="${#arr[@]}: "
+	print -n "len=${#arr[@]}: "
 	typeset -p Y_ARR
 ')
 [[ $exp == $got ]] || err_exit 'Giving an array a .unset discipline function adds a spurious [0] element' \
@@ -777,7 +777,7 @@ got=$("$SHELL" -c '
 	unset X_ARR[2]
 	unset X_ARR[1]
 	unset X_ARR[0]
-	print -n len="${#arr[@]}: "
+	print -n "len=${#arr[@]}: "
 	typeset -p X_ARR
 ')
 [[ $exp == $got ]] || err_exit 'Unsetting all elements of an array adds a spurious [0] element' \


### PR DESCRIPTION
This pull request backports the bugfix for #420 from ksh93v- 2012-10-04.

src/cmd/ksh93/sh/nvtree.c: `nv_outnode()`:
- If the array is supposed to be empty, do not continue. This avoids adding a `[0]` element to empty arrays.

src/cmd/ksh93/tests/arrays.sh:
- Add regression tests for this bug based on the corresponding reproducers.

Resolves: #420