### PR TITLE
Check for terminfo and termcap support at runtime.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,11 @@ This documents significant changes in the dev branch of ksh 93u+m.
 For full details, see the git log at: https://github.com/ksh93/ksh
 Uppercase BUG_* IDs are shell bug IDs as used by the Modernish shell library.
 
+2023-05-11:
+
+- The ability to use multi-line editing is now detected at runtime instead of
+  compile time, making detection more reliable across terminals and platforms.
+
 2023-05-01:
 
 - Fixes for indexed arrays declared to use enum constants for subscripts:

--- a/src/cmd/ksh93/data/builtins.c
+++ b/src/cmd/ksh93/data/builtins.c
@@ -292,7 +292,8 @@ const char sh_set[] =
 #if SHOPT_ESH || SHOPT_VSH
 		"[+multiline?Use multiple lines when editing lines that are "
 			"longer than the window width. Has no effect on systems "
-			"with neither \bterminfo\b nor \btermcap\b support.]"
+			"with neither \bterminfo\b nor \btermcap\b support for "
+			"the running terminal.]"
 #endif
 		"[+log?Obsolete; no effect.]"
 		"[+notify?Equivalent to \b-b\b.]"

--- a/src/cmd/ksh93/edit/edit.c
+++ b/src/cmd/ksh93/edit/edit.c
@@ -47,7 +47,6 @@
 
 static char *cursor_up;  /* move cursor up one line */
 static char *erase_eos;  /* erase to end of screen */
-#define E_MULTILINE	ep->e_multiline
 
 #if SHOPT_MULTIBYTE
 #   define is_cntrl(c)	((c<=STRIP) && iscntrl(c))
@@ -605,7 +604,7 @@ void	ed_setup(Edit_t *ep, int fd, int reedit)
 	if(pp-ep->e_prompt > qlen)
 		ep->e_plen = pp - ep->e_prompt - qlen;
 	*pp = 0;
-	if(E_MULTILINE)
+	if(ep->e_multiline)
 	{
 		static char *oldterm;
 		Namval_t *np = nv_search("TERM",sh.var_tree,0);
@@ -631,7 +630,7 @@ void	ed_setup(Edit_t *ep, int fd, int reedit)
 		else
 			ep->e_multiline = 0;
 	}
