### PR TITLE
Fix buffer overflow in quoting2.sh under ASan

### DIFF
--- a/src/cmd/ksh93/include/lexstates.h
+++ b/src/cmd/ksh93/include/lexstates.h
@@ -107,8 +107,8 @@
 #if SHOPT_MULTIBYTE
 #   define LEN		_Fcin.fclen
 #   define SETLEN(x)	(_Fcin.fclen = x)
-#   define isaname(c)	((c) < 0 ? 0 : ((c) > 0x7f ? iswalpha(c) : sh_lexstates[ST_NAME][(c)] == 0))
-#   define isaletter(c)	((c) < 0 ? 0 : ((c) > 0x7f ? iswalpha(c) : sh_lexstates[ST_DOL][(c)] == S_ALP && (c) != '.'))
+#   define isaname(c)	((c) < 0 ? 0 : ((c) > 0x7f ? isalpha(c) : sh_lexstates[ST_NAME][(c)] == 0))
+#   define isaletter(c)	((c) < 0 ? 0 : ((c) > 0x7f ? isalpha(c) : sh_lexstates[ST_DOL][(c)] == S_ALP && (c) != '.'))
 #else
 #   undef mbwide
 #   define mbwide()	(0)

--- a/src/cmd/ksh93/include/lexstates.h
+++ b/src/cmd/ksh93/include/lexstates.h
@@ -107,21 +107,21 @@
 #if SHOPT_MULTIBYTE
 #   define LEN		_Fcin.fclen
 #   define SETLEN(x)	(_Fcin.fclen = x)
-#   define isaname(c)	((c)>0x7f?isalpha(c): sh_lexstates[ST_NAME][(c)]==0)
-#   define isaletter(c)	((c)>0x7f?isalpha(c): sh_lexstates[ST_DOL][(c)]==S_ALP && (c)!='.')
+#   define isaname(c)	((c) < 0 ? 0 : ((c) > 0x7f ? isalpha(c) : sh_lexstates[ST_NAME][(c)] == 0))
+#   define isaletter(c)	((c) < 0 ? 0 : ((c) > 0x7f ? isalpha(c) : sh_lexstates[ST_DOL][(c)] == S_ALP && (c) != '.'))
 #else
 #   undef mbwide
 #   define mbwide()	(0)
 #   define LEN		1
 #   define SETLEN(x)	(x)
-#   define isaname(c)	(sh_lexstates[ST_NAME][c]==0)
-#   define isaletter(c)	(sh_lexstates[ST_DOL][c]==S_ALP && (c)!='.')
+#   define isaname(c)	((c) < 0 ? 0 : sh_lexstates[ST_NAME][c] == 0)
+#   define isaletter(c)	((c) < 0 ? 0 : (sh_lexstates[ST_DOL][c] == S_ALP && (c) != '.'))
 #endif
-#define STATE(s,c)	(s[mbwide()?((c=fcmbget(&LEN)),LEN>1?'a':c):(c=fcget())])
-#define isadigit(c)	(sh_lexstates[ST_DOL][c]==S_DIG)
-#define isastchar(c)	((c)=='@' || (c)=='*')
-#define isexp(c)	(sh_lexstates[ST_MACRO][c]==S_PAT||(c)=='$'||(c)=='`')
-#define ismeta(c)	(sh_lexstates[ST_NAME][c]==S_BREAK)
+#define STATE(s,c)	(s[mbwide() ? ((c = fcmbget(&LEN)), LEN > 1 ? 'a' : c) : (c = fcget())])
+#define isadigit(c)	((c) < 0 ? 0 : sh_lexstates[ST_DOL][c] == S_DIG)
+#define isastchar(c)	((c) == '@' || (c) == '*')
+#define isexp(c)	((c) < 0 ? 0 : (sh_lexstates[ST_MACRO][c] == S_PAT || (c) == '$' || (c) == '`'))
+#define ismeta(c)	((c) < 0 ? 0 : sh_lexstates[ST_NAME][c] == S_BREAK)
 
 extern char *sh_lexstates[ST_NONE];
 extern const char *sh_lexrstates[ST_NONE];

--- a/src/cmd/ksh93/include/lexstates.h
+++ b/src/cmd/ksh93/include/lexstates.h
@@ -107,8 +107,8 @@
 #if SHOPT_MULTIBYTE
 #   define LEN		_Fcin.fclen
 #   define SETLEN(x)	(_Fcin.fclen = x)
-#   define isaname(c)	((c) < 0 ? 0 : ((c) > 0x7f ? isalpha(c) : sh_lexstates[ST_NAME][(c)] == 0))
-#   define isaletter(c)	((c) < 0 ? 0 : ((c) > 0x7f ? isalpha(c) : sh_lexstates[ST_DOL][(c)] == S_ALP && (c) != '.'))
+#   define isaname(c)	((c) < 0 ? 0 : ((c) > 0x7f ? iswalpha(c) : sh_lexstates[ST_NAME][(c)] == 0))
+#   define isaletter(c)	((c) < 0 ? 0 : ((c) > 0x7f ? iswalpha(c) : sh_lexstates[ST_DOL][(c)] == S_ALP && (c) != '.'))
 #else
 #   undef mbwide
 #   define mbwide()	(0)


