### PR TITLE
Fix sign conversion issue in `fmtquote()` and remove some dead code

### DIFF
--- a/src/lib/libast/path/pathcanon.c
+++ b/src/lib/libast/path/pathcanon.c
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 /*

--- a/src/lib/libast/path/pathcanon.c
+++ b/src/lib/libast/path/pathcanon.c
@@ -104,15 +104,11 @@ pathcanon_20100601(char* path, size_t size, int flags)
 					}
 					*(t - 2) = '.';
 				}
-#if PRESERVE_TRAILING_SLASH
-				if (t - 5 < r) r = t;
-#else
 				if (t - 5 < r)
 				{
 					if (t - 4 == r) t = r + 1;
 					else r = t;
 				}
-#endif
 				else for (t -= 5; t > r && *(t - 1) != '/'; t--);
 				break;
 			case 3:
@@ -166,11 +162,7 @@ pathcanon_20100601(char* path, size_t size, int flags)
 			{
 				if (t > path && !*(t - 1)) t--;
 				if (t == path) *t++ = '.';
-#if DONT_PRESERVE_TRAILING_SLASH
-				else if (t > path + 1 && *(t - 1) == '/') t--;
-#else
 				else if ((s <= path || *(s - 1) != '/') && t > path + 1 && *(t - 1) == '/') t--;
-#endif
 				*t = 0;
 				errno = oerrno;
 				return t;

--- a/src/lib/libast/string/fmtesc.c
+++ b/src/lib/libast/string/fmtesc.c
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 /*

--- a/src/lib/libast/string/fmtesc.c
+++ b/src/lib/libast/string/fmtesc.c
@@ -53,15 +53,16 @@ fmtquote(const char* as, const char* qb, const char* qe, size_t n, int flags)
 	register int		doublequote;
 	register int		singlequote;
 	int			shell;
+	size_t			len;
 	char*			f;
 	char*			buf;
 
-	c = 4 * (n + 1);
+	len = 4 * (n + 1);
 	if (qb)
-		c += strlen((char*)qb);
+		len += strlen((char*)qb);
 	if (qe)
-		c += strlen((char*)qe);
-	b = buf = fmtbuf(c);
+		len += strlen((char*)qe);
+	b = buf = fmtbuf(len);
 	shell = 0;
 	doublequote = 0;
 	singlequote = 0;


### PR DESCRIPTION
src/lib/libast/string/fmtesc.c:
\- Removed reuse of an int variable when obtaining string length to fix a few sign conversion compiler warnings. Ported from graphviz: https://gitlab.com/graphviz/graphviz/-/commit/6ccb41e4b839f314a131421d7e1aa1541646b6dc

src/lib/libast/path/pathcanon.c:
\- Removed unused code hidden behind `#if` directives for `PRESERVE_TRAILING_SLASH` and `DONT_PRESERVE_TRAILING_SLASH`. Ported from graphviz: https://gitlab.com/graphviz/graphviz/-/commit/1bbee4a58fc45ba7c45263e6bb5f2e77fd711409