-	if(!E_MULTILINE && (ep->e_wsize -= ep->e_plen) < 7)
+	if(!ep->e_multiline && (ep->e_wsize -= ep->e_plen) < 7)
 	{
 		int shift = 7-ep->e_wsize;
 		ep->e_wsize = 7;
@@ -732,7 +731,7 @@ int ed_read(void *context, int fd, char *buff, int size, int reedit)
 			 * failure-prone if the window size changed, especially on modern terminals
 			 * that break the whole terminal abstraction by rewrapping lines themselves :(
 			 */
-			if(E_MULTILINE)
+			if(ep->e_multiline)
 			{
 				n = (ep->e_plen + ep->e_peol) / ep->e_winsz;
 				while(n-- > 0)
@@ -753,7 +752,7 @@ int ed_read(void *context, int fd, char *buff, int size, int reedit)
 			ep->e_winsz = newsize-1;
 			if(ep->e_winsz < MINWINDOW)
 				ep->e_winsz = MINWINDOW;
-			if(!E_MULTILINE)
+			if(!ep->e_multiline)
 			{
 				if(ep->e_wsize < MAXLINE)
 					ep->e_wsize = ep->e_winsz-2;
@@ -1111,7 +1110,7 @@ int ed_setcursor(Edit_t *ep,genchar *physical,int old,int new,int first)
 	}
 	if( delta == 0  &&  !clear)
 		return new;
-	if(E_MULTILINE)
+	if(ep->e_multiline)
 	{
 		ep->e_curpos = ed_curpos(ep, physical, old,0,ep->e_curpos);
 		if(clear && old>=ep->e_peol && (clear=ep->e_winsz-ep->e_curpos.col)>0)

--- a/src/cmd/ksh93/edit/emacs.c
+++ b/src/cmd/ksh93/edit/emacs.c
@@ -1040,9 +1040,18 @@ static int escape(Emacs_t* ep,genchar *out,int count)
 			draw(ep,UPDATE);
 			return -1;
 		case cntl('L'): /* clear screen */
-			system("\\command -p tput clear 2> /dev/null");
+		{
+			Shopt_t	o = sh.options;
+			sigblock(SIGINT);
+			sh_offoption(SH_RESTRICTED);
+			sh_offoption(SH_VERBOSE);
+			sh_offoption(SH_XTRACE);
+			sh_trap("\\command -p tput clear 2>/dev/null",0);
+			sh.options = o;
+			sigrelease(SIGINT);
 			draw(ep,REFRESH);
 			return -1;
+		}
 		case '[':	/* feature not in book */
 		case 'O':	/* after running top <ESC>O instead of <ESC>[ */
 			switch(i=ed_getchar(ep->ed,1))

--- a/src/cmd/ksh93/edit/emacs.c
+++ b/src/cmd/ksh93/edit/emacs.c
@@ -84,8 +84,6 @@ NoN(emacs)
 #define putchar(ed,c)	ed_putchar(ed,c)
 #define beep()		ed_ringbell()
 
-#define E_MULTILINE	ep->ed->e_multiline
-
 #if SHOPT_MULTIBYTE
 #   define gencpy(a,b)	ed_gencpy(a,b)
 #   define genncpy(a,b,n)	ed_genncpy(a,b,n)
@@ -244,7 +242,7 @@ int ed_emacsread(void *context, int fd,char *buff,int scend, int reedit)
 	i = sigsetjmp(env,0);
 	if (i !=0)
 	{
-		if(E_MULTILINE)
+		if(ep->ed->e_multiline)
 		{
 			cur = eol;
 			draw(ep,FINAL);
@@ -1636,7 +1634,7 @@ static void draw(Emacs_t *ep,Draw_t option)
 		}
 #endif /* SHOPT_MULTIBYTE */
 	}
-	if(E_MULTILINE && option == REFRESH)
+	if(ep->ed->e_multiline && option == REFRESH)
 		ed_setcursor(ep->ed, ep->screen, ep->ed->e_peol, ep->ed->e_peol, -1);
 
 	/******************
@@ -1667,7 +1665,7 @@ static void draw(Emacs_t *ep,Draw_t option)
 	}
 	i = (ncursor-nscreen) - ep->offset;
 	setcursor(ep,i,0);
-	if(option==FINAL && E_MULTILINE)
+	if(option==FINAL && ep->ed->e_multiline)
 		setcursor(ep,nscend+1-nscreen,0);
 	ep->scvalid = 1;
 	return;

--- a/src/cmd/ksh93/edit/emacs.c
+++ b/src/cmd/ksh93/edit/emacs.c
@@ -84,11 +84,7 @@ NoN(emacs)
 #define putchar(ed,c)	ed_putchar(ed,c)
 #define beep()		ed_ringbell()
 
-#if _tput_terminfo || _tput_termcap
 #define E_MULTILINE	ep->ed->e_multiline
-#else
-#define E_MULTILINE	0
-#endif
 
 #if SHOPT_MULTIBYTE
 #   define gencpy(a,b)	ed_gencpy(a,b)
@@ -1043,12 +1039,10 @@ static int escape(Emacs_t* ep,genchar *out,int count)
 			cur = i;
 			draw(ep,UPDATE);
 			return -1;
-#ifdef _pth_tput
 		case cntl('L'): /* clear screen */
-			system(_pth_tput " clear");
+			system("\\command -p tput clear 2> /dev/null");
 			draw(ep,REFRESH);
 			return -1;
-#endif
 		case '[':	/* feature not in book */
 		case 'O':	/* after running top <ESC>O instead of <ESC>[ */
 			switch(i=ed_getchar(ep->ed,1))

--- a/src/cmd/ksh93/edit/vi.c
+++ b/src/cmd/ksh93/edit/vi.c
@@ -89,8 +89,6 @@ NoN(vi)
 #define iswascii(c)	(!((c)&(~0177)))
 #endif
 
-#define E_MULTILINE	vp->ed->e_multiline
-
 typedef struct _vi_
 {
 	int direction;
@@ -303,7 +301,7 @@ int ed_viread(void *context, int fd, char *shbuf, int nchar, int reedit)
 	i = sigsetjmp(editb.e_env,0);
 	if( i != 0 )
 	{
-		if(E_MULTILINE)
+		if(vp->ed->e_multiline)
 		{
 			cur_virt = last_virt;
 			sync_cursor(vp);
@@ -334,7 +332,7 @@ int ed_viread(void *context, int fd, char *shbuf, int nchar, int reedit)
 		refresh(vp,INPUT);
 	}
 	getline(vp,APPEND);
-	if(E_MULTILINE)
+	if(vp->ed->e_multiline)
 		cursor(vp, last_phys);
 	/*** add a new line if user typed unescaped \n ***/
 	/* to cause the shell to process the line */
@@ -1863,7 +1861,7 @@ static void refresh(Vi_t* vp, int mode)
 		vp->long_line = vp->long_char;
 	}
 
-	if(E_MULTILINE && vp->ofirst_wind==INVALID)
+	if(vp->ed->e_multiline && vp->ofirst_wind==INVALID)
 		ed_setcursor(vp->ed, physical, last_phys+1, last_phys+1, -1);
 	vp->ocur_phys = ncur_phys;
 	vp->ocur_virt = cur_virt;

--- a/src/cmd/ksh93/edit/vi.c
+++ b/src/cmd/ksh93/edit/vi.c
@@ -89,11 +89,7 @@ NoN(vi)
 #define iswascii(c)	(!((c)&(~0177)))
 #endif
 
-#if _tput_terminfo || _tput_termcap
 #define E_MULTILINE	vp->ed->e_multiline
-#else
-#define E_MULTILINE	0
-#endif
 
 typedef struct _vi_
 {

--- a/src/cmd/ksh93/features/cmds
+++ b/src/cmd/ksh93/features/cmds
@@ -3,37 +3,3 @@ cmd	universe
 pth	ed fail{
 	echo '#define _pth_ed	"ed" /* ed not found on standard PATH */'
 }end
-
-pth	tput
-
-tput_terminfo note{ does tput support terminfo codes }end run{
-	export TERM=xterm
-	case ${_pth_tput-} in
-	\"/*/tput\")
-		tput=${_pth_tput#\"}
-		tput=${tput%\"}
-		if	"$tput" ed >/dev/null 2>&1 &&
-			"$tput" cuu1 >/dev/null 2>&1
-		then	echo '#define _tput_terminfo	1	/* tput supports terminfo codes */'
-		else	echo '#define _tput_terminfo	0	/* tput does not support terminfo codes */'
-			exit 1
-		fi ;;
-	*)	exit 1 ;;
-	esac
-}end
-
-tput_termcap note{ does tput support termcap codes }end run{
-	export TERM=xterm
-	case ${_pth_tput-} in
-	\"/*/tput\")
-		tput=${_pth_tput#\"}
-		tput=${tput%\"}
-		if	"$tput" cd >/dev/null 2>&1 &&
-			"$tput" up >/dev/null 2>&1
-		then	echo '#define _tput_termcap	1	/* tput supports termcap codes */'
-		else	echo '#define _tput_termcap	0	/* tput does not support termcap codes */'
-			exit 1
-		fi ;;
-	*)	exit 1 ;;
-	esac
-}end

--- a/src/cmd/ksh93/include/edit.h
+++ b/src/cmd/ksh93/include/edit.h
@@ -151,6 +151,12 @@ typedef struct edit
 		(c<'J'?c+1-'A':(c+10-'J'))))))))))))))))
 #endif
 
