### PR TITLE
Fix a few minor issues

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -54,7 +54,7 @@ Any uppercase BUG_* names are modernish shell bug IDs.
 
 - Filescan loops are now disabled at runtime if the --posix option is active
   as they break a portable use case: POSIXly, 'while <file; do stuff; done'
-  repeatedly excutes 'stuff' while 'file' can successfully be opened for
+  repeatedly executes 'stuff' while 'file' can successfully be opened for
   reading, without actually reading from 'file'.
 
 2022-02-12:
@@ -84,7 +84,7 @@ Any uppercase BUG_* names are modernish shell bug IDs.
   The ability of 'typeset -T' to redefine a type is not affected.
 
 - A command like 'typeset -T foo_t' without any assignment no longer creates
-  an incompletely defined 'foo_t' built-in comamnd that will crash the shell
+  an incompletely defined 'foo_t' built-in command that will crash the shell
   when used. Instead, it is now silently ignored for backwards compatibility.
 
 - Compound arrays belonging to a type created with 'typeset -T' now have
@@ -310,7 +310,7 @@ Any uppercase BUG_* names are modernish shell bug IDs.
 2021-12-16:
 
 - Changed the default selection of compiled-in /opt/ast/bin built-in libcmd
-  command to: basename, cat, cp, cut, dirname, getconf, ln, mktemp, mv.
+  commands to: basename, cat, cp, cut, dirname, getconf, ln, mktemp, mv.
   Add /opt/ast/bin to your $PATH to use these. Type 'cp --man', etc. for info.
 
 - A bug introduced on 2020-09-17 was fixed that caused interactive ksh to exit
@@ -1152,7 +1152,7 @@ Any uppercase BUG_* names are modernish shell bug IDs.
   to lose the output of the commands they ran. This bug occurred when ksh was
   compiled with the SHOPT_SPAWN compile-time option.
 
-- Bugfix: var=$(< file) now reads the file even if the standard inout, standard
+- Bugfix: var=$(< file) now reads the file even if the standard input, standard
   output and/or standard error file descriptors are closed.
 
 2020-09-20:

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ To run the default test sets for ksh and the build system, use:
 ```sh
 bin/package test
 ```
