### PR TITLE
Completion with histchars and initial tilde

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,13 @@ This documents significant changes in the dev branch of ksh 93u+m.
 For full details, see the git log at: https://github.com/ksh93/ksh
 Uppercase BUG_* IDs are shell bug IDs as used by the Modernish shell library.
 
+2023-05-12:
+
+- If history expansion is active, then command and file name completion now
+  quotes the history expansion characters with a backslash as needed to
+  avoid triggering history expansion failures if one of those characters
+  occurs in a command or file name.
+
 2023-05-11:
 
 - The ability to use multi-line editing is now detected at runtime instead of

--- a/NEWS
+++ b/NEWS
@@ -2,7 +2,7 @@ This documents significant changes in the dev branch of ksh 93u+m.
 For full details, see the git log at: https://github.com/ksh93/ksh
 Uppercase BUG_* IDs are shell bug IDs as used by the Modernish shell library.
 
-2023-05-12:
+2023-05-14:
 
 - If history expansion is active, then command and file name completion now
   quotes the history expansion characters with a backslash as needed to

--- a/NEWS
+++ b/NEWS
@@ -9,6 +9,8 @@ Uppercase BUG_* IDs are shell bug IDs as used by the Modernish shell library.
   avoid triggering history expansion failures if one of those characters
   occurs in a command or file name.
 
+- Fixed completion of file names starting with an escaped literal tilde.
+
 - Undocumented and non-functional goto label functionality has been removed.
   Command names can now end in ':' like on other shells, as POSIX requires.
 

--- a/src/cmd/ksh93/edit/completion.c
+++ b/src/cmd/ksh93/edit/completion.c
@@ -40,8 +40,8 @@ static char *fmtx(const char *string)
 	const char	*cp = string;
 	int	 	n,c;
 	int		pos = 0;
-	unsigned char 	*state = (unsigned char*)sh_lexstates[2]; 
-	int offset = staktell();
+	unsigned char 	*state = (unsigned char*)sh_lexstates[2];
+	int		offset = staktell();
 	char		hc[3];
 #if SHOPT_HISTEXPAND
 	const char	hexp = sh_isoption(SH_HISTEXPAND)!=0;

--- a/src/cmd/ksh93/edit/completion.c
+++ b/src/cmd/ksh93/edit/completion.c
@@ -49,8 +49,11 @@ static char *fmtx(const char *string)
 	int		i;
 	Namval_t	*np;
 #endif /* SHOPT_HISTEXPAND */
-	if(added=(*cp=='#' || *cp=='~'))
+	if(*cp=='#' || *cp=='~')
+	{
 		stakputc('\\');
+		added = *cp;
+	}
 	mbinit();
 #if SHOPT_HISTEXPAND
 	hc[0] = '!';
@@ -79,7 +82,7 @@ static char *fmtx(const char *string)
 		if((n=cp-string)==1)
 		{
 #if SHOPT_HISTEXPAND
-			if(((n=state[c]) && n!=S_EPAT) || ((c==hc[0] && !(added && (c=='#' || c=='~'))) || (c==hc[2] && !x)))
+			if(((n=state[c]) && n!=S_EPAT) || ((c==hc[0] && c!=added) || (c==hc[2] && !x)))
 #else
 			if((n=state[c]) && n!=S_EPAT)
 #endif /* SHOPT_HISTEXPAND */

--- a/src/cmd/ksh93/edit/completion.c
+++ b/src/cmd/ksh93/edit/completion.c
@@ -80,7 +80,7 @@ static char *fmtx(const char *string)
 		if((n=cp-string)==1)
 		{
 #if SHOPT_HISTEXPAND
-			if(((n=state[c]) && n!=S_EPAT) || ((c==hc[0]) || (c==hc[2] && !pos)))
+			if(((n=state[c]) && n!=S_EPAT) || (sh_isoption(SH_HISTEXPAND) && ((c==hc[0]) || (c==hc[2] && !pos))))
 #else
 			if((n=state[c]) && n!=S_EPAT)
 #endif /* SHOPT_HISTEXPAND */

--- a/src/cmd/ksh93/edit/completion.c
+++ b/src/cmd/ksh93/edit/completion.c
@@ -360,8 +360,14 @@ int ed_expand(Edit_t *ep, char outbuff[],int *cur,int *eol,int mode, int count)
 			mode = '*';
 		if(var!='$' && mode=='\\' && out[-1]!='*')
 			addstar = '*';
-		if(*begin=='~' && !strchr(begin,'/') && begin[-1]!='\'' && begin[-1]!='"')
-			addstar = 0;
+		if(*begin=='~')
+		{
+			/* do not perform tilde expansion while completing a quoted string */
+			if(begin>outbuff && (begin[-1]=='"' || begin[-1]=='\''))
+				sh_onstate(SH_NOTILDEXP);
+			else if(!strchr(begin,'/'))
+				addstar = 0;
+		}
 		stakputc(addstar);
 		ap = (struct argnod*)stakfreeze(1);
 	}
@@ -560,6 +566,7 @@ int ed_expand(Edit_t *ep, char outbuff[],int *cur,int *eol,int mode, int count)
 	}
  done:
 	sh_offstate(SH_FCOMPLETE);
