### PR TITLE
Minor editing mode related fixes

### DIFF
--- a/src/cmd/ksh93/edit/emacs.c
+++ b/src/cmd/ksh93/edit/emacs.c
@@ -1419,8 +1419,8 @@ static void search(Emacs_t* ep,genchar *out,int direction)
 	skip:
 	i = genlen(string);
 	if(backwards_search)
-		ep->prevdirection = -4;
-	if(ep->prevdirection == -4 && i!=4 || direction!=1)
+		ep->prevdirection = -2;
+	if(ep->prevdirection == -2 && i!=4 || direction!=1)
 		ep->prevdirection = -1;
 	if (direction < 1)
 	{

--- a/src/cmd/ksh93/tests/pty.sh
+++ b/src/cmd/ksh93/tests/pty.sh
@@ -1090,8 +1090,10 @@ w print bar
 p :test-2:
 w print foo
 p :test-3:
-w print Correc
+w echo WRONG
 p :test-4:
+w print Correc
+p :test-5:
 c p\E[A\E[A\E[A\E[B\E[B
 w $at
 u Correct
@@ -1106,8 +1108,10 @@ w print bar
 p :test-2:
 w print foo
 p :test-3:
-w print Correc
+w echo WRONG
 p :test-4:
+w print Correc
+p :test-5:
 c p\E[A\E[A\E[A\E[B\E[B
 w t
 u Correct


### PR DESCRIPTION
- In emacs.c, avoid setting `ep->prevdirection` to -4, since that variable is never supposed to be set to -4 (-2 indicates a reverse search, not -4).

- Fix the backwards reverse search regression tests. The final changes to arrowkeysearch in https://github.com/ksh93/ksh/pull/534 caused these tests to never fail in older shells, so to fix that add an 'echo WRONG' history entry.