### PR TITLE
Fix `typeset -p` output of compound array types

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,11 @@ For full details, see the git log at: https://github.com/ksh93/ksh
 
 Any uppercase BUG_* names are modernish shell bug IDs.
 
+2022-02-07:
+
+- Compound arrays belonging to a type created with 'typeset -T' now have
+  their -C attribute preserved in the output of 'typeset -p'.
+
 2022-02-05:
 
 - Fixed: for indexed arrays, given an unset array member a[i] with i > 0,

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -21,7 +21,7 @@
 
 #define SH_RELEASE_FORK	"93u+m"		/* only change if you develop a new ksh93 fork */
 #define SH_RELEASE_SVER	"1.1.0-alpha"	/* semantic version number: https://semver.org */
-#define SH_RELEASE_DATE	"2022-02-05"	/* must be in this format for $((.sh.version)) */
+#define SH_RELEASE_DATE	"2022-02-07"	/* must be in this format for $((.sh.version)) */
 #define SH_RELEASE_CPYR	"(c) 2020-2022 Contributors to ksh " SH_RELEASE_FORK
 
 /* Scripts sometimes field-split ${.sh.version}, so don't change amount of whitespace. */

--- a/src/cmd/ksh93/sh/nvtype.c
+++ b/src/cmd/ksh93/sh/nvtype.c
@@ -139,6 +139,8 @@ static const Namdisc_t type_disc =
 	0,
 };
 
+static char *Null = "";
+
 size_t nv_datasize(Namval_t *np, size_t *offset)
 {
 	size_t s=0, a=0;
@@ -333,6 +335,8 @@ static int fixnode(Namtype_t *dp, Namtype_t *pp, int i, struct Namref *nrp,int f
 				nv_offattr(nq,NV_NOFREE);
 			}
 		}
+		else if(nq->nvalue.cp==Null)
+			nq->nvalue.cp = Empty;
 		else if(nq->nvalue.cp==Empty)
 			nv_offattr(nq,NV_NOFREE);
 	
@@ -1159,7 +1163,12 @@ Namval_t *nv_mktype(Namval_t **nodes, int numnodes)
 					free((void*)np->nvalue.cp);
 			}
 			if(!nq->nvalue.cp && nq->nvfun== &pp->childfun.fun)
-				nq->nvalue.cp = Empty;
+			{
+				if(nv_isattr(np,NV_ARRAY|NV_NOFREE)==(NV_ARRAY|NV_NOFREE))
+					nq->nvalue.cp = Null;
+				else
+					nq->nvalue.cp = Empty;
+			}
 			np->nvalue.cp = 0;
 			offset += (dsize?dsize:4);
 		}

--- a/src/cmd/ksh93/sh/nvtype.c
+++ b/src/cmd/ksh93/sh/nvtype.c
@@ -139,7 +139,7 @@ static const Namdisc_t type_disc =
 	0,
 };
 
-static char *Null = "";
+static char *AltEmpty = "";
 
 size_t nv_datasize(Namval_t *np, size_t *offset)
 {
@@ -335,7 +335,7 @@ static int fixnode(Namtype_t *dp, Namtype_t *pp, int i, struct Namref *nrp,int f
 				nv_offattr(nq,NV_NOFREE);
 			}
 		}
-		else if(nq->nvalue.cp==Null)
+		else if(nq->nvalue.cp==AltEmpty)
 			nq->nvalue.cp = Empty;
 		else if(nq->nvalue.cp==Empty)
 			nv_offattr(nq,NV_NOFREE);
@@ -1165,7 +1165,7 @@ Namval_t *nv_mktype(Namval_t **nodes, int numnodes)
 			if(!nq->nvalue.cp && nq->nvfun== &pp->childfun.fun)
 			{
 				if(nv_isattr(np,NV_ARRAY|NV_NOFREE)==(NV_ARRAY|NV_NOFREE))
-					nq->nvalue.cp = Null;
+					nq->nvalue.cp = AltEmpty;
 				else
 					nq->nvalue.cp = Empty;
 			}

--- a/src/cmd/ksh93/tests/types.sh
+++ b/src/cmd/ksh93/tests/types.sh
@@ -591,7 +591,7 @@ $SHELL << \EOF
 			 compound p=( hello=world )
 			 c.b.binsert p 1 $i
 		done
-		exp='typeset -C c=(board_t b=(typeset -a board_y=( [1]=(typeset -a board_x=( [0]=(field=(hello=world;))[1]=(field=(hello=world)));));))'
+		exp='typeset -C c=(board_t b=(typeset -C -a board_y=( [1]=(typeset -a board_x=( [0]=(field=(hello=world;))[1]=(field=(hello=world)));));))'
 		[[ $(typeset -p c) == "$exp" ]] || exit 1
 	}
 	main
@@ -632,6 +632,13 @@ typeset -T Bar_t=(
 Bar_t bar
 bar.foo+=(bam)
 [[ ${bar.foo[0]} == bam ]] || err_exit 'appending to empty array variable in type does not create element 0'
+
+# ======
+# Compound arrays listed with 'typeset -p' should have their -C attribute
+# preserved in the output.
+typeset -T Z_t=(compound -a x)
+Z_t z
+[[ $(typeset -p z.x) ==  *'-C -a'* ]] || err_exit 'typeset -p for compound array element does not display all attributes'
 
 # ======
 # Type names that have 'a' as the first letter should be functional


### PR DESCRIPTION
This bugfix was initially backported from ksh93v- 2012-10-04 as part of the matchfixes branch (one of the 93v- `.sh.match` regression tests depends on this bugfix). I've separated the bugfix into its own pull request as it's a more general change affecting all compound array types.

The bug fixed by this change is one that causes `typeset -p` to omit the `-C` flag when listing compound arrays belonging to a type:
```sh
$ typeset -T Foo_t=(compound -a bar)
$ Foo_t baz
$ typeset -p baz.bar
typeset -a baz.bar=''  # This should be 'typeset -C -a'
```

src/cmd/ksh93/sh/nvtype.c:
- Backport change from 93v- 2012-10-04 that sets the array `nvalue` to a pointer named `Null` (which is `""`) in `nv_mktype()`, then to `Empty` in `fixnode()`.

src/cmd/ksh93/tests/types.sh:
- Backport the relevant 93v- changes to the types regression tests.