+	sh_offstate(SH_NOTILDEXP);
 	if(!ep->e_nlist)
 		stakset(ep->e_stkptr,ep->e_stkoff);
 	if(nomarkdirs)

--- a/src/cmd/ksh93/edit/completion.c
+++ b/src/cmd/ksh93/edit/completion.c
@@ -79,7 +79,7 @@ static char *fmtx(const char *string)
 		if((n=cp-string)==1)
 		{
 #if SHOPT_HISTEXPAND
-			if(((n=state[c]) && n!=S_EPAT) || ((c==hc[0] && !added) || (c==hc[2] && !x)))
+			if(((n=state[c]) && n!=S_EPAT) || ((c==hc[0] && !(added && (c=='#' || c=='~'))) || (c==hc[2] && !x)))
 #else
 			if((n=state[c]) && n!=S_EPAT)
 #endif /* SHOPT_HISTEXPAND */

--- a/src/cmd/ksh93/edit/completion.c
+++ b/src/cmd/ksh93/edit/completion.c
@@ -61,16 +61,16 @@ static char *fmtx(const char *string)
 		}
 	}
 	first = (string[0]==hc[2] && sh_isoption(SH_HISTEXPAND));
-	if((!sh_isoption(SH_HISTEXPAND) || (*cp!=hc[0] && *cp!=hc[2])) && (*cp=='#'))
+	if((!sh_isoption(SH_HISTEXPAND) || (*cp!=hc[0] && *cp!=hc[2])) && (*cp=='#' || (*cp=='~' && (cp[1]=='\0' || cp[1]=='/'))))
 #else
-	if(*cp=='#')
+	if(*cp=='#' || (*cp=='~' && (cp[1]=='\0' || cp[1]=='/')))
 #endif /* SHOPT_HISTEXPAND */
 		stakputc('\\');
 	mbinit();
 #if SHOPT_HISTEXPAND
-	while((c=mbchar(cp)),((c>UCHAR_MAX)||(n=state[c])==0 || n==S_EPAT) && (!sh_isoption(SH_HISTEXPAND) || ((c!=hc[0]) && (c!=hc[2] || !first))));
+	while((c=mbchar(cp)),((c>UCHAR_MAX)||(n=state[c])==0 || n==S_EPAT) && (!sh_isoption(SH_HISTEXPAND) || ((c!=hc[0]) && (c!=hc[2] || !first))) && c!='~');
 #else
-	while((c=mbchar(cp)),(c>UCHAR_MAX)||(n=state[c])==0 || n==S_EPAT);
+	while(((c=mbchar(cp)),(c>UCHAR_MAX)||(n=state[c])==0 || n==S_EPAT) && c!='~');
 #endif /* SHOPT_HISTEXPAND */
 	if(n==S_EOF && *string!='#')
 		return (char*)string;

