### PR TITLE
Fix handling of a dangling backslash in case statements

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,11 @@ This documents significant changes in the dev branch of ksh 93u+m.
 For full details, see the git log at: https://github.com/ksh93/ksh
 Uppercase BUG_* IDs are shell bug IDs as used by the Modernish shell library.
 
+2022-10-11:
+
+- Fixed a bug that caused inconsistent behavior when handling a dangling
+  backslash in a case statement.
+
 2022-10-07:
 
 - Fixed BUG_BRACQUOT: single and double shell quotes did not work to escape

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -18,7 +18,7 @@
 
 #define SH_RELEASE_FORK	"93u+m"		/* only change if you develop a new ksh93 fork */
 #define SH_RELEASE_SVER	"1.1.0-alpha"	/* semantic version number: https://semver.org */
-#define SH_RELEASE_DATE	"2022-10-07"	/* must be in this format for $((.sh.version)) */
+#define SH_RELEASE_DATE	"2022-10-11"	/* must be in this format for $((.sh.version)) */
 #define SH_RELEASE_CPYR	"(c) 2020-2022 Contributors to ksh " SH_RELEASE_FORK
 
 /* Scripts sometimes field-split ${.sh.version}, so don't change amount of whitespace. */

--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -2270,11 +2270,7 @@ int sh_exec(register const Shnode_t *t, int flags)
 				{
 					register char *s;
 					if(rex->argflag&ARG_MAC)
-					{
 						s = sh_macpat(rex,OPTIMIZE|ARG_EXP);
-						while(*s=='\\' && s[1]==0)
-							s+=2;
-					}
 					else
 						s = rex->argval;
 					type = (rex->argflag&ARG_RAW);

--- a/src/cmd/ksh93/tests/case.sh
+++ b/src/cmd/ksh93/tests/case.sh
@@ -100,32 +100,17 @@ got=$(set +x; { "$SHELL" -c 'case x in [x[:bogus:]]) echo x ;; esac'; } 2>&1)
 # ======
 # Handling of escapes in pattern matching contexts
 # https://marc.info/?l=ast-users&m=136562952931688&w=2
-exp=no
-got=$(	x=\\x
-	if [[ x == $x ]]
-	then	echo yes
-	else	echo no
-	fi
-)
-[[ $exp == $got ]] || err_exit '[[ does not handle escapes correctly' \
-	"(expected $exp, got $(printf %q "$got"))"
-got=$(	x=\\x
-	case x in
-	$x) echo yes ;;
-	*) echo no ;;
-	esac
-)
-[[ $exp == $got ]] || err_exit 'case statements do not handle escapes correctly' \
-	"(expected $exp, got $(printf %q "$got"))"
+p=\\x
+[[ x == $p ]] && err_exit '[[ does not handle escapes correctly'
+case x in
+$p) err_exit 'case statements do not handle escapes correctly' ;;
+esac
 # https://github.com/ksh93/ksh/issues/488#issuecomment-1262641076
-exp=result
-got=$(	backslash=\\
-	case \\ in
-	$backslash)	echo result ;;
-	esac
-)
-[[ $exp == $got ]] || err_exit 'case statements do not correctly handle a dangling backslash' \
-	"(expected $exp, got $(printf %q "$got"))"
+p=\\
+case \\ in
+$p)	;;
+*)	err_exit 'case statements do not correctly handle a dangling backslash' ;;
+esac
 
 # ======
 # Shell quoting within bracket expressions in glob patterns had no effect

--- a/src/cmd/ksh93/tests/case.sh
+++ b/src/cmd/ksh93/tests/case.sh
@@ -98,6 +98,36 @@ got=$(set +x; { "$SHELL" -c 'case x in [x[:bogus:]]) echo x ;; esac'; } 2>&1)
 	"(got status $e$( ((e>128)) && print -n /SIG && kill -l "$e"), $(printf %q "$got"))"
 
 # ======
+# Handling of escapes in pattern matching contexts
+# https://marc.info/?l=ast-users&m=136562952931688&w=2
+exp=no
+got=$(	x=\\x
+	if [[ x == $x ]]
+	then	echo yes
+	else	echo no
+	fi
+)
+[[ $exp == $got ]] || err_exit '[[ does not handle escapes correctly' \
+	"(expected $exp, got $(printf %q "$got"))"
+got=$(	x=\\x
+	case x in
+	$x) echo yes ;;
+	*) echo no ;;
+	esac
+)
+[[ $exp == $got ]] || err_exit 'case statements do not handle escapes correctly' \
+	"(expected $exp, got $(printf %q "$got"))"
+# https://github.com/ksh93/ksh/issues/488#issuecomment-1262641076
+exp=result
+got=$(	backslash=\\
+	case \\ in
+	$backslash)	echo result ;;
+	esac
+)
+[[ $exp == $got ]] || err_exit 'case statements do not correctly handle a dangling backslash' \
+	"(expected $exp, got $(printf %q "$got"))"
+
+# ======
 # Shell quoting within bracket expressions in glob patterns had no effect
 # https://github.com/ksh93/ksh/issues/488
 


### PR DESCRIPTION
This commit removes a while loop after a `sh_macpat` call in xec.c that causes the following reproducer to fail:
```sh
backslash=\\; case \\ in $backslash ) echo result; esac
# Should print 'result', actually prints nothing
```

In the vast majority of cases the while loop is dead code, since it only ever applies when sh_macpat generates a dangling backslash. In the cases where a dangling backslash is generated, the loop may result in the backslash being skipped. For consistent behavior, the while loop that skips the dangling backslash has been removed.

References:
https://github.com/ksh93/ksh/issues/488#issuecomment-1262165029
https://github.com/ksh93/ksh/issues/488#issuecomment-1262641076
https://github.com/ksh93/ksh/issues/488#issuecomment-1264187946

src/cmd/ksh93/sh/xec.c:
- Fix inconsistent dangling backslash behavior as described above.

src/cmd/ksh93/tests/case.sh:
- Add a regression test for the dangling backslash problem.
- Add regression tests for a different, but related problem (which is already fixed): https://marc.info/?l=ast-users&m=136562952931688&w=2