### PR DESCRIPTION
The `isaname`, `isaletter`, `isadigit`, `isexp` and `ismeta` macros don't check if `c` is a negative value before accessing `sh_lexstates`. This can result in ASan crashing because of a buffer overflow in quoting2.sh when running in a multibyte locale:
```
  test quoting2(C.UTF-8) begins at 2022-09-23+14:03:12
  =================================================================
  ==262224==ERROR: AddressSanitizer: global-buffer-overflow on address 0x557b201a451f at pc 0x557b1fe5e6fc bp 0x7fffcf1ac700 sp 0x7fffcf1ac6f8
  READ of size 1 at 0x557b201a451f thread T0
      #0 0x557b1fe5e6fb in sh_fmtq /home/johno/GitRepos/KornShell/ksh/src/cmd/ksh93/sh/string.c:341:5
      #1 0x557b1fe6098c in sh_fmtqf /home/johno/GitRepos/KornShell/ksh/src/cmd/ksh93/sh/string.c:473:10
      #2 0x557b1ff08dc0 in extend /home/johno/GitRepos/KornShell/ksh/src/cmd/ksh93/bltins/print.c:998:14
      #3 0x557b2008a56c in sfvprintf /home/johno/GitRepos/KornShell/ksh/src/lib/libast/sfio/sfvprintf.c:531:8
      #4 0x557b2005b7f7 in sfprintf /home/johno/GitRepos/KornShell/ksh/src/lib/libast/sfio/sfprintf.c:31:7
      #5 0x557b1ff04272 in b_print /home/johno/GitRepos/KornShell/ksh/src/cmd/ksh93/bltins/print.c:343:4
      #6 0x557b1ff04ebf in b_printf /home/johno/GitRepos/KornShell/ksh/src/cmd/ksh93/bltins/print.c:148:9
      #7 0x557b1fe8d9a7 in sh_exec /home/johno/GitRepos/KornShell/ksh/src/cmd/ksh93/sh/xec.c:1261:21
      #8 0x557b1fe7a7cf in sh_subshell /home/johno/GitRepos/KornShell/ksh/src/cmd/ksh93/sh/subshell.c:652:4
      #9 0x557b1fdedc0d in comsubst /home/johno/GitRepos/KornShell/ksh/src/cmd/ksh93/sh/macro.c:2207:9
      #10 0x557b1fdefc79 in varsub /home/johno/GitRepos/KornShell/ksh/src/cmd/ksh93/sh/macro.c:1181:3
      #11 0x557b1fde3bef in copyto /home/johno/GitRepos/KornShell/ksh/src/cmd/ksh93/sh/macro.c:620:21
      #12 0x557b1fde0b07 in sh_mactrim /home/johno/GitRepos/KornShell/ksh/src/cmd/ksh93/sh/macro.c:169:2
      #13 0x557b1fe05ab6 in nv_setlist /home/johno/GitRepos/KornShell/ksh/src/cmd/ksh93/sh/name.c:280:9
      #14 0x557b1fe8a7e8 in sh_exec /home/johno/GitRepos/KornShell/ksh/src/cmd/ksh93/sh/xec.c:1051:7
      #15 0x557b1fe95b85 in sh_exec /home/johno/GitRepos/KornShell/ksh/src/cmd/ksh93/sh/xec.c:1940:5
      #16 0x557b1fe99ea6 in sh_exec /home/johno/GitRepos/KornShell/ksh/src/cmd/ksh93/sh/xec.c:2271:10
      #17 0x557b1fd23b04 in exfile /home/johno/GitRepos/KornShell/ksh/src/cmd/ksh93/sh/main.c:604:4
      #18 0x557b1fd1fe10 in sh_main /home/johno/GitRepos/KornShell/ksh/src/cmd/ksh93/sh/main.c:369:2
      #19 0x557b1fd1d585 in main /home/johno/GitRepos/KornShell/ksh/src/cmd/ksh93/sh/pmain.c:41:9
      #20 0x7f55d5b5028f  (/usr/lib/libc.so.6+0x2328f) (BuildId: 26c81e7e05ebaf40bac3523b7d76be0cd71fad82)
      #21 0x7f55d5b50349 in __libc_start_main (/usr/lib/libc.so.6+0x23349) (BuildId: 26c81e7e05ebaf40bac3523b7d76be0cd71fad82)
      #22 0x557b1fc158d4 in _start /build/glibc/src/glibc/csu/../sysdeps/x86_64/start.S:115
```

src/cmd/ksh93/include/lexstates.h:
- Check if `c` is negative before accessing `sh_lexstates`. Backported from ksh2020: https://github.com/att/ast/commit/a7013320. I'll note that later in ksh2020 these macros became functions: https://github.com/att/ast/commit/adc589de. I didn't backport that commit because it requires the C99 `bool` type to avoid compiler warnings.