+/* required terminfo and termcap control sequences for multiline */
+#define TINF_CURSOR_UP	"cuu1"
+#define TINF_ERASE_EOS	"ed"
+#define TCAP_CURSOR_UP	"up"
+#define TCAP_ERASE_EOS	"cd"
+
 extern void	ed_putchar(Edit_t*, int);
 extern void	ed_ringbell(void);
 extern void	ed_setup(Edit_t*,int, int);

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -18,7 +18,7 @@
 
 #define SH_RELEASE_FORK	"93u+m"		/* only change if you develop a new ksh93 fork */
 #define SH_RELEASE_SVER	"1.1.0-alpha"	/* semantic version number: https://semver.org */
-#define SH_RELEASE_DATE	"2023-05-01"	/* must be in this format for $((.sh.version)) */
+#define SH_RELEASE_DATE	"2023-05-11"	/* must be in this format for $((.sh.version)) */
 #define SH_RELEASE_CPYR	"(c) 2020-2023 Contributors to ksh " SH_RELEASE_FORK
 
 /* Scripts sometimes field-split ${.sh.version}, so don't change amount of whitespace. */

--- a/src/cmd/ksh93/sh.1
+++ b/src/cmd/ksh93/sh.1
@@ -7833,7 +7833,7 @@ Same as
 The built-in editors will use multiple lines on the screen for lines
 that are longer than the width of the screen.  This may not work
 for all terminals.
-The shell uses the system's
+The shell uses the system default
 .BR tput (1)
 command to obtain the terminal escape codes for the necessary operations.
 Multi-line editing is disabled if this fails.
@@ -7842,7 +7842,7 @@ On most systems, setting the
 variable to your terminal's type and exporting it corrects this situation.
 The
 .B multiline
