### PR TITLE
vi mode: Prevent invalid output with text modifier "."

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,11 @@ This documents significant changes in the dev branch of ksh 93u+m.
 For full details, see the git log at: https://github.com/ksh93/ksh
 Uppercase BUG_* IDs are shell bug IDs as used by the Modernish shell library.
 
+2023-02-23:
+
+- Fixed a crash or corrupted output that occurred on some systems if the vi
+  '.' repeater command was used immediately after starting ksh in vi mode.
+
 2023-02-22:
 
 - ksh now throws a panic and exits if a read error (such as an I/O error)

--- a/src/cmd/ksh93/edit/vi.c
+++ b/src/cmd/ksh93/edit/vi.c
@@ -391,6 +391,7 @@ int ed_viread(void *context, int fd, register char *shbuf, int nchar, int reedit
 		vp->lastmotion = '\0';
 		vp->lastrepeat = 1;
 		vp->repeat = 1;
+		*vp->lastline = 0;
 		if(!yankbuf)
 			return(-1);
 		*yankbuf = 0;

--- a/src/cmd/ksh93/edit/vi.c
+++ b/src/cmd/ksh93/edit/vi.c
@@ -391,10 +391,12 @@ int ed_viread(void *context, int fd, register char *shbuf, int nchar, int reedit
 		vp->lastmotion = '\0';
 		vp->lastrepeat = 1;
 		vp->repeat = 1;
-		*vp->lastline = 0;
 		if(!yankbuf)
 			return(-1);
 		*yankbuf = 0;
+		if(!vp->lastline)
+			return(-1);
+		*vp->lastline = 0;
 	}
 
 	/*** fiddle around with prompt length ***/

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -18,7 +18,7 @@
 
 #define SH_RELEASE_FORK	"93u+m"		/* only change if you develop a new ksh93 fork */
 #define SH_RELEASE_SVER	"1.1.0-alpha"	/* semantic version number: https://semver.org */
-#define SH_RELEASE_DATE	"2023-02-22"	/* must be in this format for $((.sh.version)) */
+#define SH_RELEASE_DATE	"2023-02-23"	/* must be in this format for $((.sh.version)) */
 #define SH_RELEASE_CPYR	"(c) 2020-2023 Contributors to ksh " SH_RELEASE_FORK
 
 /* Scripts sometimes field-split ${.sh.version}, so don't change amount of whitespace. */


### PR DESCRIPTION
`vi` mode: On some operating systems, including Linux and OpenBSD, starting `ksh` and using using repeater `.` before entering any `vi` mode text modification (ordinary text input, `vi` text modification commands, `return` with at least one character already entered) produces corrupt output. This is caused by the print array being set equal to uninitialized `vp->lastline` when calling `textmod`. `p` and `P` are not affected, as the print array is subsequently set to initialized `yankbuf` for those commands.

* `vi.c`: Initialize `vp->lastline` in `ed_viread` if there has not been a previous text modification in `vi` mode. This prevents invalid output when using the text modifier `.`.