### PR TITLE
Fix infinite loop when `posix_spawn` fails (re: f762a81a)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,11 +3,18 @@ For full details, see the git log at: https://github.com/ksh93/ksh
 
 Any uppercase BUG_* names are modernish shell bug IDs.
 
-2022-08-23:
+2022-02-23:
 
 - When reading input from the keyboard, ksh now turns off nonblocking I/O
   mode for standard input if a previously ran program left it on, so that
   interactive programs that expect it to be off work properly.
+
+- Fixed a regression introduced on 2022-02-02 that caused interactive shells
+  to enter an infinite loop when a command failed to execute on Linux
+  systems with version 2.35 of glibc.
+
+- Fixed a SIGTTOU lockup that could cause ksh to freeze under strace(1) after
+  a command failed to execute in an interactive shell.
 
 2022-02-18:
 

--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -3606,7 +3606,7 @@ static pid_t sh_ntfork(const Shnode_t *t,char *argv[],int *jobid,int flag)
 					signal(SIGTSTP,SIG_DFL);
 			}
 			if(job.jobcontrol)
-				tcsetpgrp(job.fd,job.mypgid);
+				tcsetpgrp(job.fd,sh.pid);
 #endif /* _use_ntfork_tcpgrp */
 			switch(errno=sh.path_err)
 			{

--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -3593,19 +3593,26 @@ static pid_t sh_ntfork(const Shnode_t *t,char *argv[],int *jobid,int flag)
 	fail:
 		if(jobfork && spawnpid<0) 
 			job_fork(-2);
-		if(spawnpid == -1) switch(errno=sh.path_err)
+		if(spawnpid == -1)
 		{
-		    case ENOENT:
-			errormsg(SH_DICT,ERROR_exit(ERROR_NOENT),e_found+4);
-			UNREACHABLE();
+#if _use_ntfork_tcpgrp
+			if(job.jobcontrol)
+				tcsetpgrp(job.fd,job.mypgid);
+#endif /* _use_ntfork_tcpgrp */
+			switch(errno=sh.path_err)
+			{
+			    case ENOENT:
+				errormsg(SH_DICT,ERROR_exit(ERROR_NOENT),e_found+4);
+				UNREACHABLE();
 #ifdef ENAMETOOLONG
-		    case ENAMETOOLONG:
-			errormsg(SH_DICT,ERROR_exit(ERROR_NOENT),e_toolong+4);
-			UNREACHABLE();
+			    case ENAMETOOLONG:
+				errormsg(SH_DICT,ERROR_exit(ERROR_NOENT),e_toolong+4);
+				UNREACHABLE();
 #endif
-		    default:
-			errormsg(SH_DICT,ERROR_system(ERROR_NOEXEC),e_exec+4);
-			UNREACHABLE();
+			    default:
+				errormsg(SH_DICT,ERROR_system(ERROR_NOEXEC),e_exec+4);
+				UNREACHABLE();
+			}
 		}
 		job_unlock();
 	}

--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -3596,6 +3596,15 @@ static pid_t sh_ntfork(const Shnode_t *t,char *argv[],int *jobid,int flag)
 		if(spawnpid == -1)
 		{
 #if _use_ntfork_tcpgrp
+			if(jobwasset)
+			{
+				signal(SIGTTIN,SIG_IGN);
+				signal(SIGTTOU,SIG_IGN);
+				if(sh_isstate(SH_INTERACTIVE))
+					signal(SIGTSTP,SIG_IGN);
+				else
+					signal(SIGTSTP,SIG_DFL);
+			}
 			if(job.jobcontrol)
 				tcsetpgrp(job.fd,job.mypgid);
 #endif /* _use_ntfork_tcpgrp */


### PR DESCRIPTION
This commit fixes an infinite loop introduced in commit f762a81a that caused ksh to enter an infinite loop if `posix_spawn` failed
to start a new process after setting the terminal process group. Reproducer (warning: it will cause ksh to crash Wayland sessions and drives up CPU usage by a ton):
```sh
$ /tmp/this/file/does/not/exist
/usr/bin/ksh: /tmp/this/file/does/not/exist: not found
$ # Press enter
$ 
# ksh now prints $PS1 in a loop until killed with SIGKILL
```

src/cmd/ksh93/sh/xec.c: `sh_ntfork()`:
- Restore the terminal process group if `posix_spawn` failed to launch a new process. This is necessary because `posix_spawn` will set the terminal process group before it attempts to run a command and doesn't restore it on failure.