### PR TITLE
. and source: Find bare file names (Bolsky & Korn, pg. 220)

### DIFF
--- a/src/cmd/ksh93/bltins/misc.c
+++ b/src/cmd/ksh93/bltins/misc.c
@@ -274,7 +274,7 @@ int    b_dot_cmd(register int n,char *argv[],Shbltin_t *context)
 			np = 0;
 		if(!np)
 		{
-			if((fd=path_open(path_fullname(script),path_get(path_fullname(script)))) < 0)
+			if((fd=path_open(script,path_get(path_fullname(script)))) < 0)
 			{
 				errormsg(SH_DICT,ERROR_system(1),e_open,script);
 				UNREACHABLE();

--- a/src/cmd/ksh93/bltins/misc.c
+++ b/src/cmd/ksh93/bltins/misc.c
@@ -217,7 +217,7 @@ int    b_eval(int argc,char *argv[], Shbltin_t *context)
 #endif
 int    b_dot_cmd(register int n,char *argv[],Shbltin_t *context)
 {
-	register char *script;
+	register char *script, *absolute;
 	register Namval_t *np;
 	register int jmpval;
 	struct sh_scoped savst, *prevscope = sh.st.self;
@@ -274,7 +274,8 @@ int    b_dot_cmd(register int n,char *argv[],Shbltin_t *context)
 			np = 0;
 		if(!np)
 		{
-			if((fd=path_open(script,path_get(path_fullname(script)))) < 0)
+			absolute = path_fullname(script);
+			if((fd=path_open(absolute,path_get(absolute))) < 0)
 			{
 				errormsg(SH_DICT,ERROR_system(1),e_open,script);
 				UNREACHABLE();
@@ -323,7 +324,10 @@ int    b_dot_cmd(register int n,char *argv[],Shbltin_t *context)
 	if(buffer)
 		free(buffer);
 	if(!np)
+	{
 		free(tofree);
+		free(absolute);
+	}
 	sh.dot_depth--;
 	update_sh_level();
 	if((np || argv[1]) && jmpval!=SH_JMPSCRIPT)

--- a/src/cmd/ksh93/bltins/misc.c
+++ b/src/cmd/ksh93/bltins/misc.c
@@ -274,7 +274,7 @@ int    b_dot_cmd(register int n,char *argv[],Shbltin_t *context)
 			np = 0;
 		if(!np)
 		{
-			if((fd=path_open(script,path_get(script))) < 0)
+			if((fd=path_open(path_fullname(script),path_get(path_fullname(script)))) < 0)
 			{
 				errormsg(SH_DICT,ERROR_system(1),e_open,script);
 				UNREACHABLE();

--- a/src/cmd/ksh93/tests/builtins.sh
+++ b/src/cmd/ksh93/tests/builtins.sh
@@ -1587,6 +1587,7 @@ EOF
 "$SHELL" "$read_a_test"
 let Errors+=$?
 
+# ======
 # . can find a file with a relative path
 tmpfile=dottest
 print $'\nprint -r -- working' > $tmpfile

--- a/src/cmd/ksh93/tests/builtins.sh
+++ b/src/cmd/ksh93/tests/builtins.sh
@@ -1587,6 +1587,11 @@ EOF
 "$SHELL" "$read_a_test"
 let Errors+=$?
 
+# . can find a file with a relative path
+tmpfile=dottest
+print $'\nprint -r -- working' > $tmpfile
+[[ $( . "$tmpfile") == "working" ]] || err_exit 'dot command did not find relative path'
+
 # ======
 # Most built-ins should handle --version
 while IFS= read -r bltin <&3


### PR DESCRIPTION
In `ksh`, along with `pdksh`, `oksh`, `mksh` and `ksh2020`, using `.` on a non-function off of `$PATH` only succeeds if ~~an absolute~~ a file path including the directory is given. The example illustrating `.` and `source` in Bolsky and Korn (pg. 220), however, appears to indicate that `.` was intended to find bare filenames, e.g. `. .kshrc`:

````
$ cat foobar
foo=hello bar=world
print $foo $bar
$ . foobar
hello world
````

* `src/cmd/ksh93/bltins/misc.c`: After checking for functions and files on `PATH` in the function `b_dot_cmd`, save the full path of the target file to a separate variable and pass it to `path_open`. This allows the `.` builtin to source files ~~with either relative or absolute paths~~ without the directory, as indicated in Bolsky and Korn (pg. 220). Free the additional variable afterwards to avoid a memory leak.