-option is permanently forced off on systems whose
+option is ineffectual on systems whose
 .BR tput (1)
 command supports neither
 .BR terminfo (5)

--- a/src/cmd/ksh93/sh/args.c
+++ b/src/cmd/ksh93/sh/args.c
@@ -598,9 +598,6 @@ void sh_printopts(Shopt_t oflags,int mode, Shopt_t *mask)
 #if SHOPT_VSH
 	on_option(&oflags,SH_VIRAW);
 #endif
-#if !_tput_terminfo && !_tput_termcap
-	off_option(&oflags,SH_MULTILINE);
-#endif
 	if(!(mode&(PRINT_ALL|PRINT_VERBOSE))) /* only print set options */
 		sfwrite(sfstdout,"set --default",13);
 	for(tp=shtab_options; value=tp->sh_number; tp++)

--- a/src/cmd/ksh93/sh/init.c
+++ b/src/cmd/ksh93/sh/init.c
@@ -1392,7 +1392,7 @@ Shell_t *sh_init(int argc,char *argv[], Shinit_f userinit)
 #endif /* SHOPT_TIMEOUT */
 	/* initialize jobs table */
 	job_clear();
-#if (SHOPT_ESH || SHOPT_VSH) && (_tput_terminfo || _tput_termcap)
+#if (SHOPT_ESH || SHOPT_VSH)
 	sh_onoption(SH_MULTILINE);
 #endif
 	if(argc>0)

--- a/src/cmd/ksh93/tests/pty.sh
+++ b/src/cmd/ksh93/tests/pty.sh
@@ -567,7 +567,7 @@ EOF
 tst $LINENO <<"!"
 L test -t 1 inside command substitution
 p :test-1:
-d 20
+d 40
 w . ./test_t.sh
 r ^:test-1: \. \./test_t\.sh\r\n$
 r ^OK0\r\n$
@@ -592,7 +592,7 @@ L race condition while launching external commands
 # See discussion at: https://github.com/ksh93/ksh/issues/79
 
 p :test-1:
-d 20
+d 40
 w printf '%s\\n' 1 2 3 4 5 | while read; do ls /dev/null; done
 r ^:test-1: printf '%s\\n' 1 2 3 4 5 | while read; do ls /dev/null; done\r\n$
 r ^/dev/null\r\n$
@@ -672,7 +672,7 @@ L syntax error added to history file
 
 # https://github.com/ksh93/ksh/issues/209
 
-d 20
+d 40
 p :test-1:
 w do something
 r ^:test-1: do something\r\n$
@@ -711,7 +711,7 @@ L crash after switching from emacs to vi mode
 # In ksh93r using the vi 'r' command after switching from emacs mode could
 # trigger a memory fault: https://bugzilla.opensuse.org/show_bug.cgi?id=179917
 
-d 20
+d 40
 p :test-1:
 w exec "$SHELL" -o emacs
 r ^:test-1: exec "\$SHELL" -o emacs\r\n$
@@ -749,7 +749,7 @@ tst $LINENO <<"!"
 L autocomplete should not fill partial multibyte characters
 # https://github.com/ksh93/ksh/issues/223
 
-d 20
+d 40
 p :test-1:
 w : XX\t
 r ^:test-1: : XXX\r\n$
@@ -759,7 +759,7 @@ r ^:test-1: : XXX\r\n$
 L Using b, B, w and W commands in vi mode
 # https://github.com/att/ast/issues/1467
 
-d 20
+d 40
 p :test-1:
 w set -o vi
 r ^:test-1: set -o vi\r\n$
@@ -783,7 +783,7 @@ ENV=$tmp/synerror tst $LINENO <<"!"
 L syntax error in profile causes exit on startup
 # https://github.com/ksh93/ksh/issues/281
 
