### PR TITLE
vi mode: preserve history navigation and search with U

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,10 @@ Uppercase BUG_* IDs are shell bug IDs as used by the Modernish shell library.
 - Fixed a crash or corrupted output that occurred on some systems if the vi
   '.' repeater command was used immediately after starting ksh in vi mode.
 
+- In vi mode, when navigating back in the command history and then editing a
+  line from the history, the U command now correctly undoes the latest edit
+  to the history line instead of jumping back to the current command line.
+
 2023-02-22:
 
 - ksh now throws a panic and exits if a read error (such as an I/O error)

--- a/src/cmd/ksh93/edit/vi.c
+++ b/src/cmd/ksh93/edit/vi.c
@@ -898,6 +898,9 @@ static int cntlmode(Vi_t *vp)
 #endif /* SHOPT_MULTIBYTE */
 			if((last_virt=genlen(virtual)-1) >= 0  && cur_virt == INVALID)
 				cur_virt = 0;
+			virtual[last_virt+1] = '\0';
+			gencpy(vp->U_space, virtual);
+			vp->U_saved = 1;
 			/* skip blank lines when going up/down in history */
 			if((c=='k' || c=='-') && curhline != histmin && blankline(vp))
 				ed_ungetchar(vp->ed,'k');

--- a/src/cmd/ksh93/edit/vi.c
+++ b/src/cmd/ksh93/edit/vi.c
@@ -900,7 +900,6 @@ static int cntlmode(Vi_t *vp)
 				cur_virt = 0;
 			virtual[last_virt+1] = '\0';
 			gencpy(vp->U_space, virtual);
-			vp->U_saved = 1;
 			/* skip blank lines when going up/down in history */
 			if((c=='k' || c=='-') && curhline != histmin && blankline(vp))
 				ed_ungetchar(vp->ed,'k');


### PR DESCRIPTION
In `vi` mode, `U` currently reverts the command line to its state at the time control mode was first entered without regard for history navigation and reverse search. This behavior is consistent with `ksh88`. `vi` and `vim` handle `U` slightly differently:

* A new line is reached through carriage return: Revert to the line's state when control mode was first entered since arrival (same)
* A new line is reached with `o`, `O` or by opening a new file with `vi`: Clear the line (N/A)
* A different line is reached with search or navigation: Revert to the line's state when the cursor arrived (different)

Changing `U` to match `vi` behavior with `k`, `/`, etc. (as in `pdksh`, `oksh` and `mksh`) would not require any documentation changes. Bolsky and Korn (pg. 124) and the current man page say that `U` reverts all "text modifying directives," a category that does not include search and history navigation.

* `vi.c`: Save a new `U_space` (the buffer specific to the `U` command) whenever a different line is reached by search or history navigation. Instead of reverting the line change altogether, `U` will revert to the state of the history line when it was reached, as is the case in `vi(1)`.