### PR TITLE
Fix building on Haiku and fix some typos

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -89,7 +89,7 @@ Any uppercase BUG_* names are modernish shell bug IDs.
   For example, this now writes 'OK' to standard error: cat >&2 <(echo OK)
 
 - Fixed the detection of a syntax error in compound assignments to
-  associative arays.
+  associative arrays.
 
 2022-07-02:
 
@@ -1743,8 +1743,8 @@ Any uppercase BUG_* names are modernish shell bug IDs.
 - Four of the date formats accepted by 'printf %()T' have had their
   functionality altered to the common behavior of date(1):
   - '%k' and '%l' print the current hour with blank padding, the former
-    based on a 24-hour clock and the latter a twelve hour clock. These
-    are common extensions present on Linux and *BSD.
+    based on a 24-hour clock and the latter a 12-hour clock. These are
+    common extensions present on Linux and *BSD.
   - '%f' prints a date with the format string '%Y.%m.%d-%H:%M:%S' (BusyBox).
   - '%q' prints the quarter of the year (GNU).
 

--- a/src/cmd/ksh93/README
+++ b/src/cmd/ksh93/README
@@ -277,8 +277,10 @@ failures (crashes, and/or important functionality does not work).
 	GNU/Linux: Ubuntu 18.04 on armv7l (32-bit)
 	GNU/Linux: Ubuntu 20.04 on arm64
 	GNU/Linux: Void Linux (musl C library) on x86_64
+***	Haiku R1/beta3 on x86_64
 ***	HP-UX B.11.11 on pa-risc
 *	illumos: OmniOS 2020-08-19 (gcc) on x86_64
+	illumos: OmniOS r151040 (gcc) on x86_64
 	macOS 10.13.6 (High Sierra) on x86_64
 	macOS 10.14.6 (Mojave) on x86_64
 *	macOS 12.0.1 (Monterey) on arm64
@@ -293,8 +295,7 @@ failures (crashes, and/or important functionality does not work).
 ***	Windows 7 using Cygwin on x86
 ***	Windows 10 using Cygwin on x86_64
 ***	Windows 11 using Cygwin on x86_64
-*	Windows 11 using WSL 2 with Ubuntu 20.04 on x86_64
-***	Haiku R1/beta3 on x86_64
+	Windows 11 using WSL 2 with Ubuntu 20.04 on x86_64
 
 #### REPORTING BUGS ####
 

--- a/src/cmd/ksh93/fun/man
+++ b/src/cmd/ksh93/fun/man
@@ -51,7 +51,7 @@ namespace man
 	# Check for a built-in with --man, i.e., if:
 	# - 'whence -t' says it is a built-in;
 	# - it is not :, true, false, or echo;
-	# - the name or path we would excute appears in output of 'builtin'.
+	# - the name or path we would execute appears in output of 'builtin'.
 	# This way, path-bound built-ins' --man is only used if found in $PATH.
 
 	builtin_has_selfdoc()
@@ -77,7 +77,7 @@ namespace man
 	# codes even if standard error is not on a terminal. Note that, in
 	# fact, all --man output is a glorified error message! Strange but
 	# true. So to capture the output, we need to redirect standard error to
-	# standard ouput (2>&1). Also, 'test' and '[' need special invocations.
+	# standard output (2>&1). Also, 'test' and '[' need special invocations.
 	#   Also note: '--??man' is safer as some programs may override --man;
 	# see any_builtin --??help (e.g., 'whence --??help') for more info.
 

--- a/src/cmd/ksh93/sh/lex.c
+++ b/src/cmd/ksh93/sh/lex.c
@@ -477,7 +477,7 @@ int sh_lex(Lex_t* lp)
 						{
 							if(lp->lex.intest)
 								return(c);
-							/* '((' arithmetic comamnd */
+							/* '((' arithmetic command */
 							lp->lexd.nest=1;
 							lp->lastline = sh.inlineno;
 							lp->lexd.lex_state = ST_NESTED;

--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -2125,7 +2125,7 @@ int sh_exec(register const Shnode_t *t, int flags)
 			&& tt->com.comio				/* ...and one I/O redirection... */
 			&& !tt->com.comio->ionxt			/* ...but not more than one... */
 			&& !(tt->com.comio->iofile & (IOPUT|IOAPP))	/* ...and not > or >> */
-			&& !sh_isoption(SH_POSIX))			/* not in POSIX compilance mode */
+			&& !sh_isoption(SH_POSIX))			/* not in POSIX compliance mode */
 			{
 				iop = openstream(tt->com.comio,&savein);
 			}

--- a/src/lib/libast/vmalloc/vmmopen.c
+++ b/src/lib/libast/vmalloc/vmmopen.c
@@ -16,6 +16,7 @@
 *                                                                      *
 ***********************************************************************/
 #include "FEATURE/vmalloc"
+#include <ast.h>
 #if !_hdr_sys_shm
 
 NoN(vmmapopen)


### PR DESCRIPTION
I tested the release candidate and have applied a few minor fixes (sorry I haven't contributed in a while, I've been a bit busy for the past few months):

- vmmopen.c: Include the ast.h header to fix a build error on Haiku caused by the otherwise undefined `NoN` macro (re: 05f0c1b1).
- Fixed a few minor typos and updated the list of tested systems in src/cmd/ksh93/README.