### PR TITLE
vi mode: prevent invalid characters when completing

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,13 @@ This documents significant changes in the dev branch of ksh 93u+m.
 For full details, see the git log at: https://github.com/ksh93/ksh
 Uppercase BUG_* IDs are shell bug IDs as used by the Modernish shell library.
 
+2023-01-08:
+
+- Fixed a completion bug in vi mode in multibyte character locales, in which
+  one or more invalid characters were output at the end of the completion if
+  the cursor was on a "wide" character (or if the last character of the word
+  is wide and the cursor is in the immediately-following position).
+
 2022-10-31:
 
 - In vi mode, issuing the v command from a completely empty line now invokes

--- a/src/cmd/ksh93/edit/completion.c
+++ b/src/cmd/ksh93/edit/completion.c
@@ -278,9 +278,13 @@ int ed_expand(Edit_t *ep, char outbuff[],int *cur,int *eol,int mode, int count)
 #endif /* SHOPT_MULTIBYTE */
 #if SHOPT_VSH
 	out = outbuff + *cur + (sh_isoption(SH_VI)!=0);
+#if SHOPT_MULTIBYTE
+	if(sh_isoption(SH_VI) && ep->e_savedwidth > 0)
+		out += (ep->e_savedwidth - 1);
+#endif /* SHOPT_MULTIBYTE */
 #else
 	out = outbuff + *cur;
-#endif
+#endif /* SHOPT_VSH */
 	if(out[-1]=='"' || out[-1]=='\'')
 	{
 #if SHOPT_VSH

--- a/src/cmd/ksh93/edit/edit.c
+++ b/src/cmd/ksh93/edit/edit.c
@@ -595,7 +595,7 @@ void	ed_setup(register Edit_t *ep, int fd, int reedit)
 	sh.winch = 0;
 	ep->e_stkoff = staktell();
 	ep->e_stkptr = stakfreeze(0);
-# if SHOPT_MULTIBYTE
+#if SHOPT_MULTIBYTE
 	ep->e_savedwidth = 0;
 #endif /* SHOPT_MULTIBYTE */
 	if(!(last = sh.prompt))

--- a/src/cmd/ksh93/edit/edit.c
+++ b/src/cmd/ksh93/edit/edit.c
@@ -595,6 +595,9 @@ void	ed_setup(register Edit_t *ep, int fd, int reedit)
 	sh.winch = 0;
 	ep->e_stkoff = staktell();
 	ep->e_stkptr = stakfreeze(0);
+# if SHOPT_MULTIBYTE
+	ep->e_savedwidth = 0;
+#endif /* SHOPT_MULTIBYTE */
 	if(!(last = sh.prompt))
 		last = "";
 	sh.prompt = 0;

--- a/src/cmd/ksh93/edit/vi.c
+++ b/src/cmd/ksh93/edit/vi.c
@@ -2550,6 +2550,11 @@ addin:
 		ch = c;
 		if(mode>=0 && c=='\\' && virtual[mode+1]=='/')
 			c = '=';
+#if SHOPT_MULTIBYTE
+		char d[CHARSIZE+1];
+		wchar_t *savechar = &virtual[cur_virt];
+		vp->ed->e_savedwidth = mbconv(d,*savechar);
+#endif /* SHOPT_MULTIBYTE */
 		if(ed_expand(vp->ed,(char*)virtual, &cur_virt, &last_virt, ch, vp->repeat_set?vp->repeat:-1)<0)
 		{
 			if(vp->ed->e_tabcount)

--- a/src/cmd/ksh93/edit/vi.c
+++ b/src/cmd/ksh93/edit/vi.c
@@ -2551,9 +2551,11 @@ addin:
 		if(mode>=0 && c=='\\' && virtual[mode+1]=='/')
 			c = '=';
 #if SHOPT_MULTIBYTE
-		char d[CHARSIZE+1];
-		wchar_t *savechar = &virtual[cur_virt];
-		vp->ed->e_savedwidth = mbconv(d,*savechar);
+		{
+			char d[CHARSIZE+1];
+			wchar_t *savechar = &virtual[cur_virt];
+			vp->ed->e_savedwidth = mbconv(d,*savechar);
+		}
 #endif /* SHOPT_MULTIBYTE */
 		if(ed_expand(vp->ed,(char*)virtual, &cur_virt, &last_virt, ch, vp->repeat_set?vp->repeat:-1)<0)
 		{

--- a/src/cmd/ksh93/include/edit.h
+++ b/src/cmd/ksh93/include/edit.h
@@ -81,6 +81,9 @@ typedef struct edit
 	int	e_lookahead;	/* index in look-ahead buffer */
 	int	e_fcol;		/* first column */
 	int	e_wsize;	/* width of display window */
+#if SHOPT_MULTIBYTE
+	int	e_savedwidth;	/* saved width of a character */
+#endif /* SHOPT_MULTIBYTE */
 	char	*e_outbase;	/* pointer to start of output buffer */
 	char	*e_outptr;	/* pointer to position in output buffer */
 	char	*e_outlast;	/* pointer to end of output buffer */

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -18,8 +18,8 @@
 
 #define SH_RELEASE_FORK	"93u+m"		/* only change if you develop a new ksh93 fork */
 #define SH_RELEASE_SVER	"1.1.0-alpha"	/* semantic version number: https://semver.org */
-#define SH_RELEASE_DATE	"2022-10-31"	/* must be in this format for $((.sh.version)) */
-#define SH_RELEASE_CPYR	"(c) 2020-2022 Contributors to ksh " SH_RELEASE_FORK
+#define SH_RELEASE_DATE	"2023-01-08"	/* must be in this format for $((.sh.version)) */
+#define SH_RELEASE_CPYR	"(c) 2020-2023 Contributors to ksh " SH_RELEASE_FORK
 
 /* Scripts sometimes field-split ${.sh.version}, so don't change amount of whitespace. */
 /* Arithmetic $((.sh.version)) uses the last 10 chars, so the date must be at the end. */

--- a/src/cmd/ksh93/tests/pty.sh
+++ b/src/cmd/ksh93/tests/pty.sh
@@ -1117,5 +1117,17 @@ w t
 u Correct
 !
 
+((SHOPT_VSH && SHOPT_MULTIBYTE)) &&
+[[ ${LC_ALL:-${LC_CTYPE:-${LANG:-}}} =~ [Uu][Tt][Ff]-?8 ]] &&
+mkdir -p vitest/aあb && VISUAL=vi tst $LINENO <<"!"
+L vi completion from wide produces corrupt characters
+# https://github.com/ksh93/ksh/issues/571
+
+d 15
+p :test-1:
+w cd vitest/aあ\t
+r ^:test-1: cd vitest/aあb/\r\n$
+!
+
 # ======
 exit $((Errors<125?Errors:125))


### PR DESCRIPTION
When using any type of completion in `vi` mode, one or more invalid characters will be output at the end of the completion if the cursor is on a "wide" character (or if the last character of the word is wide and the cursor is in the immediately-following position). This happens because the increment of `out` for `vi` mode at `completion.c:280` does not account for character width; `out` will therefore be placed in the middle of a wide character rather than at the beginning of the following character. The fix:

* `edit.{c,h}`: Add `e_savedwidth` to store the width of a given character and initialize to `0`.
* `vi.c`: When calling the completion, determine the width of the character at `cur_virt` and save it to `e_savedwidth`.
* `completion.c`: Using `e_savedwidth`, increment `out` by the width of the character when in `vi` mode.

(Issue #571)