### PR TITLE
Fix build under LLVM15

### DIFF
--- a/src/lib/libast/aso/aso.c
+++ b/src/lib/libast/aso/aso.c
@@ -836,7 +836,7 @@ asocasptr(void volatile* p, void* o, void* n)
 
 #if defined(_aso_casptr)
 	if (!state.lockf)
-		return _aso_casptr((void**)p, o, n);
+		return _aso_cas64((void**)p, o, n);
 #endif
 	k = lock(state.data, 0, p);
 	if (*(void* volatile*)p == o)


### PR DESCRIPTION
-Wint-conversion is now default with LLVM15. Fix the following -Wint-conversion error.

error: incompatible integer to pointer conversion passing 'uint64_t' (aka 'unsigned long') to parameter of type 'void *' [-Wint-conversion]
                return _aso_casptr((void**)p, o, n);
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
./FEATURE/aso:19:66: note: expanded from macro '_aso_casptr'
                                                                      ^~~~~~~~~~~
/wrkdirs/usr/ports/shells/ksh-devel/work/ksh-9bec2b78/src/lib/libast/aso/aso.c:839:10: error: incompatible integer to pointer conversion passing 'uint64_t' (aka 'unsigned long') to parameter of type 'void *' [-Wint-conversion]
                return _aso_casptr((void**)p, o, n);
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
./FEATURE/aso:19:78: note: expanded from macro '_aso_casptr'
                                                                                  ^~~~~~~~~~~
2 errors generated.