### PR TITLE
Fix one buffer overflow in `typeset -p .sh.type`

### DIFF
--- a/src/cmd/ksh93/sh/nvtype.c
+++ b/src/cmd/ksh93/sh/nvtype.c
@@ -1473,7 +1473,7 @@ int	sh_outtype(Sfio_t *out)
 	{
 		if(nv_isnull(tp) || !nv_isvtree(tp))
 			continue;
-		if(indent && (memcmp(tp->nvname,sh.prefix,n-1) || tp->nvname[n-1]!='.' || strchr(tp->nvname+n,'.')))
+		if(indent && (strncmp(tp->nvname,sh.prefix,n-1) || tp->nvname[n-1]!='.' || strchr(tp->nvname+n,'.')))
 			continue;
 		nv_settype(L_ARGNOD,tp,0);
 		if(indent)


### PR DESCRIPTION
This small commit replaces one instance of `memcmp` with `strncmp` to fix one of the buffer overflows that causes `typeset -p .sh.type` to crash (see also https://github.com/ksh93/ksh/issues/456).