### PR TITLE
Backport ksh93v- regression tests and fix various regression test bugs

### DIFF
--- a/src/cmd/ksh93/tests/alias.sh
+++ b/src/cmd/ksh93/tests/alias.sh
@@ -163,14 +163,14 @@ got=$(
 
 # Listing members of the hash table with 'alias -pt' should work
 exp='alias -t cat
-vi: tracked alias not found
+ls: tracked alias not found
 alias -t cat
 alias -t chmod'
 got=$(
 	set +x
 	redirect 2>&1
 	hash -r cat chmod
-	alias -pt cat vi  # vi shouldn't be added to the hash table
+	alias -pt cat ls  # ls shouldn't be added to the hash table
 	alias -pt
 )
 [[ $exp == $got ]] || err_exit "Listing members of the hash table with 'alias -pt' doesn't work" \
@@ -228,12 +228,12 @@ ret=$?
 	"(expected 2, got $ret)"
 
 # Detect zombie aliases with 'alias'.
-exp='vi: alias not found
+exp='ls: alias not found
 chmod: alias not found'
 got=$($SHELL -c '
-	hash vi chmod
+	hash ls chmod
 	hash -r
-	alias vi chmod
+	alias ls chmod
 ' 2>&1)
 ret=$?
 [[ $exp == $got ]] || err_exit "Listing removed tracked aliases with 'alias' should fail with an error message" \
@@ -242,12 +242,12 @@ ret=$?
 	"(expected 2, got $ret)"
 
 # Detect zombie aliases with 'alias -p'.
-exp='vi: alias not found
+exp='ls: alias not found
 chmod: alias not found'
 got=$($SHELL -c '
-	hash vi chmod
+	hash ls chmod
 	hash -r
-	alias -p vi chmod
+	alias -p ls chmod
 ' 2>&1)
 ret=$?
 [[ $exp == $got ]] || err_exit "Listing removed tracked aliases with 'alias -p' should fail with an error message" \
@@ -256,12 +256,12 @@ ret=$?
 	"(expected 2, got $ret)"
 
 # Detect zombie tracked aliases.
-exp='vi: tracked alias not found
+exp='ls: tracked alias not found
 chmod: tracked alias not found'
 got=$($SHELL -c '
-	hash vi chmod
+	hash ls chmod
 	hash -r
-	alias -pt vi chmod
+	alias -pt ls chmod
 ' 2>&1)
 ret=$?
 [[ $exp == $got ]] || err_exit "Listing removed tracked aliases with 'alias -pt' should fail with an error message" \

--- a/src/cmd/ksh93/tests/arith.sh
+++ b/src/cmd/ksh93/tests/arith.sh
@@ -2,7 +2,7 @@
 #                                                                      #
 #               This software is part of the ast package               #
 #          Copyright (c) 1982-2012 AT&T Intellectual Property          #
-#          Copyright (c) 2020-2021 Contributors to ksh 93u+m           #
+#          Copyright (c) 2020-2022 Contributors to ksh 93u+m           #
 #                      and is licensed under the                       #
 #                 Eclipse Public License, Version 1.0                  #
 #                    by AT&T Intellectual Property                     #

--- a/src/cmd/ksh93/tests/arith.sh
+++ b/src/cmd/ksh93/tests/arith.sh
@@ -948,4 +948,39 @@ got=$(typeset -Z x=0x15; set +x; { echo $((x)); } 2>&1)
 	"(expected $(printf %q "$exp"), got $(printf %q "$got"))"
 
 # ======
+# Test for 'set -u' backported from ksh93v- 2013-09-26
+unset IFS i
+set -u
+float -a ar
+function f
+{
+	integer i=0 ar_i=0
+	for	(( i=0 ; i < 3 ; i++ ))
+	do	(( ar[ar_i++]=i))
+	done
+	printf "%q\n" "${ar[*]}"
+}
+[[ $(f) == "'0 1 2'" ]] || err_exit '0 value for variable in arithmetic expression inside function with set -u fails'
+set +u
+
+# Test for unset x.NOT_KNOWN floating point variable (backported
+# from ksh93v- 2013-09-13).
+unset x
+float x
+((x.NOT_KNOWN == 0)) || err_exit 'x.NOT_KNOWN is unknown and should have value 0'
+
+# Test for a bug with short integers that causes core dumps
+# (backported from ksh93v- 2013-08-07).
+"$SHELL" <<- \EOF || err_exit 'detected short integer bug that causes core dumps'
+       typeset -s -i -a t
+       typeset -s -i p
+       (( p=2**17 )) # tape start position
+       (( t[p]+=13))
+       while (( t[p] != 0 ))
+       do      ((t[p]-=1 , p+=1))
+       done
+       exit 0
+EOF
+
+# ======
 exit $((Errors<125?Errors:125))

--- a/src/cmd/ksh93/tests/arrays.sh
+++ b/src/cmd/ksh93/tests/arrays.sh
@@ -820,4 +820,8 @@ got=$(typeset -p foo)
 	"(expected $(printf %q "$exp"), got $(printf %q "$got"))"
 
 # ======
+# Regression test for 'typeset -a' from ksh93v- 2013-04-02
+"$SHELL" -c 'a=(foo bar); [[ $(typeset -a) == *"a=("*")"* ]]' || err_exit "'typeset -a' doesn't work correctly"
+
+# ======
 exit $((Errors<125?Errors:125))

--- a/src/cmd/ksh93/tests/arrays2.sh
+++ b/src/cmd/ksh93/tests/arrays2.sh
@@ -224,6 +224,13 @@ exp=3
 [[ ${foo[bar][x]} == $exp ]] || err_exit "subscript gets added incorrectly to an associative array when ++ operator is called" \
 	"(expected '$exp', got '${foo[bar][x]}')"
 
+unset A
+typeset -A A
+typeset -A A[a]
+A[a][z]=1
+[[ ${!A[a][@]} == z ]] || err_exit 'A[a] should only have subscript z' \
+	"(got $(printf %q "${!A[a][@]}"))"
+
 # ======
 # Multidimensional arrays with an unset method shouldn't cause a crash.
 # The test itself must be run inside of a function.

--- a/src/cmd/ksh93/tests/attributes.sh
+++ b/src/cmd/ksh93/tests/attributes.sh
@@ -738,4 +738,17 @@ unset .foo.bar .foo
 set +o allexport
 
 # ======
+# Regression test from ksh93v- 2012-10-24 for testing the zerofill width
+# after exporting a variable.
+unset exp got
+typeset -Z4 VAR1
+VAR1=1
+exp=$(typeset -p VAR1)
+export VAR1
+got=$(typeset -p VAR1)
+got=${got/ -x/}
+[[ $got == "$exp" ]] || err_exit 'typeset -x causes zerofill width to change' \
+	"(expected $(printf %q "$exp"), got $(printf %q "$got"))"
+
+# ======
 exit $((Errors<125?Errors:125))

--- a/src/cmd/ksh93/tests/basic.sh
+++ b/src/cmd/ksh93/tests/basic.sh
@@ -347,7 +347,7 @@ then	[[ $($SHELL -c 'cat <(print foo)' 2> /dev/null) == foo ]] || err_exit 'proc
 	[[ $({ $SHELL -c 'cat <(for i in x y z; do print $i; done)';} 2> /dev/null) == $'x\ny\nz' ]] ||
 		err_exit 'process substitution of compound commands not working'
 fi
-[[ $($SHELL -r 'command -p :' 2>&1) == *restricted* ]]  || err_exit 'command -p not restricted'
+[[ $($SHELL -cr 'command -p :' 2>&1) == *restricted* ]]  || err_exit 'command -p not restricted'
 print cat >  $tmp/scriptx
 chmod +x $tmp/scriptx
 [[ $($SHELL -c "print foo | $tmp/scriptx ;:" 2> /dev/null ) == foo ]] || err_exit 'piping into script fails'

--- a/src/cmd/ksh93/tests/bracket.sh
+++ b/src/cmd/ksh93/tests/bracket.sh
@@ -355,6 +355,9 @@ test ! ! ! 2> /dev/null || err_exit 'test ! ! ! should return 0'
 test ! ! x 2> /dev/null || err_exit 'test ! ! x should return 0'
 test ! ! '' 2> /dev/null && err_exit 'test ! ! "" should return non-zero'
 
+x=10
+([[ x -eq 10 ]]) 2> /dev/null || err_exit 'x -eq 10 fails in [[...]] with x=10'
+
 # ======
 # The POSIX mode should disable the ancient 'test -t' compatibility hack.
 if	[[ -o ?posix ]]

--- a/src/cmd/ksh93/tests/comvario.sh
+++ b/src/cmd/ksh93/tests/comvario.sh
@@ -652,6 +652,11 @@ test_read_type_crash
 test_read_C_into_array
 test_read_C_special_shell_keywords
 
+unset bar
+enum bool=(false true)
+bool -a bar
+bar[3]=true
+[[ $((5+bar[3])) != 6 ]] && err_exit '$((5+bar[3])) should be 6'
 
 # tests done
 exit $((Errors<125?Errors:125))

--- a/src/cmd/ksh93/tests/comvario.sh
+++ b/src/cmd/ksh93/tests/comvario.sh
@@ -2,7 +2,7 @@
 #                                                                      #
 #               This software is part of the ast package               #
 #          Copyright (c) 1982-2012 AT&T Intellectual Property          #
-#          Copyright (c) 2020-2021 Contributors to ksh 93u+m           #
+#          Copyright (c) 2020-2022 Contributors to ksh 93u+m           #
 #                      and is licensed under the                       #
 #                 Eclipse Public License, Version 1.0                  #
 #                    by AT&T Intellectual Property                     #

--- a/src/cmd/ksh93/tests/enum.sh
+++ b/src/cmd/ksh93/tests/enum.sh
@@ -57,7 +57,7 @@ done
 typeset -T X_t=( typeset name=aha )
 typeset -a[X_t] arr
 ) 2> /dev/null
-[[ $? == 1 ]] || err_exit 'typeset -a[X_t] should generate an error message when X-t is not an enumeration type'
+[[ $? == 1 ]] || err_exit 'typeset -a[X_t] should generate an error message when X_t is not an enumeration type'
 
 typeset -a [Color_t] arr
 arr[green]=foo
@@ -167,6 +167,28 @@ got=$("$SHELL" -c 'enum trap=(BAD TYPE)' 2>&1)
 exp=': trap: is a special shell builtin'
 [[ $got == *"$exp" ]] || err_exit "enum overrides special builtin" \
 	"(expected match of *$(printf %q "$exp"); got $(printf %q "$got"))"
+
+# ======
+# Various tests backported from ksh93v- for enum type arrays.
+enum bool=(false true)
+bool -A a=( [2]=true [4]=false )
+exp=true
+got=${a[2]}
+[[ $got == $exp ]] || err_exit 'associative array assignment failure when using enums' \
+	"(expected $(printf %q "$exp"); got $(printf %q "$got"))"
+exp=2
+got=${#a[@]}
+[[ $got == $exp ]] || err_exit 'bool -A a should only have two elements' \
+	"(expected $(printf %q "$exp"); got $(printf %q "$got"))"
+
+bool -a bia
+(( bia[4]=false ))
+[[ ${bia[3]} ]] && err_exit 'empty index array element should not produce a value'
+(( bia[3] == 0 )) || err_exit 'empty index array element should be numerically 0'
+bool -A baa
+(( baa[4]=false ))
+[[ ${baa[3]} ]] && err_exit 'empty associative array element should not produce a value'
+(( baa[3] == 0 )) || err_exit 'empty associative array element should be numerically 0'
 
 # ======
 exit $((Errors<125?Errors:125))

--- a/src/cmd/ksh93/tests/exit.sh
+++ b/src/cmd/ksh93/tests/exit.sh
@@ -2,7 +2,7 @@
 #                                                                      #
 #               This software is part of the ast package               #
 #          Copyright (c) 1982-2011 AT&T Intellectual Property          #
-#          Copyright (c) 2020-2021 Contributors to ksh 93u+m           #
+#          Copyright (c) 2020-2022 Contributors to ksh 93u+m           #
 #                      and is licensed under the                       #
 #                 Eclipse Public License, Version 1.0                  #
 #                    by AT&T Intellectual Property                     #

--- a/src/cmd/ksh93/tests/exit.sh
+++ b/src/cmd/ksh93/tests/exit.sh
@@ -183,4 +183,25 @@ done
 || err_exit 'Redirection error with function execution causes shell to exit'
 
 # ======
+# Backported regression test from ksh93v- 2014-09-29 for the
+# exit status of functions in command substitutions.
+foo() {
+  print -r foo | read
+  return 1
+}
+o1=$(foo "foo")
+status=$?
+exp=1
+((exp == status)) ||  err_exit 'function which fails inside of a command substitution returns wrong exit status' \
+	"(expected '$exp', got '$status')"
+
+# Backported test from ksh93v- 2014-07-21 for the exit status
+# of subshells with a failing command without pipefail enabled.
+x=$({ sleep .1; false;} | true)
+status=$?
+exp=0
+(( exp == status )) || err_exit 'without pipefail, non-zero exit in pipeline causes command substitution to fail' \
+	"(expected '$exp', got '$status')"
+
+# ======
 exit $((Errors<125?Errors:125))

--- a/src/cmd/ksh93/tests/functions.sh
+++ b/src/cmd/ksh93/tests/functions.sh
@@ -392,7 +392,7 @@ function closure
 	done
 	return $r
 }
-closure 0 || err_exit -u2 'for loop function optimization bug2'
+closure 0 || err_exit 'for loop function optimization bug'
 dir=$tmp/dir
 mkdir $dir
 cd $dir || { err_exit "cd $dir failed"; exit 1; }

--- a/src/cmd/ksh93/tests/heredoc.sh
+++ b/src/cmd/ksh93/tests/heredoc.sh
@@ -2,7 +2,7 @@
 #                                                                      #
 #               This software is part of the ast package               #
 #          Copyright (c) 1982-2012 AT&T Intellectual Property          #
-#          Copyright (c) 2020-2021 Contributors to ksh 93u+m           #
+#          Copyright (c) 2020-2022 Contributors to ksh 93u+m           #
 #                      and is licensed under the                       #
 #                 Eclipse Public License, Version 1.0                  #
 #                    by AT&T Intellectual Property                     #

--- a/src/cmd/ksh93/tests/heredoc.sh
+++ b/src/cmd/ksh93/tests/heredoc.sh
@@ -515,6 +515,14 @@ EOF' 2>&1)
 $SHELL -c '$(true << !)
 !' 2> /dev/null && err_exit "a here-doc that isn't completed before the closing ) in a command substitution doesn't cause an error"
 
+# Here-document test backported from ksh93v- 2014-04-15 for backtick
+# command substitutions.
+x=$("$SHELL" -c 'test=`"$SHELL" 2>&1 << EOF
+print $?
+EOF`
+print $test')
+[[ $x == 0 ]] || err_exit  '`` command substitution containing here-doc not working'
+
 # ======
 # Check that ${p}, where p is a special parameter, does not cause a syntax error in a here-document.
 # Bug for ${!} and ${$} reported at: https://github.com/ksh93/ksh/issues/127
@@ -524,6 +532,15 @@ ${'"$p"'}
 EOF
 ' 2>&1) || err_exit "special parameter \${$p} throws syntax error in here-document (got \"$err\")"
 done
+
+# ======
+# Regression test for the cat builtin backported from
+# ksh93v- 2013-08-29.
+if builtin cat 2> /dev/null; then
+	exp='foo bar baz bork blah blarg'
+	got=$(cat <<<"foo bar baz" 3<&0 <<<"$(</dev/fd/3) bork blah blarg")
+	[[ $got == "$exp" ]] || '3<%0 does not work when 0 is <<< here-doc'
+fi
 
 # ======
 exit $((Errors<125?Errors:125))

--- a/src/cmd/ksh93/tests/leaks.sh
+++ b/src/cmd/ksh93/tests/leaks.sh
@@ -2,7 +2,7 @@
 #                                                                      #
 #               This software is part of the ast package               #
 #          Copyright (c) 1982-2012 AT&T Intellectual Property          #
-#          Copyright (c) 2020-2021 Contributors to ksh 93u+m           #
+#          Copyright (c) 2020-2022 Contributors to ksh 93u+m           #
 #                      and is licensed under the                       #
 #                 Eclipse Public License, Version 1.0                  #
 #                    by AT&T Intellectual Property                     #

--- a/src/cmd/ksh93/tests/locale.sh
+++ b/src/cmd/ksh93/tests/locale.sh
@@ -2,7 +2,7 @@
 #                                                                      #
 #               This software is part of the ast package               #
 #          Copyright (c) 1982-2012 AT&T Intellectual Property          #
-#          Copyright (c) 2020-2021 Contributors to ksh 93u+m           #
+#          Copyright (c) 2020-2022 Contributors to ksh 93u+m           #
 #                      and is licensed under the                       #
 #                 Eclipse Public License, Version 1.0                  #
 #                    by AT&T Intellectual Property                     #
@@ -400,7 +400,6 @@ then	LC_ALL=en_US.UTF-8
 			== "$got" ]] \
 		|| err_exit "incorrect string from printf %q"
 	fi
-	
 fi
 
 # ======

--- a/src/cmd/ksh93/tests/options.sh
+++ b/src/cmd/ksh93/tests/options.sh
@@ -2,7 +2,7 @@
 #                                                                      #
 #               This software is part of the ast package               #
 #          Copyright (c) 1982-2012 AT&T Intellectual Property          #
-#          Copyright (c) 2020-2021 Contributors to ksh 93u+m           #
+#          Copyright (c) 2020-2022 Contributors to ksh 93u+m           #
 #                      and is licensed under the                       #
 #                 Eclipse Public License, Version 1.0                  #
 #                    by AT&T Intellectual Property                     #

--- a/src/cmd/ksh93/tests/path.sh
+++ b/src/cmd/ksh93/tests/path.sh
@@ -955,4 +955,17 @@ exp=$PWD$'\n'$PWD
         "(expected $(printf %q "$exp"), got $(printf %q "$got"))"
 
 # ======
+# Test backported from ksh93v- 2013-06-28 for deleting
+# a loaded libcmd builtin.
+if builtin cat 2> /dev/null
+then	path=$PATH
+	PATH=/bin:/usr/bin
+	if [[ $(type -t cat) == builtin ]]
+	then	builtin -d cat
+		[[ $(type -t cat) == builtin ]] && err_exit 'builtin -d does not delete builtin libcmd builtin'
+	fi
+fi
+PATH=$path
+
+# ======
 exit $((Errors<125?Errors:125))

--- a/src/cmd/ksh93/tests/quoting.sh
+++ b/src/cmd/ksh93/tests/quoting.sh
@@ -2,7 +2,7 @@
 #                                                                      #
 #               This software is part of the ast package               #
 #          Copyright (c) 1982-2011 AT&T Intellectual Property          #
-#          Copyright (c) 2020-2021 Contributors to ksh 93u+m           #
+#          Copyright (c) 2020-2022 Contributors to ksh 93u+m           #
 #                      and is licensed under the                       #
 #                 Eclipse Public License, Version 1.0                  #
 #                    by AT&T Intellectual Property                     #

--- a/src/cmd/ksh93/tests/quoting.sh
+++ b/src/cmd/ksh93/tests/quoting.sh
@@ -362,4 +362,13 @@ ARGS=("$@")
 set -- "${ARGS[@]}"
 (( $# )) &&  err_exit 'set -- "${ARGS[@]}" for empty array should not produce arguments'
 
+# ======
+# Backported tests from ksh93v- 2013-04-22 for using
+# backslashes in variables.
+x=\\x
+[[ x == $x ]] && err_exit "\$x='$x' should not match x"
+case x in
+$x) err_exit "case \$x='$x' should not match x";;
+esac
+
 exit $((Errors<125?Errors:125))

--- a/src/cmd/ksh93/tests/sh_match.sh
+++ b/src/cmd/ksh93/tests/sh_match.sh
@@ -210,7 +210,7 @@ cat >"${testscript}" <<-TEST1SCRIPT
 			printf '\\n'
 		} >"\${tmpfile}"
 
-		diff -u <( printf '%s\\n' "\${xtext}") "\${tmpfile}"
+		diff -u <( printf '%s\\n' "\${xtext}") "\${tmpfile}" | sed '/No differences encountered/d'
 		if cmp <( printf '%s\\n' "\${xtext}") "\${tmpfile}" ; then
 			printf "#input and output OK (%d characters).\\n" "\$(wc -m <"\${tmpfile}")"
 		else

--- a/src/cmd/ksh93/tests/shtests
+++ b/src/cmd/ksh93/tests/shtests
@@ -13,7 +13,7 @@ USAGE=$'
 [-author?David Korn <dgk@research.att.com>]
 [-author?Glenn Fowler <gsf@research.att.com>]
 [-copyright?(c) 2000-2012 AT&T Intellectual Property]
-[-copyright?(c) 2020-2021 Contributors to https://github.com/ksh93/ksh]
+[-copyright?(c) 2020-2022 Contributors to https://github.com/ksh93/ksh]
 [-license?http://www.eclipse.org/org/documents/epl-v10.html]
 [+NAME?shtests - ksh regression test harness]
 [+DESCRIPTION?\bshtests\b is the \bksh\b(1) regression test harness for

--- a/src/cmd/ksh93/tests/signal.sh
+++ b/src/cmd/ksh93/tests/signal.sh
@@ -568,5 +568,11 @@ got=$("$SHELL" -c 'trap + INT; "$SHELL" -c '\''kill -s INT $$'\''; echo "$?, con
 	"(got status $e$( ((e>128)) && print -n /SIG && kill -l "$e"), $(printf %q "$got"))"
 trap - INT
 
+# Test for 'trap - INT' backported from ksh93v- 2013-07-27
+float s=SECONDS
+(trap - INT; exec sleep 2) & sleep .5; kill -sINT $!
+wait $!
+(( (SECONDS-s) < 1.8)) && err_exit "'trap - INT' causing trap to not be ignored"
+
 # ======
 exit $((Errors<125?Errors:125))

--- a/src/cmd/ksh93/tests/substring.sh
+++ b/src/cmd/ksh93/tests/substring.sh
@@ -306,7 +306,7 @@ done
 
 (
 PS4=$tmpPS4
-[[ $(string=$string $SHELL -c  ": \${string/$pattern/}; print \${.sh.match[26]}") == Z ]] || err_exit -u2 'sh.match[26] not Z'
+[[ $(string=$string $SHELL -c  ": \${string/$pattern/}; print \${.sh.match[26]}") == Z ]] || err_exit 'sh.match[26] not Z'
 : ${string/$pattern/}
 (( ${#.sh.match[@]} == 53 )) || err_exit '.sh.match has wrong number of elements'
 [[ ${.sh.match[@]:2:4} == 'B C D E'  ]] || err_exit '${.sh.match[@]:2:4} incorrect'

--- a/src/cmd/ksh93/tests/types.sh
+++ b/src/cmd/ksh93/tests/types.sh
@@ -621,7 +621,6 @@ function main
 	for ((i=2 ; i < 8 ; i++ )) ; do
 		pawn_t c.board[1][$i]
 	done
-	
 }
 main 2> /dev/null && err_exit 'type assignment to compound array instance should generate an error'
 

--- a/src/cmd/ksh93/tests/types.sh
+++ b/src/cmd/ksh93/tests/types.sh
@@ -724,5 +724,16 @@ exp=$'start1\ntypeset -x a=one\nstart2\ntypeset -x a=one\nend2\nend1'
 [[ $got == "$exp" ]] || err_exit 'exporting variable to #!-less script' \
 	"(expected $(printf %q "$exp"), got $(printf %q "$got"))"
 
+# Backported regression test from ksh93v- 2013-08-07 for
+# short integer arrays in types.
+got=$("$SHELL" 2>&1 <<- \EOF
+       typeset -T X_t=(typeset -si -a arr=(7 8) )
+       X_t x
+       print -r -- $((x.arr[1]))
+EOF) || err_exit "short integer arrays in types fails (got exit status $?)"
+exp=8
+[[ $got == $exp ]] || err_exit "short integer arrays in types isn't working correctly" \
+	"(expected $(printf %q "$exp"), got $(printf %q "$got"))"
+
 # ======
 exit $((Errors<125?Errors:125))

--- a/src/cmd/ksh93/tests/variables.sh
+++ b/src/cmd/ksh93/tests/variables.sh
@@ -561,6 +561,10 @@ actual=$*
 [[ $actual == "$expect" ]] || err_exit "IFS failed with invalid multi-byte character" \
 	"(expected $(printf %q "$expect"), got $(printf %q "$actual"))"
 
+# Backported test from ksh93v- 2013-06-28 for 'unset IFS'
+unset IFS
+[[ ${IFS+abc} ]] && err_exit "testing for unset IFS not working"
+
 # ^^^ end: IFS tests ^^^
 # restore default split:
 unset IFS


### PR DESCRIPTION
Changes in this pull request:

- tests/*.sh: Backported many additional regression tests and test fixes from the alpha and beta releases of ksh93v-.

- tests/alias.sh: Avoid trying to add `vi` to the hash table, as some platforms do not provide a `vi` implementation installed as part of the default system. This fixes a regression test failure I was getting in one of my Linux virtual machines.

- tests/builtins.sh: Fixed a bug in one of the regression tests that caused an incorrect total error count if any of the tests failed.

- tests/sh_match.sh: Fixed a regression test failure on DragonFly BSD caused by the `diff` command printing an extra 'No differences encountered' line.