### PR TITLE
vi mode: Do not attempt control mode 0 or ^ from the start of the line

### DIFF
--- a/src/cmd/ksh93/edit/vi.c
+++ b/src/cmd/ksh93/edit/vi.c
@@ -1629,12 +1629,6 @@ static int mvcursor(register Vi_t* vp,register int motion)
 	{
 		/***** Cursor move commands *****/
 
-	case '0':		/** First column **/
-		if(cur_virt <= 0)
-			return(ABORT);
-		tcur_virt = 0;
-		break;
-
 	case '^':		/** First nonblank character **/
 		if(cur_virt <= 0)
 			return(ABORT);

--- a/src/cmd/ksh93/edit/vi.c
+++ b/src/cmd/ksh93/edit/vi.c
@@ -2567,7 +2567,7 @@ addin:
 		int x;
 		for(x=0; x <= cur_virt; x++)
 		{
-			if(!isspace(virtual[x]))
+			if(!isspace(virtual[x]) && virtual[x] != 0)
 			{
 				allempty = 0;
 				break;

--- a/src/cmd/ksh93/edit/vi.c
+++ b/src/cmd/ksh93/edit/vi.c
@@ -741,17 +741,6 @@ static int cntlmode(Vi_t *vp)
 	{
 		vp->repeat_set = 0;
 		was_inmacro = inmacro;
-		if( c == '0' )
-		{
-			/*** move to leftmost column ***/
-			if(cur_virt > 0)
-			{
-				cur_virt = 0;
-				sync_cursor(vp);
-			}
-			continue;
-		}
-
 		if( digit(c) )
 		{
 			c = getcount(vp,c);
@@ -1628,6 +1617,12 @@ static int mvcursor(register Vi_t* vp,register int motion)
 	switch(motion)
 	{
 		/***** Cursor move commands *****/
+
+	case '0':		/** First column **/
+		if(cur_virt <= 0)
+			return(ABORT);
+		tcur_virt = 0;
+		break;
 
 	case '^':		/** First nonblank character **/
 		if(cur_virt <= 0)

--- a/src/cmd/ksh93/edit/vi.c
+++ b/src/cmd/ksh93/edit/vi.c
@@ -749,6 +749,10 @@ static int cntlmode(Vi_t *vp)
 				cur_virt = 0;
 				sync_cursor(vp);
 			}
+			else
+			{
+				ed_ringbell();	
+			}
 			continue;
 		}
 
@@ -1631,13 +1635,19 @@ static int mvcursor(register Vi_t* vp,register int motion)
 
 	case '0':		/** First column **/
 		if(cur_virt == INVALID)
+		{
+			ed_ringbell();
 			return(ABORT);	
+		}
 		tcur_virt = 0;
 		break;
 
 	case '^':		/** First nonblank character **/
 		if(cur_virt == INVALID)
+		{
+			ed_ringbell();
 			return(ABORT);
+		}
 		tcur_virt = first_virt;
 		while( tcur_virt < last_virt && isblank(tcur_virt) )
 			++tcur_virt;

--- a/src/cmd/ksh93/edit/vi.c
+++ b/src/cmd/ksh93/edit/vi.c
@@ -749,10 +749,6 @@ static int cntlmode(Vi_t *vp)
 				cur_virt = 0;
 				sync_cursor(vp);
 			}
-			else
-			{
-				ed_ringbell();	
-			}
 			continue;
 		}
 
@@ -1635,19 +1631,13 @@ static int mvcursor(register Vi_t* vp,register int motion)
 
 	case '0':		/** First column **/
 		if(cur_virt <= 0)
-		{
-			ed_ringbell();
-			return(ABORT);	
-		}
+			return(ABORT);
 		tcur_virt = 0;
 		break;
 
 	case '^':		/** First nonblank character **/
 		if(cur_virt <= 0)
-		{
-			ed_ringbell();
 			return(ABORT);
-		}
 		tcur_virt = first_virt;
 		while( tcur_virt < last_virt && isblank(tcur_virt) )
 			++tcur_virt;

--- a/src/cmd/ksh93/edit/vi.c
+++ b/src/cmd/ksh93/edit/vi.c
@@ -744,7 +744,7 @@ static int cntlmode(Vi_t *vp)
 		if( c == '0' )
 		{
 			/*** move to leftmost column ***/
-			if(cur_virt != INVALID)
+			if(cur_virt > 0)
 			{
 				cur_virt = 0;
 				sync_cursor(vp);
@@ -1634,7 +1634,7 @@ static int mvcursor(register Vi_t* vp,register int motion)
 		/***** Cursor move commands *****/
 
 	case '0':		/** First column **/
-		if(cur_virt == INVALID)
+		if(cur_virt <= 0)
 		{
 			ed_ringbell();
 			return(ABORT);	
@@ -1643,7 +1643,7 @@ static int mvcursor(register Vi_t* vp,register int motion)
 		break;
 
 	case '^':		/** First nonblank character **/
-		if(cur_virt == INVALID)
+		if(cur_virt <= 0)
 		{
 			ed_ringbell();
 			return(ABORT);

--- a/src/cmd/ksh93/edit/vi.c
+++ b/src/cmd/ksh93/edit/vi.c
@@ -744,8 +744,11 @@ static int cntlmode(Vi_t *vp)
 		if( c == '0' )
 		{
 			/*** move to leftmost column ***/
-			cur_virt = 0;
-			sync_cursor(vp);
+			if(cur_virt != INVALID)
+			{
+				cur_virt = 0;
+				sync_cursor(vp);
+			}
 			continue;
 		}
 
@@ -1627,10 +1630,14 @@ static int mvcursor(register Vi_t* vp,register int motion)
 		/***** Cursor move commands *****/
 
 	case '0':		/** First column **/
+		if(cur_virt == INVALID)
+			return(ABORT);	
 		tcur_virt = 0;
 		break;
 
 	case '^':		/** First nonblank character **/
+		if(cur_virt == INVALID)
+			return(ABORT);
 		tcur_virt = first_virt;
 		while( tcur_virt < last_virt && isblank(tcur_virt) )
 			++tcur_virt;
@@ -2567,7 +2574,7 @@ addin:
 		int x;
 		for(x=0; x <= cur_virt; x++)
 		{
-			if(!isspace(virtual[x]) && virtual[x] != 0)
+			if(!isspace(virtual[x]))
 			{
 				allempty = 0;
 				break;

--- a/src/cmd/ksh93/edit/vi.c
+++ b/src/cmd/ksh93/edit/vi.c
@@ -741,6 +741,9 @@ static int cntlmode(Vi_t *vp)
 	{
 		vp->repeat_set = 0;
 		was_inmacro = inmacro;
+
+		/*** see if it's a repeat count parameter ***/
+
 		if( digit(c) )
 		{
 			c = getcount(vp,c);


### PR DESCRIPTION
Please see [the comment below](https://github.com/ksh93/ksh/pull/524#issuecomment-1227071575).

Related to Issue #520. In `vi` mode, the bugged `/dev/fd/3` (or named FIFO in FreeBSD) completion can be reached by using `0` or `^` without first moving away from the start of the line and completing with `=` or `*`. This seems to happen because ~~a `NULL` is placed in position 0 if no character exists there~~ the cursor reaches position 0 without changing it from `NULL`. `isspace` does not detect `NULL`, so the completion attempt proceeds. ~~Checking for `virtual[x] != 0` (`NULL` in both ASCII and EBCDIC) in the `textmod` `allempty` loop stops the attempt.~~