### PR TITLE
Avoid heredoc bug in older ksh.

### DIFF
--- a/src/cmd/ksh93/Mamfile
+++ b/src/cmd/ksh93/Mamfile
@@ -47,7 +47,7 @@ make install
 			exec -	exec >shopt.h
 			exec -	echo '/* Generated from ksh93/SHOPT.sh by ksh93/Mamfile */'
 			exec -	. "$PACKAGEROOT/src/cmd/ksh93/SHOPT.sh"
-			exec -	exec cat <<-EOF
+			exec -	cat <<-EOF
 			exec -		/* overrides */
 			exec -		#if SHOPT_SCRIPTONLY
 			exec -		#undef SHOPT_ACCT


### PR DESCRIPTION
Older ksh do not handle 'exec cat <<EOF' correctly:

$ ksh93 --version
  version         sh (AT&T Research) 93v- 2014-12-24
$ ksh93 <<EOF
exec cat <<_EOF
hello
_EOF
EOF
cat: -: Bad file descriptor
cat: closing standard input: Bad file descriptor

As the build system attempts to find a known good shell, and all ksh versions are considered better shells than any other shell that the user may have installed (see the "grab a decent default shell" in bin/package), known ksh bugs need to be avoided.