### PR TITLE
Fix various Haiku build errors, interruptions and warnings

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -11,6 +11,10 @@ Uppercase BUG_* IDs are shell bug IDs as used by the Modernish shell library.
   fallback string in an expansion like ${emptyvar:-fallback string} to fail to
   split into fields correctly if the fallback string contained a !, ^ or -.
 
+- Fixed a few different build errors on Haiku that prevented ksh from compiling
+  with the mkservice and eloop builtins enabled, caused compiling with -lnetwork
+  to fail, and could interrupt the build with crash report popups.
+
 2022-10-13:
 
 - Added a -V/--novmon option to ulimit that supports setting the number of open

--- a/src/cmd/INIT/make.probe
+++ b/src/cmd/INIT/make.probe
@@ -77,7 +77,7 @@ echo 'template<class T> int gt(T a, T b);
 template<class T> int gt(T a, T b) { return a > b; }
 int main () { return gt(2,1); }' > ptr.$src
 echo 'int main(){return 0;}' > require.$src
-echo '#if mips && !sgi || __CYGWIN__ || __HAIKU__
+echo '#if mips && !sgi || __CYGWIN__ || __HAIKU__ || __APPLE__
 ( /* some systems choke on this probe */
 #else
 #if test_const

--- a/src/cmd/INIT/make.probe
+++ b/src/cmd/INIT/make.probe
@@ -77,7 +77,7 @@ echo 'template<class T> int gt(T a, T b);
 template<class T> int gt(T a, T b) { return a > b; }
 int main () { return gt(2,1); }' > ptr.$src
 echo 'int main(){return 0;}' > require.$src
-echo '#if mips && !sgi || __CYGWIN__
+echo '#if mips && !sgi || __CYGWIN__ || __HAIKU__
 ( /* some systems choke on this probe */
 #else
 #if test_const

--- a/src/cmd/ksh93/Mamfile
+++ b/src/cmd/ksh93/Mamfile
@@ -56,7 +56,7 @@ make install
 					exec - case "" in
 					exec - *?) echo " " ;;
 					exec - esac
-					exec - for i in shell dll cmd ast m jobs i socket nsl secdb
+					exec - for i in shell dll cmd ast m jobs i socket nsl secdb network
 					exec - do case $i in
 					exec - "shell"|shell)
 					exec - ;;
@@ -1326,6 +1326,7 @@ make install
 		prev +li
 		prev ${mam_libsocket}
 		prev ${mam_libsecdb}
+		prev ${mam_libnetwork}
 		exec - ${CC} ${CCLDFLAGS} ${mam_cc_FLAGS} ${CCFLAGS} ${LDFLAGS} ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -o ksh pmain.o ${mam_libshell} ${mam_libnsl} ${mam_libast} -lm
 	done ksh generated
 	make shcomp
@@ -1347,6 +1348,7 @@ make install
 		prev +li
 		prev ${mam_libsocket}
 		prev ${mam_libsecdb}
+		prev ${mam_libnetwork}
 		exec - ${CC} ${CCLDFLAGS} ${mam_cc_FLAGS} ${CCFLAGS} ${LDFLAGS} ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -o shcomp shcomp.o ${mam_libshell} ${mam_libnsl} ${mam_libast} -lm
 	done shcomp generated
 	make suid_exec
@@ -1366,6 +1368,7 @@ make install
 		prev +li
 		prev ${mam_libsocket}
 		prev ${mam_libsecdb}
+		prev ${mam_libnetwork}
 		exec - ${CC} ${CCLDFLAGS} ${mam_cc_FLAGS} ${CCFLAGS} ${LDFLAGS} ${mam_cc_L+-L.} ${mam_cc_L+-L${INSTALLROOT}/lib} -o suid_exec suid_exec.o ${mam_libast} ${mam_libnsl} ${mam_libast} -lm
 	done suid_exec generated
 	make shell

