### PR TITLE
Fix `LINENO` by incrementing it when skipping newlines

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,11 @@ This documents significant changes in the dev branch of ksh 93u+m.
 For full details, see the git log at: https://github.com/ksh93/ksh
 Uppercase BUG_* IDs are shell bug IDs as used by the Modernish shell library.
 
+2022-09-11:
+
+- Fixed a bug introduced in ksh93u+ 2012-04-23 that caused LINENO to have the
+  wrong value after parsing a multi-line compound assignment.
+
 2022-09-01:
 
 - Fixed a bug where 'command -x' would create a tracked alias for a command,

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -18,7 +18,7 @@
 
 #define SH_RELEASE_FORK	"93u+m"		/* only change if you develop a new ksh93 fork */
 #define SH_RELEASE_SVER	"1.1.0-alpha"	/* semantic version number: https://semver.org */
-#define SH_RELEASE_DATE	"2022-09-01"	/* must be in this format for $((.sh.version)) */
+#define SH_RELEASE_DATE	"2022-09-11"	/* must be in this format for $((.sh.version)) */
 #define SH_RELEASE_CPYR	"(c) 2020-2022 Contributors to ksh " SH_RELEASE_FORK
 
 /* Scripts sometimes field-split ${.sh.version}, so don't change amount of whitespace. */

--- a/src/cmd/ksh93/sh/lex.c
+++ b/src/cmd/ksh93/sh/lex.c
@@ -256,7 +256,9 @@ int sh_lex(Lex_t* lp)
 	if(lp->noreserv)
 	{
 		lp->lex.reservok = 0;
-		while((fcgetc(c)) && c==' ' || c== '\t' || c=='\n');
+		while((fcgetc(c)) && c==' ' || c== '\t' || c=='\n')
+			if(c=='\n')
+				sh.inlineno++;
 		fcseek(-LEN);
 		if(c=='[')
 			lp->assignok = SH_ASSIGN;

--- a/src/cmd/ksh93/sh/lex.c
+++ b/src/cmd/ksh93/sh/lex.c
@@ -256,7 +256,7 @@ int sh_lex(Lex_t* lp)
 	if(lp->noreserv)
 	{
 		lp->lex.reservok = 0;
-		while((fcgetc(c)) && c==' ' || c== '\t' || c=='\n')
+		while((fcgetc(c)) && (c==' ' || c== '\t' || c=='\n'))
 			if(c=='\n')
 				sh.inlineno++;
 		fcseek(-LEN);

--- a/src/cmd/ksh93/tests/variables.sh
+++ b/src/cmd/ksh93/tests/variables.sh
@@ -1461,4 +1461,18 @@ do
 done
 
 # ======
+# A regression introduced in ksh93u+ 2012-04-23 caused LINENO to have
+# the wrong value after parsing a multi-line compound assignment.
+# https://github.com/ksh93/ksh/issues/484
+exp=3
+got=$("$SHELL" <<-\EOF
+	x=(typeset -a x=(
+	                [1]=))
+	echo $LINENO
+	EOF
+)
+((exp == got)) || err_exit 'LINENO is wrong after a multi-line compound assignment' \
+	"(expected $exp, got $(printf %q "$got"))"
+
+# ======
 exit $((Errors<125?Errors:125))


### PR DESCRIPTION
In ksh93u+ 2012-04-23 a while loop was added to `sh_lex()` that skips newlines without incrementing `LINENO`:
https://github.com/ksh93/ksh/blob/4bc8bda11f5dcf2305f53bb46648e2f34269dc20/src/cmd/ksh93/sh/lex.c#L256-L263
2012-04-23 version: https://github.com/ksh93/ksh93-history/blob/2012-04-23/src/cmd/ksh93/sh/lex.c#L338-L345

This oversight has been fixed by incrementing `sh.inlineno` each time a line is skipped.

Resolves: https://github.com/ksh93/ksh/issues/484