-For ksh, use the `shtests` command direclty to control the regression test runs.
+For ksh, use the `shtests` command directly to control the regression test runs.
 Start by reading the information printed by:
 ```sh
 bin/shtests --man

--- a/src/cmd/INIT/iffe.sh
+++ b/src/cmd/INIT/iffe.sh
@@ -424,7 +424,7 @@ noisy()
 copy() # "output-file" "data-that-must-not-be-processed-by-echo"
 {
 	# Some ksh88 clones (pdksh, mksh) lack 'printf' as a built-in utility, so if a
-	# ksh-type shell was detected, use the 'print' built-in for better peformance.
+	# ksh-type shell was detected, use the 'print' built-in for better performance.
 	case $1 in
 	-)	case $shell in
 		ksh)	print -r - "$2"

--- a/src/cmd/ksh93/README-AUDIT.md
+++ b/src/cmd/ksh93/README-AUDIT.md
@@ -103,7 +103,7 @@ Next we turn our attention to the auditing facility. Assuming ksh has been
 compiled with the `SHOPT_AUDIT` option (the default), you must create an audit
 configuration file on each system to tell ksh93 where to store the audit
 records and to specify which users are to be audited. The configuration file
-must be readable by the users whose activites are audited. Its default
+must be readable by the users whose activities are audited. Its default
 location is `/etc/ksh_audit` but that can be changed in the `SHOPT.sh` file.
 The configuration file should contain a line that defines the file to write
 the audit records to, followed by the UID of each user whose commands are to

--- a/src/cmd/ksh93/bltins/read.c
+++ b/src/cmd/ksh93/bltins/read.c
@@ -19,7 +19,7 @@
 *                                                                      *
 ***********************************************************************/
 /*
- * read [-ACprsSv] [-d delim] [-u fd] [-t timeout] [-n count] [-N count] [var?prompt] [var ...]
+ * read [-AaCprsSv] [-d delim] [-u fd] [-t timeout] [-n count] [-N count] [var?prompt] [var ...]
  *
  *   David Korn
  *   AT&T Labs

--- a/src/cmd/ksh93/bltins/test.c
+++ b/src/cmd/ksh93/bltins/test.c
@@ -483,7 +483,6 @@ int test_unop(register int op,register const char *arg)
 				np = nv_refnode(np);
 			else
 				return(0);
-			
 		}
 		if(ap = nv_arrayptr(np))
 			return(nv_arrayisset(np,ap));

--- a/src/cmd/ksh93/bltins/typeset.c
+++ b/src/cmd/ksh93/bltins/typeset.c
@@ -906,7 +906,6 @@ static int     setall(char **argv,register int flag,Dt_t *troot,struct tdata *tp
 				{
 					if(!(flag&NV_RJUST))
 						newflag &= ~NV_RJUST;
-					
 					else if(!(flag&NV_LJUST))
 						newflag &= ~NV_LJUST;
 				}
@@ -1601,7 +1600,6 @@ static void print_scan(Sfio_t *file, int flag, Dt_t *root, int option,struct tda
 				}
 				else if((flag&NV_IARRAY))
 					continue;
-				
 			}
 			tp->scanmask = flag&~NV_NOSCOPE;
 			tp->scanroot = root;

--- a/src/cmd/ksh93/edit/edit.c
+++ b/src/cmd/ksh93/edit/edit.c
@@ -69,7 +69,6 @@ static Lex_t *savelex;
     {
 	switch(c)
 	{
-	    
 	    case cntl('A'): return('A');
 	    case cntl('B'): return('B');
 	    case cntl('C'): return('C');

--- a/src/cmd/ksh93/edit/emacs.c
+++ b/src/cmd/ksh93/edit/emacs.c
@@ -205,7 +205,6 @@ int ed_emacsread(void *context, int fd,char *buff,int scend, int reedit)
 	}
 	raw = 1;
 	/* This mess in case the read system call fails */
-	
 	ed_setup(ep->ed,fd,reedit);
 #if !SHOPT_MULTIBYTE
 	out = (genchar*)buff;
@@ -715,9 +714,7 @@ update:
 			continue;
 		}
 	}
-	
 process:
-
 	if (c == (-1))
 	{
 		lookahead = 0;
@@ -1414,7 +1411,6 @@ static void search(Emacs_t* ep,genchar *out,int direction)
 	}
 	skip:
 	i = genlen(string);
-	
 	if(ep->prevdirection == -2 && i!=2 || direction!=1)
 		ep->prevdirection = -1;
 	if (direction < 1)
@@ -1583,7 +1579,6 @@ static void draw(register Emacs_t *ep,Draw_t option)
 	**********************/
 	
 	i = ncursor - nscreen;
-	
 	if ((ep->offset && i<=ep->offset)||(i >= (ep->offset+w_size)))
 	{
 		/* Center the cursor on the screen */
@@ -1600,12 +1595,9 @@ static void draw(register Emacs_t *ep,Draw_t option)
 	
 	nptr = &nscreen[ep->offset];
 	sptr = ep->screen;
-	
 	i = w_size;
-	
 	while (i-- > 0)
 	{
-		
 		if (*nptr == '\0')
 		{
 			*(nptr + 1) = '\0';
@@ -1638,7 +1630,6 @@ static void draw(register Emacs_t *ep,Draw_t option)
 	if(ep->ed->e_multiline && option == REFRESH)
 		ed_setcursor(ep->ed, ep->screen, ep->ed->e_peol, ep->ed->e_peol, -1);
 
-	
 	/******************
 	
 	Screen overflow checks 

--- a/src/cmd/ksh93/edit/history.c
+++ b/src/cmd/ksh93/edit/history.c
@@ -178,7 +178,6 @@ static int sh_checkaudit(History_t *hp, const char *name, char *logbuf, size_t l
 done:
 	sh_close(fd);
 	return(r);
-	
 }
 #endif /* SHOPT_AUDIT */
 
@@ -1014,7 +1013,6 @@ int hist_copy(char *s1,int size,int command,int line)
 			}
 			*s1++ = c;
 		}
-			
 	}
 	sfseek(hp->histfp,(off_t)0,SEEK_END);
 	if(s1==0)

--- a/src/cmd/ksh93/sh/arith.c
+++ b/src/cmd/ksh93/sh/arith.c
@@ -516,7 +516,6 @@ static Sfdouble_t arith(const char **ptr, struct lval *lvalue, int type, Sfdoubl
 		sfsync(NIL(Sfio_t*));
 		if(lvalue->emode&ARITH_COMP)
 			return(-1);
-			
 		errormsg(SH_DICT,ERROR_exit((lvalue->emode&3)!=0),lvalue->value,*ptr);
 	}
 	*ptr = str;

--- a/src/cmd/ksh93/sh/fault.c
+++ b/src/cmd/ksh93/sh/fault.c
@@ -348,7 +348,6 @@ void	sh_sigreset(register int mode)
 				free(trap);
 			sh.st.trap[sig] = 0;
 		}
-		
 	}
 	if(sh.st.trapcom[0] && sh.st.trapcom[0] != Empty)
 		free(sh.st.trapcom[0]);

--- a/src/cmd/ksh93/sh/init.c
+++ b/src/cmd/ksh93/sh/init.c
@@ -1077,7 +1077,6 @@ static char* get_math(register Namval_t* np, Namfun_t *fp)
 	}
 	val = sfstruse(sh.strbuf);
 	return(val);
-	
 }
 
 static char *setdisc_any(Namval_t *np, const char *event, Namval_t *action, Namfun_t *fp)
@@ -1169,7 +1168,6 @@ int sh_type(register const char *path)
 {
 	register const char*	s;
 	register int		t = 0;
-	
 	if (s = (const char*)strrchr(path, '/'))
 	{
 		if (*path == '-')

--- a/src/cmd/ksh93/sh/lex.c
+++ b/src/cmd/ksh93/sh/lex.c
@@ -1994,7 +1994,6 @@ static int here_copy(Lex_t *lp,register struct ionod *iop)
 				special++;
 			fcget();
 			break;
-				
 		    case S_GRAVE:
 		    case S_DOL:
 			special++;

--- a/src/cmd/ksh93/sh/macro.c
+++ b/src/cmd/ksh93/sh/macro.c
@@ -1506,7 +1506,6 @@ retry1:
 			{
 				ap->nelem &= ~ARRAY_SCAN;
 				dolg = 0;
-		
 			}
 		}
 		break;
@@ -2659,7 +2658,6 @@ static void tilde_expand2(register int offset)
  * If ~name  is replaced with login directory of name.
  * If string doesn't start with ~ or ~... not found then 0 returned.
  */
-                                                            
 static char *sh_tilde(register const char *string)
 {
 	register char		*cp;

--- a/src/cmd/ksh93/sh/name.c
+++ b/src/cmd/ksh93/sh/name.c
@@ -353,7 +353,6 @@ void nv_setlist(register struct argnod *arg,register int flags, Namval_t *typ)
 						while(ap->argnxt.ap)
 							ap = ap->argnxt.ap;
 						ap->argnxt.ap = tp->com.comarg;
-						
 					}
 					tp->com.comarg = tp->com.comset;
 					tp->com.comset = 0;
@@ -506,7 +505,6 @@ void nv_setlist(register struct argnod *arg,register int flags, Namval_t *typ)
 						_nv_unset(np,NV_EXPORT);  /* this can free ap */
 						if(was_assoc_array)
 							 nv_setarray(np,nv_associative);
-				
 					}
 				}
 				else
@@ -1045,7 +1043,6 @@ Namval_t *nv_create(const char *name,  Dt_t *root, int flags, Namfun_t *dp)
 						flags &= ~NV_FARRAY;
 						if(fixed)
 							flags &= ~NV_ARRAY;
-							
 #endif /* SHOPT_FIXEDARRAY */
 					}
 					else
@@ -1101,7 +1098,6 @@ Namval_t *nv_create(const char *name,  Dt_t *root, int flags, Namfun_t *dp)
 							memcpy(sp+1,sub,n-2);
 							sp[n-1] = ']';
 							cp = sp+n;
-							
 						}
 					}
 					else if(c==0 && mode && (n=nv_aindex(np))>0)
@@ -1311,7 +1307,6 @@ Namval_t *nv_open(const char *name, Dt_t *root, int flags)
 #if NVCACHE
 	struct Cache_entry	*xp;
 #endif
-	
 	sh_stats(STAT_NVOPEN);
 	memset(&fun,0,sizeof(fun));
 	sh.openmatch = 0;
@@ -2333,7 +2328,6 @@ void sh_scope(struct argnod *envlist, int fun)
 	{
 		dtview(rp->sdict,newroot);
 		newroot = rp->sdict;
-	
 	}
 	dtview(newscope,(Dt_t*)newroot);
 	sh.var_tree = newscope;

--- a/src/cmd/ksh93/sh/nvdisc.c
+++ b/src/cmd/ksh93/sh/nvdisc.c
@@ -659,7 +659,6 @@ static void putdisc(Namval_t* np, const char* val, int flag, Namfun_t* fp)
 		nv_disc(np,fp,NV_POP);
 		if(!(fp->nofree&1))
 			free((void*)fp);
-			
 	}
 }
 

--- a/src/cmd/ksh93/sh/nvtree.c
+++ b/src/cmd/ksh93/sh/nvtree.c
@@ -874,7 +874,6 @@ static char **genvalue(char **argv, const char *prefix, int n, struct Walk *wp)
 					continue;
 				if((wp->array = nv_isarray(np)) && (ap=nv_arrayptr(np)))
 					k = array_elem(ap);
-					
 				if(wp->indent>0)
 					sfnputc(outfile,'\t',wp->indent);
 				nv_attribute(np,outfile,"typeset",1);

--- a/src/cmd/ksh93/sh/nvtype.c
+++ b/src/cmd/ksh93/sh/nvtype.c
@@ -339,7 +339,6 @@ static int fixnode(Namtype_t *dp, Namtype_t *pp, int i, struct Namref *nrp,int f
 			nq->nvalue.cp = Empty;
 		else if(nq->nvalue.cp==Empty)
 			nv_offattr(nq,NV_NOFREE);
-	
 	}
 	if(fp)
 		nv_disc(nq, &dp->childfun.fun, NV_LAST);
@@ -603,7 +602,6 @@ static int typeinfo(Opt_t* op, Sfio_t *out, const char *str, Optdisc_t *fp)
 	Namval_t	*np,*nq,*tp;
 	int		n, i, offset=staktell();
 	Sfio_t		*sp;
-	
 	np = *(Namval_t**)(fp+1);
 	stakputs(NV_CLASS);
 	stakputc('.');

--- a/src/cmd/ksh93/sh/parse.c
+++ b/src/cmd/ksh93/sh/parse.c
@@ -1641,7 +1641,6 @@ static Shnode_t *simple(Lex_t *lexp,int flag, struct ionod *io)
 				lexp->comp_assign = 2;
 				goto retry;
 			}
-			
 		}
 		if(!(flag&SH_NOIO))
 		{

--- a/src/cmd/ksh93/sh/path.c
+++ b/src/cmd/ksh93/sh/path.c
@@ -1432,7 +1432,6 @@ static noreturn void exscript(register char *path,register char *argv[],char **e
 		close( fd);
 	}
     }
- 
     /*
      * Produce a pseudo-floating point representation
      * with 3 bits base-8 exponent, 13 bits fraction.
@@ -1605,7 +1604,6 @@ Pathcomp_t *path_addpath(Pathcomp_t *first, register const char *path,int type)
 	Pathcomp_t *old=0;
 	int offset = staktell();
 	char *savptr;
-	
 	if(!path && type!=PATH_PATH)
 		return(first);
 	if(type!=PATH_FPATH)
@@ -1756,7 +1754,6 @@ Pathcomp_t *path_unsetfpath(void)
 				}
 				continue;
 			}
-			
 		}
 		old = pp;
 		pp = pp->next;

--- a/src/cmd/ksh93/sh/streval.c
+++ b/src/cmd/ksh93/sh/streval.c
@@ -870,7 +870,6 @@ again:
 				stakpush(vp,d,Sfdouble_t);
 				stakputc(lvalue.isfloat);
 			}
-	
 			/* check for function call */
 			if(lvalue.fun)
 				continue;

--- a/src/cmd/ksh93/sh/subshell.c
+++ b/src/cmd/ksh93/sh/subshell.c
@@ -313,7 +313,6 @@ Namval_t *sh_assignok(register Namval_t *np,int add)
 			nv_delete(mp,walk,NV_NOFREE);
 			*((Namval_t**)mp) = lp->child;
 			lp->child = mp;
-			
 		}
 	}
 	lp->dict = dp;

--- a/src/cmd/ksh93/sh/suid_exec.c
+++ b/src/cmd/ksh93/sh/suid_exec.c
@@ -498,7 +498,6 @@ static void maketemp(char *template)
 		*--cp = (n%10) + '0';
 		n /= 10;
 	}
-	
 }
 
 /*

--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -55,7 +55,7 @@
 #   include <sys/resource.h>
 #endif
 
-#if _lib_posix_spawn > 1 && _lib_posix_spawn_file_actions_addtcsetpgrp_np
+#if SHOPT_SPAWN && _lib_posix_spawn > 1 && _lib_posix_spawn_file_actions_addtcsetpgrp_np
 #define _use_ntfork_tcpgrp 1
 #endif
 
@@ -578,7 +578,6 @@ static void put_level(Namval_t* np,const char *val,int flags,Namfun_t *fp)
 	{
 		sh_setscope(sp);
 		error_info.id = sp->cmdname;
-		
 	}
 }
 
@@ -1088,7 +1087,6 @@ int sh_exec(register const Shnode_t *t, int flags)
 #endif /* SHOPT_NAMESPACE */
 							sh.prefix = NV_CLASS;
 							flgs |= NV_TYPE;
-			
 						}
 						if(sh.fn_depth && !sh.prefix)
 							flgs |= NV_NOSCOPE;
@@ -1465,7 +1463,6 @@ int sh_exec(register const Shnode_t *t, int flags)
 #endif /* SHOPT_NAMESPACE */
 							np = nv_search(com0,sh.fun_tree,HASH_NOSCOPE);
 						}
-						
 						if(!np->nvalue.ip)
 						{
 							if(indx==1)
@@ -1777,7 +1774,6 @@ int sh_exec(register const Shnode_t *t, int flags)
 						job_wait(parent);
 						sh_iorestore(topfd,SH_JMPCMD);
 						sh_done((sh.exitval&SH_EXITSIG)?(sh.exitval&SH_EXITMASK):0);
-
 					}
 					job_unlock();
 				}
@@ -3430,7 +3426,6 @@ static void coproc_init(int pipes[])
 		if(fcntl(*sh.cpipe,F_SETFD,FD_CLOEXEC)>=0)
 			sh.fdstatus[sh.cpipe[0]] |= IOCLEX;
 		sh.fdptrs[sh.cpipe[0]] = sh.cpipe;
-			
 		if(fcntl(sh.cpipe[1],F_SETFD,FD_CLOEXEC) >=0)
 			sh.fdstatus[sh.cpipe[1]] |= IOCLEX;
 	}

--- a/src/cmd/ksh93/tests/subshell.sh
+++ b/src/cmd/ksh93/tests/subshell.sh
@@ -1137,7 +1137,7 @@ fun()
 	print -n stdout=$foo
 	print -u2 stderr=$foo
 }
-[[ `fun 2>&1` == 'stdout=foostderr=foo' ]] || err_exit 'nested command substitution with 2>&1 not working'
+[[ `set +x; fun 2>&1` == 'stdout=foostderr=foo' ]] || err_exit 'nested command substitution with 2>&1 not working'
 
 # Various regression tests from ksh93v- 2012-10-04 and 2012-10-24
 $SHELL > /dev/null -c 'echo $(for x in whatever; do case y in *) true;; esac; done)' || err_exit 'syntax error with case in command substitution'

--- a/src/cmd/ksh93/tests/types.sh
+++ b/src/cmd/ksh93/tests/types.sh
@@ -725,7 +725,7 @@ exp=$'start1\ntypeset -x a=one\nstart2\ntypeset -x a=one\nend2\nend1'
 
 # Backported regression test from ksh93v- 2013-08-07 for
 # short integer arrays in types.
-got=$("$SHELL" 2>&1 <<- \EOF
+got=$(set +x; "$SHELL" 2>&1 <<- \EOF
        typeset -T X_t=(typeset -si -a arr=(7 8) )
        X_t x
        print -r -- $((x.arr[1]))

--- a/src/lib/libast/comp/setlocale.c
+++ b/src/lib/libast/comp/setlocale.c
@@ -2512,7 +2512,6 @@ single(int category, Lc_t* lc, unsigned int flags)
 			ast.locale.set &= ~(1<<category);
 		else
 			ast.locale.set |= (1<<category);
-		
 	}
 	else if (lc_categories[category].flags ^ flags)
 	{


### PR DESCRIPTION
Changes:
- Fixed two xtrace test failures introduced in commit cfc8744c.
- The definition of `_use_ntfork_tcpgrp` in xec.c is now dependent on `SHOPT_SPAWN` being defined (re: 8e9ed5be).
- Removed many unnecessary newlines and fixed various typos.