### PR TITLE
edit.c: On start/resize, adjust for prompt length when multiline is off.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,10 @@ This documents significant changes in the dev branch of ksh 93u+m.
 For full details, see the git log at: https://github.com/ksh93/ksh
 Uppercase BUG_* IDs are shell bug IDs as used by the Modernish shell library.
 
+2023-04-09:
+
+- Fixed command line redrawing on resizing the window with --multiline off.
+
 2023-04-08:
 
 - Fixed a termcap(5) detection bug that broke multiline editing on FreeBSD.

--- a/src/cmd/ksh93/edit/edit.c
+++ b/src/cmd/ksh93/edit/edit.c
@@ -749,6 +749,8 @@ int ed_read(void *context, int fd, char *buff, int size, int reedit)
 				ep->e_winsz = MINWINDOW;
 			if(!E_MULTILINE && ep->e_wsize < MAXLINE)
 				ep->e_wsize = ep->e_winsz-2;
+			if(ep->e_wsize > ep->e_plen)
+				ep->e_wsize -= ep->e_plen;
 			/* redraw command line */
 #if SHOPT_ESH && SHOPT_VSH
 			if(sh_isoption(SH_VI))

--- a/src/cmd/ksh93/edit/edit.c
+++ b/src/cmd/ksh93/edit/edit.c
@@ -747,10 +747,13 @@ int ed_read(void *context, int fd, char *buff, int size, int reedit)
 			ep->e_winsz = newsize-1;
 			if(ep->e_winsz < MINWINDOW)
 				ep->e_winsz = MINWINDOW;
-			if(!E_MULTILINE && ep->e_wsize < MAXLINE)
-				ep->e_wsize = ep->e_winsz-2;
-			if(ep->e_wsize > ep->e_plen)
-				ep->e_wsize -= ep->e_plen;
+			if(!E_MULTILINE)
+			{
+				if(ep->e_wsize < MAXLINE)
+					ep->e_wsize = ep->e_winsz-2;
+				if(ep->e_wsize > ep->e_plen)
+					ep->e_wsize -= ep->e_plen;
+			}
 			/* redraw command line */
 #if SHOPT_ESH && SHOPT_VSH
 			if(sh_isoption(SH_VI))

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -18,7 +18,7 @@
 
 #define SH_RELEASE_FORK	"93u+m"		/* only change if you develop a new ksh93 fork */
 #define SH_RELEASE_SVER	"1.1.0-alpha"	/* semantic version number: https://semver.org */
-#define SH_RELEASE_DATE	"2023-04-08"	/* must be in this format for $((.sh.version)) */
+#define SH_RELEASE_DATE	"2023-04-09"	/* must be in this format for $((.sh.version)) */
 #define SH_RELEASE_CPYR	"(c) 2020-2023 Contributors to ksh " SH_RELEASE_FORK
 
 /* Scripts sometimes field-split ${.sh.version}, so don't change amount of whitespace. */


### PR DESCRIPTION
See Issue #632.

In both line editors, starting the shell or resizing the window when `multiline` is set to off causes graphical errors for the first line of text not reached by a subsequent carriage return or `Ctrl + C`. The correct position for scrolling is three spaces away from the window edge; when the error occurs, the text instead continues for the length of `$PS1` before scrolling begins. For example, if `$COLUMNS` is 90 and `$PS1` is 20 characters long, text scrolls after 87 characters rather than 67. This results in partial multiline output (depending on how long `$PS1` is) and, on some operating systems, the repetition of the command line.

The cause is in the function `ed_read` in `edit.c`. When the shell starts or the window is resized, the new size-associated variables are determined through `ed_read` rather than `ed_setup`. Because the code in `ed_read` only accounts for prompt length when `multiline` is on, the effective window size exceeds its correct value by the number of characters in `$PS1`.

* `edit.c`: In `ed_read`, adjust for the length of the prompt when determining the new window size when `multiline` is set to off, provided that the result will be greater than zero.