### PR TITLE
vi mode: Disable = and tab at the start of the line

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,12 @@ This documents significant changes in the dev branch of ksh 93u+m.
 For full details, see the git log at: https://github.com/ksh93/ksh
 Uppercase BUG_* IDs are shell bug IDs as used by the Modernish shell library.
 
+2022-08-24:
+
+- Fixed a bug that caused ksh in the vi editor mode to crash or produce
+  invalid completions if ESC = was used at the beginning of a line. Both
+  tab and = completions are now disabled at the start of the command line.
+
 2022-08-20:
 
 - Fixed a bug in command line options processing that caused short-form

--- a/src/cmd/ksh93/edit/vi.c
+++ b/src/cmd/ksh93/edit/vi.c
@@ -1561,7 +1561,10 @@ static void getline(register Vi_t* vp,register int mode)
 				vp->ed->e_tabcount = 0;
 			}
 			if(cur_virt <= 0)
+			{
+				ed_ringbell();
 				break;
+			}
 			/* FALLTHROUGH */
 		default:
 		fallback:
@@ -1583,7 +1586,6 @@ static void getline(register Vi_t* vp,register int mode)
 			break;
 		}
 		refresh(vp,INPUT);
-
 	}
 }
 

--- a/src/cmd/ksh93/edit/vi.c
+++ b/src/cmd/ksh93/edit/vi.c
@@ -1560,6 +1560,8 @@ static void getline(register Vi_t* vp,register int mode)
 				}
 				vp->ed->e_tabcount = 0;
 			}
+			if(cur_virt <= 0)
+				break;
 			/* FALLTHROUGH */
 		default:
 		fallback:
@@ -2540,10 +2542,10 @@ addin:
 		/* FALLTHROUGH */
 	case '*':		/** do file name expansion in place **/
 	case '\\':		/** do file name completion in place **/
+	case '=':		/** list file name expansions **/
 		if( cur_virt == INVALID )
 			return(BAD);
 		/* FALLTHROUGH */
-	case '=':		/** list file name expansions **/
 		save_v(vp);
 		i = last_virt;
 		++last_virt;

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -18,7 +18,7 @@
 
 #define SH_RELEASE_FORK	"93u+m"		/* only change if you develop a new ksh93 fork */
 #define SH_RELEASE_SVER	"1.1.0-alpha"	/* semantic version number: https://semver.org */
-#define SH_RELEASE_DATE	"2022-08-20"	/* must be in this format for $((.sh.version)) */
+#define SH_RELEASE_DATE	"2022-08-24"	/* must be in this format for $((.sh.version)) */
 #define SH_RELEASE_CPYR	"(c) 2020-2022 Contributors to ksh " SH_RELEASE_FORK
 
 /* Scripts sometimes field-split ${.sh.version}, so don't change amount of whitespace. */

--- a/src/cmd/ksh93/sh.1
+++ b/src/cmd/ksh93/sh.1
@@ -5584,10 +5584,10 @@ or
 character.
 .TP 10
 .BI ^I  " tab"
-Attempts command or file name completion as described above
-and returns to input mode.
-If a partial completion occurs, repeating this will
-behave as if
+Except at the start of the line, attempts command or
+file name completion as described above and returns to
+input mode. If a partial completion occurs, repeating
+this will behave as if
 .B =
 were entered from control mode.
 If no match is found or entered after


### PR DESCRIPTION
Bring `vi` mode in line with `emacs` mode behavior at the start of the line by disabling `=` completion and `\t`. The purpose is to avoid buggy completions at the start of the line that can cause crashes in MacOS and OpenBSD. See Issue #520.

* Disabling `=`: Move an if-statement checking for `INVALID` `cur_virt` to include `=` mode along with `*` and `\` mode.
* Disabling `\t`: Add an if-statement checking for `cur_virt <= 0` in `case '\t'` of `getline`.