### PR TITLE
Fix `%C` in `TIMEFORMAT` with the times(3) fallback and fix default precision

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,9 @@ Uppercase BUG_* IDs are shell bug IDs as used by the Modernish shell library.
 - Fixed a bug where 'command -x' would create a tracked alias for a command,
   causing 'whence' not to find an /opt/ast/bin built-in command correctly.
 
+- Fixed a bug in the 'time' keyword where the default precision of a format
+  specifier (e.g. %lU) was six instead of three, as documented.
+
 2022-08-30:
 
 - When printing a function definition, 'typeset -f function_name' now

--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -228,7 +228,7 @@ static void p_time(Sfio_t *out, const char *format, clock_t *tm)
 		if(c!='%')
 			continue;
 		unsigned char l_modifier = 0;
-		int precision = 6;
+		int precision = 3;
 
 		sfwrite(stkp, first, format-first);
 		c = *++format;
@@ -314,18 +314,26 @@ static void p_time(Sfio_t *out, const char *format, clock_t *tm)
 			n = 1;
 		else if(c=='S')
 			n = 2;
+		else if(c=='C')
+			n = 3;
 		else
 		{
 			stkseek(stkp,offset);
 			errormsg(SH_DICT,ERROR_exit(0),e_badtformat,c);
 			return;
 		}
-		d = (double)tm[n]/sh.lim.clk_tck;
+		if(n==3)
+		{
+			/* sum of U + S */
+			d = (double)((tm[1]+tm[2])/sh.lim.clk_tck);
+		}
+		else
+			d = (double)tm[n]/sh.lim.clk_tck;
 	skip:
 		if(l_modifier)
-			l_time(stkp, tm[n], precision);
+			l_time(stkp, n==3 ? tm[1] + tm[2] : tm[n], precision);
 		else
-			sfprintf(stkp,"%.*f",precision, d);
+			sfprintf(stkp,"%.*f", precision, d);
 #endif
 		first = format+1;
 	}

--- a/src/cmd/ksh93/tests/basic.sh
+++ b/src/cmd/ksh93/tests/basic.sh
@@ -584,6 +584,19 @@ actual=$(
 [[ $actual == "$expect" ]] || err_exit "'%' is not treated literally when placed after a format specifier" \
 	"(expected $(printf %q "$expect"), got $(printf %q "$actual"))"
 
+# A precision level of six should work, while the default
+# level of precision should be three.
+exp='0m00.[0-9]{6}s
+0m00.[0-9]{3}s'
+got=$(
+	TIMEFORMAT=$'%6lR\n%lC'
+	redirect 2>&1
+	set +x
+	time :
+)
+[[ $got =~ $exp ]] || err_exit "the supported precision levels in TIMEFORMAT don't function correctly" \
+	"(expected $(printf %q "$exp"), got $(printf %q "$got"))"
+
 # The locale's radix point shouldn't be ignored
 us=$(
 	LC_ALL='C.UTF-8' # radix point '.'


### PR DESCRIPTION
Changes:
- The man page documents the default precision level for `TIMEFORMAT` when no number is provided to a format specifier (i.e., `%lU`) should be three, not six. This was not how `time` behaved, so the default behavior has been corrected (a precision level of six remains usable with a format specifier such as `%6lU`).
- The times(3) fallback did not handle the `%C` format at all (re: a1af93f), because the aforementioned commit didn't apply the full patch. This commit implements the rest of the code for the `%C` format specifier.
- Added a regression test for `time` precision levels three and six.