--- a/src/lib/libast/features/lib
+++ b/src/lib/libast/features/lib
@@ -404,11 +404,11 @@ tst	socket_peek note{ recv(MSG_PEEK) works on socketpair() }end execute{
 
 		static char	msg[] = "abcd";
 
-#ifdef __HAIKU__
+	#ifdef __HAIKU__
 		/* On Haiku this test will either fail (without additional LDFLAGS),
 		   or with -lnetwork it will lock up. */
 		return 1;
-#else
+	#else
 		if (socketpair(AF_UNIX, SOCK_STREAM, 0, fds))
 			return 1;
 		if (write(fds[1], msg, sizeof(msg)) != sizeof(msg))
@@ -424,7 +424,7 @@ tst	socket_peek note{ recv(MSG_PEEK) works on socketpair() }end execute{
 			if (buf[i] != msg[i])
 				return 1;
 		return 0;
-#endif
+	#endif
 	}
 }end
 

--- a/src/lib/libast/features/lib
+++ b/src/lib/libast/features/lib
@@ -404,6 +404,11 @@ tst	socket_peek note{ recv(MSG_PEEK) works on socketpair() }end execute{
 
 		static char	msg[] = "abcd";
 
+#ifdef __HAIKU__
+		/* On Haiku this test will either fail (without additional LDFLAGS),
+		   or with -lnetwork it will lock up. */
+		return 1;
+#else
 		if (socketpair(AF_UNIX, SOCK_STREAM, 0, fds))
 			return 1;
 		if (write(fds[1], msg, sizeof(msg)) != sizeof(msg))
@@ -419,6 +424,7 @@ tst	socket_peek note{ recv(MSG_PEEK) works on socketpair() }end execute{
 			if (buf[i] != msg[i])
 				return 1;
 		return 0;
+#endif
 	}
 }end
 

--- a/src/lib/libast/features/vmalloc
+++ b/src/lib/libast/features/vmalloc
@@ -45,7 +45,7 @@ tst	mem_sbrk note{ brk()/sbrk() work as expected }end execute{
 }end
 
 tst	map_malloc note{ map malloc to _ast_malloc }end noexecute{
-	#if __CYGWIN__
+	#if __CYGWIN__ || __HAIKU__
 	int main() { return 1; }
 	#else
 	static int user = 0;
@@ -95,7 +95,7 @@ lib	alloca note{ alloca exists }end link{
 }end
 
 tst	mal_alloca note{ alloca is based on malloc() }end execute{
-	#if __CYGWIN__
+	#if __CYGWIN__ || __HAIKU__
 	int main() { return 1; }
 	#else
 	#if _hdr_alloca

--- a/src/lib/libast/port/astwinsize.c
+++ b/src/lib/libast/port/astwinsize.c
@@ -30,6 +30,8 @@
 #include <sys/ioctl.h>
 #endif
 
+#undef ioctl
+#undef sleep
 #define ioctl		______ioctl
 #define sleep		______sleep
 


### PR DESCRIPTION
src/cmd/ksh93/Mamfile:
- Detect the existence of libnetwork and link against it to prevent missing symbol errors when compiling ksh on Haiku with the `mkservice` and `eloop` builtins enabled.

src/lib/libast/features/lib:
- The test for `socket_peek` fails on Haiku when no additional LDFLAGS are passed. However, when `-lnetwork` is passed in LDFLAGS, for some reason this test will lock up. To work around that, refuse to run this test on Haiku.

src/cmd/INIT/make.probe,
src/lib/libast/features/vmalloc:
- Disable three probes that crash on Haiku and produce a popup, delaying the build.

src/lib/libast/port/astwinsize.c:
- Undefine the `ioctl` macro before redefining it (this fixes one compiler warning on Haiku). Just to be safe, also undefine a possible `sleep` macro as well.

Fixes: https://github.com/ksh93/ksh/issues/551