### PR TITLE
No completion before the first character or in an empty line

### DIFF
--- a/src/cmd/ksh93/edit/emacs.c
+++ b/src/cmd/ksh93/edit/emacs.c
@@ -779,10 +779,8 @@ static int escape(register Emacs_t* ep,register genchar *out,int count)
 {
 	register int i,value;
 	int digit,ch,c,d;
-	int x,allempty;
 	digit = 0;
 	value = 0;
-	allempty = 1;
 	while ((i=ed_getchar(ep->ed,0)),digit(i))
 	{
 		value *= 10;
@@ -1003,14 +1001,19 @@ static int escape(register Emacs_t* ep,register genchar *out,int count)
 			/* FALLTHROUGH */
 		case '*':		/* filename expansion */
 		case '=':	/* escape = - list all matching file names */
+		{
+			char allempty = 1;
+			int x;
 			ep->mark = cur;
 			for(x=0; x < cur; x++)
+			{
 				if(!isspace(out[x]))
 				{
 					allempty = 0;
 					break;
 				}
-			if(cur<1 || allempty==1)
+			}
+			if(cur<1 || allempty)
 			{
 				beep();
 				return(-1);
@@ -1048,6 +1051,7 @@ static int escape(register Emacs_t* ep,register genchar *out,int count)
 				draw(ep,UPDATE);
 			}
 			return(-1);
+		}
 
 		/* search back for character */
 		case cntl(']'):	/* feature not in book */

--- a/src/cmd/ksh93/edit/emacs.c
+++ b/src/cmd/ksh93/edit/emacs.c
@@ -1005,7 +1005,7 @@ static int escape(register Emacs_t* ep,register genchar *out,int count)
 		case '=':	/* escape = - list all matching file names */
 			ep->mark = cur;
 			for(x=0; x <= cur; x++)
-				if(out[x] > ' ')
+				if(!isspace(out[x]))
 				{
 					allempty = 0;
 					break;

--- a/src/cmd/ksh93/edit/emacs.c
+++ b/src/cmd/ksh93/edit/emacs.c
@@ -1004,7 +1004,7 @@ static int escape(register Emacs_t* ep,register genchar *out,int count)
 		case '*':		/* filename expansion */
 		case '=':	/* escape = - list all matching file names */
 			ep->mark = cur;
-			for(x=0; x <= cur; x++)
+			for(x=0; x < cur; x++)
 				if(!isspace(out[x]))
 				{
 					allempty = 0;

--- a/src/cmd/ksh93/edit/emacs.c
+++ b/src/cmd/ksh93/edit/emacs.c
@@ -779,8 +779,10 @@ static int escape(register Emacs_t* ep,register genchar *out,int count)
 {
 	register int i,value;
 	int digit,ch,c,d;
+	int x,allempty;
 	digit = 0;
 	value = 0;
+	allempty = 1;
 	while ((i=ed_getchar(ep->ed,0)),digit(i))
 	{
 		value *= 10;
@@ -1002,7 +1004,13 @@ static int escape(register Emacs_t* ep,register genchar *out,int count)
 		case '*':		/* filename expansion */
 		case '=':	/* escape = - list all matching file names */
 			ep->mark = cur;
-			if(cur<1)
+			for(x=0; x <= cur; x++)
+				if(out[x] > ' ')
+				{
+					allempty = 0;
+					break;
+				}
+			if(cur<1 || allempty==1)
 			{
 				beep();
 				return(-1);

--- a/src/cmd/ksh93/edit/vi.c
+++ b/src/cmd/ksh93/edit/vi.c
@@ -1350,7 +1350,7 @@ static void getline(register Vi_t* vp,register int mode)
 {
 	register int c;
 	register int tmp;
-	int	max_virt=0, last_save=0, backslash=0;
+	int	max_virt=0, last_save=0, backslash=0, x, allempty=1;
 	genchar saveline[MAXLINE];
 	vp->addnl = 1;
 
@@ -1537,6 +1537,17 @@ static void getline(register Vi_t* vp,register int mode)
 			return;
 
 		case '\t':		/** command completion **/
+			for(x=0; x <= cur_virt; x++)
+				if(!isspace(virtual[x]))
+				{
+					allempty = 0;
+					break;
+				}
+			if(allempty == 1)
+			{
+				ed_ringbell();
+				break;
+			}
 			if(sh_isoption(SH_VI) &&
 				mode != SEARCH &&
 				last_virt >= 0 &&

--- a/src/cmd/ksh93/edit/vi.c
+++ b/src/cmd/ksh93/edit/vi.c
@@ -1350,7 +1350,7 @@ static void getline(register Vi_t* vp,register int mode)
 {
 	register int c;
 	register int tmp;
-	int	max_virt=0, last_save=0, backslash=0, x, allempty=1;
+	int	max_virt=0, last_save=0, backslash=0;
 	genchar saveline[MAXLINE];
 	vp->addnl = 1;
 
@@ -1537,13 +1537,18 @@ static void getline(register Vi_t* vp,register int mode)
 			return;
 
 		case '\t':		/** command completion **/
+		{
+			char allempty = 1;
+			int x;
 			for(x=0; x <= cur_virt; x++)
+			{
 				if(!isspace(virtual[x]))
 				{
 					allempty = 0;
 					break;
 				}
-			if(allempty == 1)
+			}
+			if(allempty)
 			{
 				ed_ringbell();
 				break;
@@ -1577,6 +1582,7 @@ static void getline(register Vi_t* vp,register int mode)
 				break;
 			}
 			/* FALLTHROUGH */
+		}
 		default:
 		fallback:
 			if( mode == REPLACE )
@@ -2531,8 +2537,6 @@ static int textmod(register Vi_t *vp,register int c, int mode)
 	register int trepeat = vp->repeat;
 	genchar *savep;
 	int ch;
-	int x;
-	int allempty = 1;
 
 	if(mode && (fold(vp->lastmotion)=='F' || fold(vp->lastmotion)=='T')) 
 		vp->lastmotion = ';';
@@ -2558,13 +2562,18 @@ addin:
 	case '*':		/** do file name expansion in place **/
 	case '\\':		/** do file name completion in place **/
 	case '=':		/** list file name expansions **/
+	{
+		char allempty = 1;
+		int x;
 		for(x=0; x <= cur_virt; x++)
+		{
 			if(!isspace(virtual[x]))
 			{
 				allempty = 0;
 				break;
 			}
-		if( cur_virt == INVALID || allempty == 1 )
+		}
+		if(cur_virt == INVALID || allempty)
 			return(BAD);
 		/* FALLTHROUGH */
 		save_v(vp);
@@ -2603,6 +2612,7 @@ addin:
 			return(APPEND);
 		}
 		break;
+	}
 
 	case '@':		/** macro expansion **/
 		if( mode )

--- a/src/cmd/ksh93/edit/vi.c
+++ b/src/cmd/ksh93/edit/vi.c
@@ -2548,7 +2548,7 @@ addin:
 	case '\\':		/** do file name completion in place **/
 	case '=':		/** list file name expansions **/
 		for(x=0; x <= cur_virt; x++)
-			if(virtual[x] > ' ')
+			if(!isspace(virtual[x]))
 			{
 				allempty = 0;
 				break;

--- a/src/cmd/ksh93/edit/vi.c
+++ b/src/cmd/ksh93/edit/vi.c
@@ -2520,6 +2520,8 @@ static int textmod(register Vi_t *vp,register int c, int mode)
 	register int trepeat = vp->repeat;
 	genchar *savep;
 	int ch;
+	int x;
+	int allempty = 1;
 
 	if(mode && (fold(vp->lastmotion)=='F' || fold(vp->lastmotion)=='T')) 
 		vp->lastmotion = ';';
@@ -2545,7 +2547,13 @@ addin:
 	case '*':		/** do file name expansion in place **/
 	case '\\':		/** do file name completion in place **/
 	case '=':		/** list file name expansions **/
-		if( cur_virt == INVALID )
+		for(x=0; x <= cur_virt; x++)
+			if(virtual[x] > ' ')
+			{
+				allempty = 0;
+				break;
+			}
+		if( cur_virt == INVALID || allempty == 1 )
 			return(BAD);
 		/* FALLTHROUGH */
 		save_v(vp);

--- a/src/cmd/ksh93/sh.1
+++ b/src/cmd/ksh93/sh.1
@@ -4990,6 +4990,8 @@ will provide a numbered list of matching alternatives.
 A specific selection can be made by entering the
 selection number followed by a
 .IR tab .
+Neither completion nor listing operations are attempted before
+the first character in a line.
 .SS Key Bindings.
 The
 .B
@@ -5584,10 +5586,9 @@ or
 character.
 .TP 10
 .BI ^I  " tab"
-Except at the start of the line, attempts command or
-file name completion as described above and returns to
-input mode. If a partial completion occurs, repeating
-this will behave as if
+Attempts command or file name completion as described
+above and returns to input mode. If a partial completion
+occurs, repeating this will behave as if
 .B =
 were entered from control mode.
 If no match is found or entered after


### PR DESCRIPTION
There are still two contexts in which the unhelpful "alias + builtin + path" completion occurs:

* After the start of an empty line
* After the start of a line, but before the first character

To stop completion from being attempted in these contexts, a loop is added to `vi.c` and `emacs.c` that looks over the previous positions (current position inclusive) and allows the completion process to continue once it finds the first non-space character. The existing placement restrictions remain in case the cursor arrives in a negative position via a bug.

