### PR TITLE
Delete < 1995 junk code from tminit to fix `printf %(%Z)T` on Cygwin

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,9 @@ Uppercase BUG_* IDs are shell bug IDs as used by the Modernish shell library.
 - Fixed an intermittent crash in 'command -x' experienced on some arm/arm64
   systems running Linux.
 
+- Fixed a bug that caused 'printf "%(%Z)T\n" now' to print nonsense strings
+  such as 'ica' on Cygwin.
+
 2023-03-24:
 
 - Fixed a crash in read -d D in multibyte locales that occurred when a byte

--- a/src/lib/libast/tm/tminit.c
+++ b/src/lib/libast/tm/tminit.c
@@ -293,24 +293,6 @@ tmlocal(void)
 			s = "";
 		local.daylight = s;
 	}
-	else if ((s = getenv("TZ")) && *s && *s != ':' && (s = strdup(s)))
-	{
-		/*
-		 * POSIX style but skipped by tmlocaltime()
-		 */
-
-		local.standard = s;
-		if (*++s && *++s && *++s)
-		{
-			*s++ = 0;
-			tmgoff(s, &t, 0);
-			for (s = t; isalpha(*t); t++);
-			*t = 0;
-		}
-		else
-			s = "";
-		local.daylight = s;
-	}
 	else
 	{
 		/*


### PR DESCRIPTION
The `TZ` variable is commonly set to values such as 'America/Los_Angeles', which makes it a terrible choice when attempting to obtain the timezone name with `printf '%(%Z)T'`. In some scenarios the output returned by `printf %T` is completely bogus because it assumes `$TZ` will be set to a short string (e.g., "MST"); in practice this is rarely the case. On Cygwin, attempting to use `%Z` to get the timezone does the following for PST (`$TZ` is set to "America/Los_Angeles"):
```sh
# External date(1) command
$ date +%Z
PDT

# ksh93 printf builtin
$ printf '%(%Z)T\n' now
ica
```
The 'ica' was extracted from the end of 'America' in `$TZ`. For `%Z`, that result is complete nonsense (the result from date(1) is 'PDT', which `printf %T` should match). This bug currently causes two regression tests in builtins.sh to fail on Cygwin.

Minor note: This bug is only relevant for the handling of `$TZ`, not `$TZNAME`. While `$TZNAME` is fairly uncommon, it should have the correct set of names when set (e.g., `$TZNAME` will be "PST,PDT" for Pacific Time, which the current code handles just fine).

src/lib/libast/tm/tminit.c:
- Fix the above problem by removing the bogus code that obtains 'ica' and other nonsense strings from `$TZ`.