--- a/src/cmd/ksh93/edit/completion.c
+++ b/src/cmd/ksh93/edit/completion.c
@@ -70,7 +70,7 @@ static char *fmtx(const char *string)
 #if SHOPT_HISTEXPAND
 	while((c=mbchar(cp)),((c>UCHAR_MAX)||(n=state[c])==0 || n==S_EPAT) && (!sh_isoption(SH_HISTEXPAND) || ((c!=hc[0]) && (c!=hc[2] || !first))));
 #else
-	while(((c=mbchar(cp)),(c>UCHAR_MAX)||(n=state[c])==0 || n==S_EPAT));
+	while((c=mbchar(cp)),(c>UCHAR_MAX)||(n=state[c])==0 || n==S_EPAT);
 #endif /* SHOPT_HISTEXPAND */
 	if(n==S_EOF && *string!='#')
 		return (char*)string;

--- a/src/cmd/ksh93/edit/completion.c
+++ b/src/cmd/ksh93/edit/completion.c
@@ -360,7 +360,7 @@ int ed_expand(Edit_t *ep, char outbuff[],int *cur,int *eol,int mode, int count)
 			mode = '*';
 		if(var!='$' && mode=='\\' && out[-1]!='*')
 			addstar = '*';
-		if(*begin=='~' && !strchr(begin,'/'))
+		if(*begin=='~' && !strchr(begin,'/') && begin[-1]!='\'' && begin[-1]!='"')
 			addstar = 0;
 		stakputc(addstar);
 		ap = (struct argnod*)stakfreeze(1);

--- a/src/cmd/ksh93/edit/completion.c
+++ b/src/cmd/ksh93/edit/completion.c
@@ -44,7 +44,11 @@ static char *fmtx(const char *string)
 	if(*cp=='#' || *cp=='~')
 		stakputc('\\');
 	mbinit();
+#if SHOPT_HISTEXPAND
+	while((c=mbchar(cp)),((c>UCHAR_MAX)||(n=state[c])==0 || n==S_EPAT) && (!sh_isoption(SH_HISTEXPAND) || c!='!'));
+#else
 	while((c=mbchar(cp)),(c>UCHAR_MAX)||(n=state[c])==0 || n==S_EPAT);
+#endif /* SHOPT_HISTEXPAND */
 	if(n==S_EOF && *string!='#')
 		return (char*)string;
 	stakwrite(string,--cp-string);
