### PR TITLE
Remove unnecessary `sh.defpathlist` variable (re: 24d5cd85)

### DIFF
--- a/src/cmd/ksh93/include/shell.h
+++ b/src/cmd/ksh93/include/shell.h
@@ -349,7 +349,6 @@ struct Shell_s
 	void		*lex_context;
 	void		*arg_context;
 	void		*pathlist;
-	void		*defpathlist;
 	void		*cdpathlist;
 	char		**argaddr;
 	char		cond_expan;	/* set while processing ${var=val}, ${var:=val}, ${var?err}, ${var:?err} */

--- a/src/cmd/ksh93/sh/path.c
+++ b/src/cmd/ksh93/sh/path.c
@@ -41,12 +41,12 @@
 #define LIBCMD	"cmd"
 
 
-static int		canexecute(char*,int);
-static void		funload(int,const char*);
-static void noreturn	exscript(char*, char*[], char**);
-static int		checkdotpaths(Pathcomp_t*,Pathcomp_t*,Pathcomp_t*,int);
-static void		checkdup(register Pathcomp_t*);
-static Pathcomp_t	*defpathinit(void);
+static int			canexecute(char*,int);
+static void			funload(int,const char*);
+static void noreturn		exscript(char*, char*[], char**);
+static int			checkdotpaths(Pathcomp_t*,Pathcomp_t*,Pathcomp_t*,int);
+static void			checkdup(register Pathcomp_t*);
+static inline Pathcomp_t	*defpathinit(void);
 
 static const char *std_path(void)
 {
@@ -366,7 +366,7 @@ Pathcomp_t *path_nextcomp(register Pathcomp_t *pp, const char *name, Pathcomp_t 
 	return((Pathcomp_t*)0);
 }
 
-static Pathcomp_t* defpathinit(void)
+static inline Pathcomp_t* defpathinit(void)
 {
 	return(path_addpath((Pathcomp_t*)0,std_path(),PATH_PATH));
 }
@@ -381,8 +381,7 @@ static void pathinit(void)
 	}
 	else
 	{
-		if(!(pp=(Pathcomp_t*)sh.defpathlist))
-			pp = defpathinit();
+		pp = defpathinit();
 		sh.pathlist = (void*)path_dup(pp);
 	}
 	if(val=sh_scoped((FPATHNOD))->nvalue.cp)
@@ -407,8 +406,7 @@ Pathcomp_t *path_get(const char *name)
 	}
 	if(!pp && (!(sh_scoped(PATHNOD)->nvalue.cp)) || sh_isstate(SH_DEFPATH))
 	{
-		if(!(pp=(Pathcomp_t*)sh.defpathlist))
-			pp = defpathinit();
+		pp = defpathinit();
 	}
 	return(pp);
 }
@@ -630,12 +628,7 @@ int	path_search(register const char *name,Pathcomp_t **oldpp, int flag)
 		stakputc(0);
 		return(0);
 	}
-	if(sh_isstate(SH_DEFPATH))
-	{
-		if(!sh.defpathlist)
-			defpathinit();
-	}
-	else if(!sh.pathlist)
+	if(!sh_isstate(SH_DEFPATH) && !sh.pathlist)
 		pathinit();
 	if(flag)
 	{
@@ -663,8 +656,8 @@ int	path_search(register const char *name,Pathcomp_t **oldpp, int flag)
 	}
 	if(flag==0 || !pp || (pp->flags&PATH_FPATH))
 	{
-		if(!pp)
-			pp=sh_isstate(SH_DEFPATH)?sh.defpathlist:sh.pathlist;
+		if(!pp && !sh_isstate(SH_DEFPATH))
+			pp = sh.pathlist;
 		if(pp && strlen(name)<256 && strmatch(name,e_alphanum) && (fno=opentype(name,pp,1))>=0)
 		{
 			if(flag >= 2)
@@ -1635,12 +1628,7 @@ Pathcomp_t *path_addpath(Pathcomp_t *first, register const char *path,int type)
 	if(old)
 	{
 		if(!first && !path)
-		{
-			Pathcomp_t *pp = (Pathcomp_t*)sh.defpathlist;
-			if(!pp)
-				pp = defpathinit();
-			first = path_dup(pp);
-		}
+			first = path_dup(defpathinit());
 		if(cp=(sh_scoped(FPATHNOD))->nvalue.cp)
 			first = (void*)path_addpath((Pathcomp_t*)first,cp,PATH_FPATH);
 		path_delete(old);

--- a/src/cmd/ksh93/sh/path.c
+++ b/src/cmd/ksh93/sh/path.c
@@ -41,12 +41,12 @@
 #define LIBCMD	"cmd"
 
 
-static int			canexecute(char*,int);
-static void			funload(int,const char*);
-static void noreturn		exscript(char*, char*[], char**);
-static int			checkdotpaths(Pathcomp_t*,Pathcomp_t*,Pathcomp_t*,int);
-static void			checkdup(register Pathcomp_t*);
-static inline Pathcomp_t	*defpathinit(void);
+static int		canexecute(char*,int);
+static void		funload(int,const char*);
+static void noreturn	exscript(char*, char*[], char**);
+static int		checkdotpaths(Pathcomp_t*,Pathcomp_t*,Pathcomp_t*,int);
+static void		checkdup(register Pathcomp_t*);
+static Pathcomp_t	*defpathinit(void);
 
 static const char *std_path(void)
 {
@@ -366,7 +366,7 @@ Pathcomp_t *path_nextcomp(register Pathcomp_t *pp, const char *name, Pathcomp_t 
 	return((Pathcomp_t*)0);
 }
 
-static inline Pathcomp_t* defpathinit(void)
+static Pathcomp_t* defpathinit(void)
 {
 	return(path_addpath((Pathcomp_t*)0,std_path(),PATH_PATH));
 }


### PR DESCRIPTION
The `sh.defpathlist` variable is never set once, which makes every use of this variable unnecessary (as it's always null). This commit removes `sh.defpathlist` while also fixing a possible memory leak (there was another location where `defpathinit()` was invoked without saving the returned pointer, causing a memory leak).