### PR TITLE
Fix Isssue#623

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,6 +9,11 @@ Uppercase BUG_* IDs are shell bug IDs as used by the Modernish shell library.
   depending on whether the compound assignment was outside or within a command
   substitution of the form $(...) or ${ ...; }. Both cases are now fixed.
 
+- Fixed a parsing bug in arithmetic functions like
+	function .sh.math.add x y { .sh.value=x+y; }
+  so that the '.sh.value=x+y' is correctly interpreted as an assignment, not
+  as a command name. After this, (( z = add(x,y) )) works correctly.
+
 2023-04-03:
 
 - Fixed multiple crashing bugs in discipline functions invoked from non-forked

--- a/src/cmd/ksh93/sh/parse.c
+++ b/src/cmd/ksh93/sh/parse.c
@@ -13,6 +13,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                  Martijn Dekker <martijn@inlv.org>                   *
 *            Johnothan King <johnothanking@protonmail.com>             *
+*                      Phi <phi.debian@gmail.com>                      *
 *                                                                      *
 ***********************************************************************/
 /*

--- a/src/cmd/ksh93/sh/parse.c
+++ b/src/cmd/ksh93/sh/parse.c
@@ -918,7 +918,8 @@ static Shnode_t *funct(Lex_t *lexp)
 			memcpy(ap,lexp->arg,sz);
 			lexp->arg = ap;
 		}
-		t->funct.functtre = item(lexp,SH_NOIO);
+		lexp->assignok=1; /* Issue#623 Phi */
+  		t->funct.functtre = item(lexp,SH_NOIO);
 	}
 	else if(sh.shcomp)
 		exit(1);

--- a/src/cmd/ksh93/sh/parse.c
+++ b/src/cmd/ksh93/sh/parse.c
@@ -918,8 +918,8 @@ static Shnode_t *funct(Lex_t *lexp)
 			memcpy(ap,lexp->arg,sz);
 			lexp->arg = ap;
 		}
-		lexp->assignok=1; /* Issue#623 Phi */
-  		t->funct.functtre = item(lexp,SH_NOIO);
+		lexp->assignok = 1;
+		t->funct.functtre = item(lexp,SH_NOIO);
 	}
 	else if(sh.shcomp)
 		exit(1);

--- a/src/cmd/ksh93/tests/arith.sh
+++ b/src/cmd/ksh93/tests/arith.sh
@@ -989,4 +989,10 @@ got=$(set +x; eval 'got=$( ((y=1<<4)); echo $y )' 2>&1; echo $got) \
 || err_exit "bitwise left shift operator fails to parse in comsub (got $(printf %q "$got"))"
 
 # ======
+# https://github.com/ksh93/ksh/issues/623
+function .sh.math.add x y { .sh.value=x+y; }
+got=$(PATH=/dev/null; typeset -i z; redirect 2>&1; z='add(2 , 3)')
+[[ e=$? -eq 0 && $got == '5' ]] || err_exit ".sh.math.* function parsing: got status $e and $(printf %q "$got")"
+
+# ======
 exit $((Errors<125?Errors:125))


### PR DESCRIPTION
Allow assignment after the parsing of
   function x a b c {
After this point we know that assigment are ok so we say so in parse.c::921 in funct()
		lexp->assignok=1; /* Issue#623 Phi */
  		t->funct.functtre = item(lexp,SH_NOIO);
This allow .sh.value= assigment