### PR TITLE
Backport `print -u p` from ksh93v- 2014-06-06 (re: 4d182da8)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,9 @@ Uppercase BUG_* IDs are shell bug IDs as used by the Modernish shell library.
 
 2022-09-25:
 
+- Backported support for 'print -u p' from ksh93v- 2014-06-06 (this is
+  equivalent to using 'print -p').
+
 - Fixed a bug introduced on 2021-04-04 that incorrectly allowed 'typeset' to
   turn off the readonly and export attributes on a readonly variable.
 

--- a/src/cmd/ksh93/bltins/print.c
+++ b/src/cmd/ksh93/bltins/print.c
@@ -222,6 +222,12 @@ int    b_print(int argc, char *argv[], Shbltin_t *context)
 			rflag = 1;
 			break;
 		case 'u':
+			if(opt_info.arg[0]=='p' && opt_info.arg[1]==0)
+			{
+				fd = sh.coutpipe;
+				msg = e_query;
+				break;
+			}
 			fd = (int)strtol(opt_info.arg,&opt_info.arg,10);
 			if(*opt_info.arg)
 				fd = -1;

--- a/src/cmd/ksh93/data/builtins.c
+++ b/src/cmd/ksh93/data/builtins.c
@@ -1196,12 +1196,12 @@ const char sh_optlet[]	=
 ;
 
 const char sh_optprint[] =
-"[-1c?\n@(#)$Id: print (AT&T Research) 2008-11-26 $\n]"
+"[-1c?\n@(#)$Id: print (ksh 93u+m) 2022-09-26 $\n]"
 "[--catalog?" SH_DICT "]"
 "[+NAME?print - write arguments to standard output]"
 "[+DESCRIPTION?By default, \bprint\b writes each \astring\a operand to "
 	"standard output and appends a newline character.]"  
-"[+?Unless, the \b-r\b or \b-f\b option is specified, each \b\\\b "
+"[+?Unless the \b-r\b or \b-f\b option is specified, each \b\\\b "
 	"character in each \astring\a operand is processed specially as "
 	"follows:]{"
 		"[+\\a?Alert character.]"
@@ -1235,7 +1235,8 @@ const char sh_optprint[] =
 	"above.]"
 "[s?Write the output as an entry in the shell history file instead of "
 	"standard output.]"
-"[u]:[fd:=1?Write to file descriptor number \afd\a instead of standard output.]"
+"[u]:[fd:=1?Write to file descriptor number \afd\a instead of standard output. "
+	"If \afd\a is \bp\b, write to the co-process; same as \b-p\b.]"
 "[v?Treat each \astring\a as a variable name and write the value in \b%B\b "
 	"format.  Cannot be used with \b-f\b.]"
 "[C?Treat each \astring\a as a variable name and write the value in \b%#B\b "


### PR DESCRIPTION
The commit that backported support for `read -u p` from ksh93v- did not backport `print -u p`. For completeness, support for `-u p` has been added to the print builtin as well (equivalent to `-p`).