### PR TITLE
slowread(): Turn off O_NONBLOCK for stdin if it is on

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -18,6 +18,7 @@ ksh 93u+m general copyright notice
 #             Johnothan King <johnothanking@protonmail.com>            #
 #          hyenias <58673227+hyenias@users.noreply.github.com>         #
 #               Anuradha Weeraman <anuradha@weeraman.com>              #
+#                   atheik <atteh.mailbox@gmail.com>                   #
 #                   Chase <nicetrynsa@protonmail.ch>                   #
 #                 Finnbarr P. Murphy <fpm@hotmail.com>                 #
 #                 Govind Kamat <govind_kamat@yahoo.com>                #

--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,12 @@ For full details, see the git log at: https://github.com/ksh93/ksh
 
 Any uppercase BUG_* names are modernish shell bug IDs.
 
+2022-08-23:
+
+- When reading input from the keyboard, ksh now turns off nonblocking I/O
+  mode for standard input if a previously ran program left it on, so that
+  interactive programs that expect it to be off work properly.
+
 2022-02-18:
 
 - Fixed a regression introduced on 2021-04-11 that caused the += operator in

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -21,7 +21,7 @@
 
 #define SH_RELEASE_FORK	"93u+m"		/* only change if you develop a new ksh93 fork */
 #define SH_RELEASE_SVER	"1.1.0-alpha"	/* semantic version number: https://semver.org */
-#define SH_RELEASE_DATE	"2022-02-18"	/* must be in this format for $((.sh.version)) */
+#define SH_RELEASE_DATE	"2022-02-23"	/* must be in this format for $((.sh.version)) */
 #define SH_RELEASE_CPYR	"(c) 2020-2022 Contributors to ksh " SH_RELEASE_FORK
 
 /* Scripts sometimes field-split ${.sh.version}, so don't change amount of whitespace. */

--- a/src/cmd/ksh93/sh/io.c
+++ b/src/cmd/ksh93/sh/io.c
@@ -1944,7 +1944,7 @@ static ssize_t piperead(Sfio_t *iop,void *buff,register size_t size,Sfdisc_t *ha
 static ssize_t slowread(Sfio_t *iop,void *buff,register size_t size,Sfdisc_t *handle)
 {
 	int	(*readf)(void*, int, char*, int, int);
-	int	reedit=0, rsize;
+	int	reedit=0, rsize, n, fno;
 #if SHOPT_HISTEXPAND
 	char    *xp=0;
 #endif /* SHOPT_HISTEXPAND */
@@ -1969,6 +1969,14 @@ static ssize_t slowread(Sfio_t *iop,void *buff,register size_t size,Sfdisc_t *ha
 		errno = EINTR;
 		return(-1);
 	}
+	fno = sffileno(iop);
+#ifdef O_NONBLOCK
+	if((n=fcntl(fno,F_GETFL,0))!=-1 && n&O_NONBLOCK)
+	{
+		n &= ~O_NONBLOCK;
+		fcntl(fno, F_SETFL, n);
+	}
+#endif /* O_NONBLOCK */
 	while(1)
 	{
 		if(io_prompt(iop,sh.nextprompt)<0 && errno==EIO)


### PR DESCRIPTION
This change turns off O_NONBLOCK for stdin if a previously ran
program left it on so that interactive programs that expect it
to be off work properly.

src/cmd/ksh93/sh/io.c: slowread():
- Turn off O_NONBLOCK for stdin if it is on.

Fixes: #469