### PR TITLE
strgrpmatch: correct a typecasting

### DIFF
--- a/src/lib/libast/string/strmatch.c
+++ b/src/lib/libast/string/strmatch.c
@@ -198,5 +198,5 @@ strsubmatch(const char* s, const char* p, int flags)
 int
 strgrpmatch(const char* b, const char* p, ssize_t* sub, int n, int flags)
 {
-	return strngrpmatch(b, b ? strlen(b) : 0, p, sub, n, flags|STR_INT);
+	return strngrpmatch(b, b ? strlen(b) : 0, p, sub, n, flags);
 }


### PR DESCRIPTION
By the definition of "strgrpmatch", the type of the argument "sub" is "ssize_t *". Obviously, "int" and "ssize_t" are not always same (e.g. 32bit and 64bit -- a cause of segfault). So "strgrpmatch" should not set the "STR_INT" flag to inform "strngrpmatch" to cast "sub".