@@ -52,7 +56,7 @@ static char *fmtx(const char *string)
 	{
 		if((n=cp-string)==1)
 		{
-			if((n=state[c]) && n!=S_EPAT)
+			if((n=state[c]) && (n!=S_EPAT || c=='!'))
 				stakputc('\\');
 			stakputc(c);
 		}

--- a/src/cmd/ksh93/edit/completion.c
+++ b/src/cmd/ksh93/edit/completion.c
@@ -50,7 +50,7 @@ static char *fmtx(const char *string)
 #else
 	const char	hexp = 0;
 #endif /* SHOPT_HISTEXPAND */
-	if((!hexp || (*cp!=hc[0] && *cp!=hc[2])) && (*cp=='#' || (*cp=='~' && (cp[1]=='\0' || cp[1]=='/'))))
+	if((!hexp || (*cp!=hc[0] && *cp!=hc[2])) && (*cp=='#' || *cp=='~'))
 		stakputc('\\');
 	mbinit();
 	while((c=mbchar(cp)),((c>UCHAR_MAX)||(n=state[c])==0 || n==S_EPAT)
@@ -360,7 +360,7 @@ int ed_expand(Edit_t *ep, char outbuff[],int *cur,int *eol,int mode, int count)
 			mode = '*';
 		if(var!='$' && mode=='\\' && out[-1]!='*')
 			addstar = '*';
-		if(*begin=='~' && !strchr(begin,'/') && begin==last-1)
+		if(*begin=='~' && !strchr(begin,'/'))
 			addstar = 0;
 		stakputc(addstar);
 		ap = (struct argnod*)stakfreeze(1);

--- a/src/cmd/ksh93/edit/completion.c
+++ b/src/cmd/ksh93/edit/completion.c
@@ -79,9 +79,9 @@ static char *fmtx(const char *string)
 		if((n=cp-string)==1)
 		{
 #if SHOPT_HISTEXPAND
-			if(((n=state[c]) && (n!=S_EPAT)) || ((c==hc[0] && !added) || (c==hc[2] && !x)))
+			if(((n=state[c]) && n!=S_EPAT) || ((c==hc[0] && !added) || (c==hc[2] && !x)))
 #else
-			if((n=state[c]) && (n!=S_EPAT))
+			if((n=state[c]) && n!=S_EPAT)
 #endif /* SHOPT_HISTEXPAND */
 				stakputc('\\');
 			stakputc(c);

--- a/src/cmd/ksh93/edit/hexpand.c
+++ b/src/cmd/ksh93/edit/hexpand.c
@@ -139,6 +139,23 @@ static int is_wordboundary(char c)
 }
 
 /*
+ * assign history expansion characters to an array of 3
+ */
+
+void hist_setchars(char *hc)
+{
+	Namval_t *np;
+	char *cp;
+	int i;
+	hc[0] = '!';
+	hc[1] = '^';
+	hc[2] = '#';
+	if((np = nv_open("histchars",sh.var_tree,NV_NOADD)) && (cp = nv_getval(np)))
+		for(i=0; i<3 && cp[i]; i++)
+			hc[i] = cp[i];
+}
+
+/*
  * history expansion main routine
  */
 
@@ -163,29 +180,13 @@ int hist_expand(const char *ln, char **xp)
 		*tmp=0,	/* temporary line buffer */
 		*tmp2=0;/* temporary line buffer */
 	Histloc_t hl;	/* history location */
-	Namval_t *np;	/* histchars variable */
 	static struct subst	sb = {0,0};	/* substitution strings */
 	static Sfio_t	*wm=0;	/* word match from !?string? event designator */
 
 	if(!wm)
 		wm = sfopen(NULL, NULL, "swr");
 
-	hc[0] = '!';
-	hc[1] = '^';
-	hc[2] = '#';
-	if((np = nv_open("histchars",sh.var_tree,NV_NOADD)) && (cp = nv_getval(np)))
-	{
-		if(cp[0])
-		{
-			hc[0] = cp[0];
-			if(cp[1])
-			{
-				hc[1] = cp[1];
-				if(cp[2])
-					hc[2] = cp[2];
-			}
-		}
-	}
+	hist_setchars(hc);
 
 	/* save shell stack */
 	if(off = staktell())

--- a/src/cmd/ksh93/include/edit.h
+++ b/src/cmd/ksh93/include/edit.h
@@ -209,6 +209,7 @@ extern const char	e_runvi[];
 
 #define	HIST_FLAG_RETURN_MASK	(HIST_EVENT|HIST_PRINT|HIST_ERROR)
 
+extern void hist_setchars(char *);
 extern int hist_expand(const char *, char **);
 
 #endif /* SHOPT_HISTEXPAND */

--- a/src/cmd/ksh93/include/shell.h
+++ b/src/cmd/ksh93/include/shell.h
@@ -80,6 +80,7 @@ typedef union Shnode_u Shnode_t;
 #define	SH_PREINIT	18	/* set with SH_INIT before parsing options */
 #define SH_COMPLETE	19	/* set for command completion */
 #define SH_XARG		21	/* set while in xarg (command -x) mode */
+#define SH_NOTILDEXP	22	/* set to disable tilde expansion */
 
 /*
  * Shell options (set -o). Used with sh_isoption(), sh_onoption(), sh_offoption().

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -18,7 +18,7 @@
 
 #define SH_RELEASE_FORK	"93u+m"		/* only change if you develop a new ksh93 fork */
 #define SH_RELEASE_SVER	"1.1.0-alpha"	/* semantic version number: https://semver.org */
-#define SH_RELEASE_DATE	"2023-05-11"	/* must be in this format for $((.sh.version)) */
+#define SH_RELEASE_DATE	"2023-05-12"	/* must be in this format for $((.sh.version)) */
 #define SH_RELEASE_CPYR	"(c) 2020-2023 Contributors to ksh " SH_RELEASE_FORK
 
 /* Scripts sometimes field-split ${.sh.version}, so don't change amount of whitespace. */

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -18,7 +18,7 @@
 
 #define SH_RELEASE_FORK	"93u+m"		/* only change if you develop a new ksh93 fork */
 #define SH_RELEASE_SVER	"1.1.0-alpha"	/* semantic version number: https://semver.org */
-#define SH_RELEASE_DATE	"2023-05-12"	/* must be in this format for $((.sh.version)) */
+#define SH_RELEASE_DATE	"2023-05-14"	/* must be in this format for $((.sh.version)) */
 #define SH_RELEASE_CPYR	"(c) 2020-2023 Contributors to ksh " SH_RELEASE_FORK
 
 /* Scripts sometimes field-split ${.sh.version}, so don't change amount of whitespace. */

--- a/src/cmd/ksh93/sh/macro.c
+++ b/src/cmd/ksh93/sh/macro.c
@@ -441,7 +441,7 @@ static void copyto(Mac_t *mp,int endch, int newquote)
 	mp->sp = NULL;
 	mp->quote = newquote;
 	first = cp = fcseek(0);
-	if(!mp->quote && *cp=='~' && cp[1]!=LPAREN)
+	if(!mp->quote && *cp=='~' && cp[1]!=LPAREN && !sh_isstate(SH_NOTILDEXP))
 		tilde = stktell(stkp);
 	/* handle // operator specially */
 	if(mp->pattern==2 && *cp=='/')
@@ -807,7 +807,7 @@ static void copyto(Mac_t *mp,int endch, int newquote)
 		    case S_EQ:
 			if(mp->assign==1)
 			{
-				if(*cp=='~' && !endch && !mp->quote && !mp->lit)
+				if(*cp=='~' && !endch && !mp->quote && !mp->lit && !sh_isstate(SH_NOTILDEXP))
 					tilde = stktell(stkp)+(c+1);
 				mp->assign = 2;
 			}
@@ -830,7 +830,7 @@ static void copyto(Mac_t *mp,int endch, int newquote)
 				tilde = -1;
 				c=0;
 			}
-			if(n==S_COLON && mp->assign==2 && *cp=='~' && endch==0 && !mp->quote &&!mp->lit)
+			if(n==S_COLON && mp->assign==2 && *cp=='~' && endch==0 && !mp->quote && !mp->lit && !sh_isstate(SH_NOTILDEXP))
 				tilde = stktell(stkp)+(c+1);
 			else if(n==S_SLASH && mp->pattern==2)
 			{

--- a/src/cmd/ksh93/sh/macro.c
+++ b/src/cmd/ksh93/sh/macro.c
@@ -441,7 +441,7 @@ static void copyto(Mac_t *mp,int endch, int newquote)
 	mp->sp = NULL;
 	mp->quote = newquote;
 	first = cp = fcseek(0);
-	if(!mp->quote && *cp=='~' && cp[1]!=LPAREN)
+	if(!mp->quote && *cp=='~' && cp[1]!=LPAREN && !sh_isstate(SH_FCOMPLETE))
 		tilde = stktell(stkp);
 	/* handle // operator specially */
 	if(mp->pattern==2 && *cp=='/')

--- a/src/cmd/ksh93/sh/macro.c
+++ b/src/cmd/ksh93/sh/macro.c
@@ -441,7 +441,7 @@ static void copyto(Mac_t *mp,int endch, int newquote)
 	mp->sp = NULL;
 	mp->quote = newquote;
 	first = cp = fcseek(0);
-	if(!mp->quote && *cp=='~' && cp[1]!=LPAREN && !sh_isstate(SH_FCOMPLETE))
+	if(!mp->quote && *cp=='~' && cp[1]!=LPAREN)
 		tilde = stktell(stkp);
 	/* handle // operator specially */
 	if(mp->pattern==2 && *cp=='/')

--- a/src/cmd/ksh93/tests/pty.sh
+++ b/src/cmd/ksh93/tests/pty.sh
@@ -1168,20 +1168,49 @@ r ^:test-1: cd vitest/aあb/\r\n$
 !
 
 ((SHOPT_HISTEXPAND)) && ((SHOPT_VSH || SHOPT_ESH)) &&
-mkdir -p 'excltest/aa!b' && tst $LINENO <<"!"
-L tab-completing with an exclamation mark in the result
+mkdir -p 'chrtest/aa#b' && tst $LINENO <<"!"
+L tab-completing with first histchar
 
 d 20
 p :test-1:
-w set +o histexpand
+w histchars='#^!'
 p :test-2:
-w ls excltest/a\t
-r ^:test-2: ls excltest/aa!b/\r\n$
+w set +o histexpand
 p :test-3:
-w set -o histexpand
+w ls chrtest/a\t
+r ^:test-3: ls chrtest/aa#b/\r\n$
 p :test-4:
-w ls excltest/a\t
-r ^:test-4: ls excltest/aa\\!b/\r\n$
+w set -o histexpand
+p :test-5:
+w ls chrtest/a\t
+r ^:test-5: ls chrtest/aa\\#b/\r\n$
+p :test-6:
+w unset histchars
+!
+
+((SHOPT_HISTEXPAND)) && ((SHOPT_VSH || SHOPT_ESH)) &&
+mkdir -p 'chrtest2/@a@b' && tst $LINENO <<"!"
+L tab-completing with third histchar
+
+d 20
+p :test-1:
+w histchars='!^@'
+p :test-2:
+w cd chrtest2
+p :test-3:
+w set +o histexpand
+p :test-4:
+w ls \t
+r ^:test-4: ls @a@b/\r\n$
+p :test-5:
+w set -o histexpand
+p :test-6:
+w ls \t
+r ^:test-6: ls \\@a@b/\r\n$
+p :test-7:
+w unset histchars
+p :test-8:
+w cd ..
 !
 
 # ======

--- a/src/cmd/ksh93/tests/pty.sh
+++ b/src/cmd/ksh93/tests/pty.sh
@@ -1000,7 +1000,7 @@ tst $LINENO <<"!"
 L suspend a blocked write to a FIFO
 # https://github.com/ksh93/ksh/issues/464
 
-d 20
+d 40
 p :test-1:
 w echo >testfifo
 r echo

--- a/src/cmd/ksh93/tests/pty.sh
+++ b/src/cmd/ksh93/tests/pty.sh
@@ -1207,10 +1207,6 @@ w set -o histexpand
 p :test-6:
 w ls \t
 r ^:test-6: ls \\@a@b/\r\n$
-p :test-7:
-w unset histchars
-p :test-8:
-w cd ..
 !
 
 ((SHOPT_VSH || SHOPT_ESH)) &&
@@ -1223,8 +1219,6 @@ w cd chrtest3
 p :test-2:
 w ls ~a\t
 r ^:test-2: ls ~ab/\r\n$
-p :test-3:
-w cd ..
 !
 
 ((SHOPT_VSH || SHOPT_ESH)) &&
@@ -1237,8 +1231,6 @@ w cd chrtest4
 p :test-2:
 w ls \\~\t
 r ^:test-2: ls \\~/\r\n$
-p :test-3:
-w cd ..
 !
 
 # ======

--- a/src/cmd/ksh93/tests/pty.sh
+++ b/src/cmd/ksh93/tests/pty.sh
@@ -1211,26 +1211,14 @@ r ^:test-6: ls \\@a@b/\r\n$
 
 ((SHOPT_VSH || SHOPT_ESH)) &&
 mkdir -p 'chrtest3/~ab' && tst $LINENO <<"!"
-L tab-completing with ~ in the filename
+L tab-completing with escaped ~
 
 d 20
 p :test-1:
 w cd chrtest3
 p :test-2:
-w ls ~a\t
-r ^:test-2: ls ~ab/\r\n$
-!
-
-((SHOPT_VSH || SHOPT_ESH)) &&
-mkdir -p 'chrtest4/~' && tst $LINENO <<"!"
-L tab-completing with ~ as a name
-
-d 20
-p :test-1:
-w cd chrtest4
-p :test-2:
 w ls \\~\t
-r ^:test-2: ls \\~/\r\n$
+r ^:test-2: ls \\~ab/\r\n$
 !
 
 # ======

--- a/src/cmd/ksh93/tests/pty.sh
+++ b/src/cmd/ksh93/tests/pty.sh
@@ -1167,5 +1167,27 @@ w cd vitest/aあ\t
 r ^:test-1: cd vitest/aあb/\r\n$
 !
 
+((SHOPT_HISTEXPAND)) && ((SHOPT_VSH || SHOPT_ESH)) &&
+mkdir -p excltest/aa\!b && tst $LINENO <<"!"
+L tab-completing with an exclamation mark in the result
+d 20
+p :test-1:
+w set -o histexpand
+p :test-2:
+w ls excltest/a\t
+r ^:test-2: ls excltest/aa\!b/\r\n$
+p :test-3: 
+w ls excltest/aa\!\t
+r ^:test-3: ls excltest/aa\!b/\r\n$
+p :test-4:
+w set +o histexpand
+p :test-5:
+w ls excltest/a\t
+r ^:test-5: ls excltest/aa!b/\r\n$
+p :test-6:
+w ls excltest/aa!\t
+r ^:test-6: ls excltest/aa!b/\r\n$
+!
+
 # ======
 exit $((Errors<125?Errors:125))

--- a/src/cmd/ksh93/tests/pty.sh
+++ b/src/cmd/ksh93/tests/pty.sh
@@ -1213,5 +1213,19 @@ p :test-8:
 w cd ..
 !
 
+((SHOPT_VSH || SHOPT_ESH)) &&
+mkdir -p 'chrtest3/~ab' && tst $LINENO <<"!"
+L tab-completing with ~ in the filename
+
+d 20
+p :test-1:
+w cd chrtest3
+p :test-2:
+w ls ~a\t
+r ^:test-2: ls ~ab/\r\n$
+p :test-3:
+cd ..
+!
+
 # ======
 exit $((Errors<125?Errors:125))

--- a/src/cmd/ksh93/tests/pty.sh
+++ b/src/cmd/ksh93/tests/pty.sh
@@ -1215,7 +1215,7 @@ L tab-completing with escaped ~
 
 d 20
 p :test-1:
-w cd chrtest3
+w cd chrtest3; .sh.tilde.get() { print -n WRONG_TILDE_EXPANSION >&2; };
 p :test-2:
 w ls \\~\t
 r ^:test-2: ls \\~ab/\r\n$

--- a/src/cmd/ksh93/tests/pty.sh
+++ b/src/cmd/ksh93/tests/pty.sh
@@ -1167,7 +1167,7 @@ w cd vitest/aあ\t
 r ^:test-1: cd vitest/aあb/\r\n$
 !
 
-((SHOPT_HISTEXPAND)) && ((SHOPT_VSH || SHOPT_ESH)) &&
+((SHOPT_HISTEXPAND && (SHOPT_VSH || SHOPT_ESH))) &&
 mkdir -p 'chrtest/aa#b' && tst $LINENO <<"!"
 L tab-completing with first histchar
 
@@ -1188,7 +1188,7 @@ p :test-6:
 w unset histchars
 !
 
-((SHOPT_HISTEXPAND)) && ((SHOPT_VSH || SHOPT_ESH)) &&
+((SHOPT_HISTEXPAND && (SHOPT_VSH || SHOPT_ESH))) &&
 mkdir -p 'chrtest2/@a@b' && tst $LINENO <<"!"
 L tab-completing with third histchar
 

--- a/src/cmd/ksh93/tests/pty.sh
+++ b/src/cmd/ksh93/tests/pty.sh
@@ -1168,25 +1168,20 @@ r ^:test-1: cd vitest/aあb/\r\n$
 !
 
 ((SHOPT_HISTEXPAND)) && ((SHOPT_VSH || SHOPT_ESH)) &&
-mkdir -p excltest/aa\!b && tst $LINENO <<"!"
+mkdir -p 'excltest/aa!b' && tst $LINENO <<"!"
 L tab-completing with an exclamation mark in the result
+
 d 20
 p :test-1:
-w set -o histexpand
+w set +o histexpand
 p :test-2:
 w ls excltest/a\t
-r ^:test-2: ls excltest/aa\!b/\r\n$
-p :test-3: 
-w ls excltest/aa\!\t
-r ^:test-3: ls excltest/aa\!b/\r\n$
+r ^:test-2: ls excltest/aa!b/\r\n$
+p :test-3:
+w set -o histexpand
 p :test-4:
-w set +o histexpand
-p :test-5:
 w ls excltest/a\t
-r ^:test-5: ls excltest/aa!b/\r\n$
-p :test-6:
-w ls excltest/aa!\t
-r ^:test-6: ls excltest/aa!b/\r\n$
+r ^:test-4: ls excltest/aa\\!b/\r\n$
 !
 
 # ======

--- a/src/cmd/ksh93/tests/pty.sh
+++ b/src/cmd/ksh93/tests/pty.sh
@@ -1224,7 +1224,21 @@ p :test-2:
 w ls ~a\t
 r ^:test-2: ls ~ab/\r\n$
 p :test-3:
-cd ..
+w cd ..
+!
+
+((SHOPT_VSH || SHOPT_ESH)) &&
+mkdir -p 'chrtest4/~' && tst $LINENO <<"!"
+L tab-completing with ~ as a name
+
+d 20
+p :test-1:
+w cd chrtest4
+p :test-2:
+w ls \\~\t
+r ^:test-2: ls \\~/\r\n$
+p :test-3:
+w cd ..
 !
 
 # ======

--- a/src/cmd/ksh93/tests/pty.sh
+++ b/src/cmd/ksh93/tests/pty.sh
@@ -1219,6 +1219,15 @@ w cd chrtest3
 p :test-2:
 w ls \\~\t
 r ^:test-2: ls \\~ab/\r\n$
+p :test-3:
+w ls '~\t
+r ^:test-3: ls \\~ab/\r\n$
+p :test-4:
+w ls "~\t
+r ^:test-4: ls \\~ab/\r\n$
+p :test-5:
+w ls $'~\t
+r ^:test-5: ls \\~ab/\r\n$
 !
 
 # ======


### PR DESCRIPTION
This PR addresses ~~three~~ four completion-related problems.

First: when using completion, any ~~exclamation marks~~ instance of the first `histchar` ("!" by default) will be left unescaped if it is included in the result, regardless of whether it had been escaped when the completion was performed:

    cd \!(tab)
    cd !very\ long\ and\ strange\ directory\ name/

This is perfectly correct if `histexpand` is turned off. If `histexpand` is enabled, however, the resulting command will either error out or perform an unexpected history expansion. To prevent this, escape any ~~exclamation marks~~ instance of the first `histchar` in the result of a completion if `histexpand` is enabled.

Second: if the third `histchar` ("#" by default) is anything other than `#`, it will not be escaped at the beginning of the string. This causes similar unexpected behavior.

~~Third: if a filename starts with a tilde (`~`), completion invariably fails unless it is escaped. Achieving a partial completion unescapes any tildes, making it necessary to navigate back and fix it. This happens because `addstar` is always set to zero when the completion string starts with a tilde; setting `addstar` to zero only when the tilde is by itself (or is entered as a directory name) solves the issue.~~ 

Third: if a filename starts with an escaped tilde (`~`), achieving a partial completion unescapes the first tilde, making it necessary to navigate back and fix it. This happens because `fmtx` only reaches `stakwrite` soon enough if an `S_EPAT` character is in the string, a category that includes `#` but not `~`. Alter the relevant loop to stop at `~` as well.

Fourth: when at the start of a quotation, `~` can complete to `$HOME` or undergo tilde expansion to an existing user. Send such `~` to `fmtx` so it can be escaped properly.

~~`completion.c`: In the function `fmtx`, add a preceding backslash to exclamation marks in the completion result if `histexpand` is set to `on`.~~

* `completion.c`: Escape initial tildes in completion candidates as intended, including tildes starting a quotation. In the function `fmtx`, when `histexpand` is on, add a preceding backslash to the first `histchar` everywhere, and to the third `histchar` when it appears at the beginning of the string.
* `hexpand.{c,h}`: Use a separate function to set the three histchars.

As a side note, `bash` escapes ~~exclamation marks~~ the first `histchar` in all cases, whereas `zsh` only escapes ~~exclamation marks~~ with `histexpand` enabled.