-d 20
+d 40
 r /synerror: syntax error: `\(' unmatched\r\n$
 p :test-1:
 w echo ok
@@ -809,7 +809,7 @@ r ^:test-2: : One\\ "Two Three"\$'Four Five'\.mp3\r\n$
 L crash when entering comment into history file (vi mode)
 # https://github.com/att/ast/issues/798
 
-d 20
+d 40
 p :test-1:
 c foo \E#
 r ^:test-1: #foo\r\n$
@@ -824,7 +824,7 @@ L tab completion while expanding ${.sh.*} variables
 # https://github.com/att/ast/issues/1461
 # also tests $'...' string: https://github.com/ksh93/ksh/issues/462
 
-d 20
+d 40
 p :test-1:
 w test \$'foo\\'bar' \$\{.sh.level\t
 r ^:test-1: test \$'foo\\'bar' \$\{.sh.level\}\r\n$
@@ -835,7 +835,7 @@ L tab completion executes command substitutions
 # https://github.com/ksh93/ksh/issues/268
 # https://github.com/ksh93/ksh/issues/462#issuecomment-1038482307
 
-d 20
+d 40
 p :test-1:
 w $(echo true)\t
 r ^:test-1: \$\(echo true\)\r\n$
@@ -913,7 +913,7 @@ r one two three end
 L tab completion of '.' and '..'
 # https://github.com/ksh93/ksh/issues/372
 
-d 20
+d 40
 
 # typing '.' followed by two tabs should show a menu that includes "number) ../"
 p :test-1:
@@ -1143,7 +1143,7 @@ r ^:test-3: true fullcomplete/foi\r\n
 L full-word completion in vi mode
 # https://github.com/ksh93/ksh/pull/580
 
-d 20
+d 40
 p :test-1:
 w true fullcomplete/foi\Eh\\a
 r ^:test-1: true fullcomplete/foi\r\n
@@ -1161,7 +1161,7 @@ mkdir -p vitest/aあb && VISUAL=vi tst $LINENO <<"!"
 L vi completion from wide produces corrupt characters
 # https://github.com/ksh93/ksh/issues/571
 
-d 20
+d 40
 p :test-1:
 w cd vitest/aあ\t
 r ^:test-1: cd vitest/aあb/\r\n$

--- a/src/cmd/ksh93/tests/pty.sh
+++ b/src/cmd/ksh93/tests/pty.sh
@@ -619,7 +619,7 @@ r ^:test-2: \r\n$
 ((SHOPT_ESH)) && tst $LINENO <<"!"
 L emacs backslash escaping
 
-d 15
+d 20
 p :test-1:
 w set -o emacs
 
@@ -913,7 +913,7 @@ r one two three end
 L tab completion of '.' and '..'
 # https://github.com/ksh93/ksh/issues/372
 
-d 15
+d 20
 
 # typing '.' followed by two tabs should show a menu that includes "number) ../"
 p :test-1:
@@ -974,7 +974,7 @@ L tab completion with space in string and -o noglob on
 # https://github.com/ksh93/ksh/pull/413
 # Amended to test that completion keeps working after -o noglob
 
-d 15
+d 20
 p :test-1:
 w set -o noglob
 p :test-2:
@@ -1000,7 +1000,7 @@ tst $LINENO <<"!"
 L suspend a blocked write to a FIFO
 # https://github.com/ksh93/ksh/issues/464
 
-d 15
+d 20
 p :test-1:
 w echo >testfifo
 r echo


### PR DESCRIPTION
Checking for `terminfo` and `termcap` support for a common terminal at compilation time can cause two problems. First, an operating system may have a missing or defective description for a common terminal (see https://github.com/ksh93/ksh/commit/4f863e956f3a82c3b3533face7d76c3350fd6ab1 and https://github.com/ksh93/ksh/commit/79a908f427eee739e498b79669a7c2fc35c2d20b, respectively). Second, whatever terminal the user chooses may have substantially different capabilities. Instead, check for `termcap` and `terminfo` support at the first line and whenever the value of `TERM` changes:

* `edit.h`: Add the needed `terminfo` and `termcap` names for inclusion: `cuu1` and `ed`, and `up` and `cd`, respectively.
* `edit.c`: Remove the `TPUT_*` definitions, as well as `_tput_terminfo` and `_tput_termcap` `if` statements. When checking for capabilities at runtime, check for the corresponding `termcap` capability name if a `terminfo` capability is unavailable. In `get_tput`, use the OS default `tput` for testing.
* `vi.c`: `E_MULTILINE` is always equal to `vp->ed->e_multiline`.
* `emacs.c`: `E_MULTILINE` is always equal to `vp->ed->e_multiline`; when clearing the screen, use the OS default `tput` and suppress any error messages.
* `args.c`: Remove code disabling `SH_MULTILINE` when `terminfo` or `termcap` support is not detected at compile.
* `init.c`: Remove `termcap` and `terminfo` support as a condition for enabling `SH_MULTILINE`.
* features/cmds: Remove all `tput`-related tests.
* `pty.sh`: Increase a few more timing delays related to regression failures on macOS.
* `sh.1`: The multi-line editing option is no longer disabled at compile time, only rendered ineffectual at runtime if the chosen terminal does not support it.