### PR TITLE
Fix regression in handling of `head` builtin's `-s` flag (re: 4b445059)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,11 @@ This documents significant changes in the dev branch of ksh 93u+m.
 For full details, see the git log at: https://github.com/ksh93/ksh
 Uppercase BUG_* IDs are shell bug IDs as used by the Modernish shell library.
 
+2022-08-15:
+
+- Fixed a bug introduced on 2022-02-12 that would cause the optional head
+  builtin's -s option to fail.
+
 2022-08-06:
 
 - Fixed an interactive shell crashing on redefining, then unsetting one of

--- a/src/cmd/ksh93/tests/b_head.sh
+++ b/src/cmd/ksh93/tests/b_head.sh
@@ -1,0 +1,92 @@
+########################################################################
+#                                                                      #
+#               This software is part of the ast package               #
+#           Copyright (c) 2019-2020 Contributors to ksh2020            #
+#             Copyright (c) 2022 Contributors to ksh 93u+m             #
+#                      and is licensed under the                       #
+#                 Eclipse Public License, Version 2.0                  #
+#                                                                      #
+#                A copy of the License is available at                 #
+#      https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.html      #
+#         (with md5 checksum 84283fa8859daf213bdda5a9f8d1be1d)         #
+#                                                                      #
+#                 Kurtis Rader <krader@skepticism.us>                  #
+#            Johnothan King <johnothanking@protonmail.com>             #
+#                                                                      #
+########################################################################
+
+# Tests for `head` builtin
+
+. "${SHTESTS_COMMON:-${0%/*}/_common}"
+if ! builtin head 2> /dev/null; then
+	warning 'Could not detect head builtin; skipping tests'
+	exit 0
+fi
+
+cat > "$tmp/file1" <<EOF
+This is line 1 in file1
+This is line 2 in file1
+This is line 3 in file1
+This is line 4 in file1
+This is line 5 in file1
+This is line 6 in file1
+This is line 7 in file1
+This is line 8 in file1
+This is line 9 in file1
+This is line 10 in file1
+This is line 11 in file1
+This is line 12 in file1
+EOF
+
+cat > "$tmp/file2" <<EOF2
+This is line 1 in file2
+This is line 2 in file2
+This is line 3 in file2
+This is line 4 in file2
+This is line 5 in file2
+EOF2
+
+# ==========
+# -*n*; i.e., an integer presented as a flag.
+#
+# The `awk` invocation is to strip whitespace around the output of `wc` since it might pad the
+# value.
+exp=11
+got=$(head -11 < "$tmp/file1" | wc -l | awk '{ print $1 }')
+[[ "$got" = "$exp" ]] || err_exit "'head -n' failed" "(expected $(printf %q "$exp"), got $(printf %q "$got"))"
+
+# ==========
+#   -n, --lines=lines
+#                   Copy lines lines from each file. The default value is 10.
+got=$(head -n 3 "$tmp/file1")
+exp=$'This is line 1 in file1\nThis is line 2 in file1\nThis is line 3 in file1'
+[[ "$got" = "$exp" ]] || err_exit "'head -n' failed" "(expected $(printf %q "$exp"), got $(printf %q "$got"))"
+
+# ==========
+#   -c, --bytes=chars
+#                   Copy chars bytes from each file.
+got=$(head -c 14 "$tmp/file1")
+exp=$'This is line 1'
+[[ "$got" = "$exp" ]] || err_exit "'head -c' failed" "(expected $(printf %q "$exp"), got $(printf %q "$got"))"
+
+# ==========
+#   -q, --quiet|silent
+#                   Never output filename headers.
+got=$(head -q -n 3 "$tmp/file1" "$tmp/file2")
+exp=$'This is line 1 in file1\nThis is line 2 in file1\nThis is line 3 in file1\nThis is line 1 in file2\nThis is line 2 in file2\nThis is line 3 in file2'
+[[ "$got" = "$exp" ]] || err_exit "'head -q' failed" "(expected $(printf %q "$exp"), got $(printf %q "$got"))"
+
+# ==========
+#   -s, --skip=char Skip char characters or lines from each file before copying.
+got=$(head -s 5 -c 18 "$tmp/file1")
+exp=$'is line 1 in file1'
+[[ "$got" = "$exp" ]] || err_exit "'head -s' failed" "(expected $(printf %q "$exp"), got $(printf %q "$got"))"
+
+# ==========
+#   -v, --verbose   Always output filename headers.
+got=$(head -v -n 3 "$tmp/file1")
+exp=$'file1 <==\nThis is line 1 in file1\nThis is line 2 in file1\nThis is line 3 in file1'
+[[ "$got" =~ "$exp" ]] || err_exit "'head -v' failed" "(expected $(printf %q "$exp"), got $(printf %q "$got"))"
+
+# ======
+exit $((Errors<125?Errors:125))

--- a/src/lib/libast/sfio/sfmove.c
+++ b/src/lib/libast/sfio/sfmove.c
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 #include	"sfhdr.h"
@@ -41,7 +42,6 @@ Sfoff_t sfmove(Sfio_t*	fr,	/* moving data from this stream */
 	ssize_t		rsize = 0;
 
 	if(!(fr)) return (Sfoff_t)0;
-	if(fw)
 
 	for(n_move = 0; n != 0; )
 	{


### PR DESCRIPTION
Commit 4b445059 accidentally left in half of an if statement that was originally just a use of the `SFMTXBEGIN2` macro (which is a no-op without `vt_threaded` defined). As a result, `head -s` broke in one of the ksh2020 regression tests. Reproducer:
```bash
# Note that head must be enabled in src/cmd/ksh93/data/builtins.c
builtin head || exit 1
cat > "/tmp/file1" <<EOF
This is line 1 in file1
This is line 2 in file1
This is line 3 in file1
This is line 4 in file1
This is line 5 in file1
This is line 6 in file1
This is line 7 in file1
This is line 8 in file1
This is line 9 in file1
This is line 10 in file1
This is line 11 in file1
This is line 12 in file1
EOF
got=$(head -s 5 -c 18 "/tmp/file1")
exp=$'is line 1 in file1'
[[ "$got" = "$exp" ]] || print "'head -s' failed" "(expected $(printf %q "$exp"), got $(printf %q "$got"))"
```

This is the code change in src/lib/libast/sfio/sfmove.c that introduced the regression (note that since the if statement wasn't completely removed, it now guards the `for` loop despite the newline):
```diff
@@ -43,12 +43,9 @@ Sfoff_t sfmove(Sfio_t*	fr,	/* moving data from this stream */
 	Sfoff_t		n_move, sk, cur;
 	uchar		*rbuf = NIL(uchar*);
 	ssize_t		rsize = 0;
-	SFMTXDECL(fr);	/* declare a shadow stream variable for from stream */
-	SFMTXDECL2(fw);	/* declare a shadow stream variable for to stream */
 
-	SFMTXENTER(fr, (Sfoff_t)0);
+	if(!(fr)) return (Sfoff_t)0;
 	if(fw)
-		SFMTXBEGIN2(fw, (Sfoff_t)0);
 
 	for(n_move = 0; n != 0; )
 	{
```

I noticed this bug since I'm making a separate commit to backport more of the ksh2020 regression tests.

src/lib/libast/sfio/sfmove.c:
\- Remove the incomplete if statement to fix the `-s` flag.

src/cmd/ksh93/tests/b_head.sh:
\- Backport the ksh2020 regression tests for the `head` builtin.