### PR TITLE
Another set of minor bugfixes

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -33,7 +33,7 @@ Uppercase BUG_* IDs are shell bug IDs as used by the Modernish shell library.
 - Multiline editing is now automatically disabled if and when the TERM
   environment variable is unset, not exported, or set to a terminal type
   that does not support the necessary operations. It is automatically
-  reenabled when the TERM variable is corrected and --multiline is on.
+  re-enabled when the TERM variable is corrected and --multiline is on.
 
 2023-04-08:
 

--- a/src/cmd/INIT/w2.c
+++ b/src/cmd/INIT/w2.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1994-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2023 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -12,9 +12,11 @@
 *                                                                      *
 *                 Glenn Fowler <gsf@research.att.com>                  *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 #include <wchar.h>
+#include <wctype.h>
 
 int
 main()

--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -1964,9 +1964,9 @@ int sh_exec(const Shnode_t *t, int flags)
 			int nargs;
 			Namval_t *np;
 			int flag = errorflg|OPTIMIZE_FLAG;
-			struct dolnod	*argsav=0;
+			struct dolnod	*argsav = NULL;
 			struct comnod	*tp;
-			char *cp, *trap, *nullptr = 0;
+			char *cp, *trap, *null_pointer = NULL;
 			int nameref, refresh=1;
 			char *av[5];
 #if SHOPT_OPTIMIZE
@@ -2010,7 +2010,7 @@ int sh_exec(const Shnode_t *t, int flags)
 					save_prompt = sh.nextprompt;
 					sh.nextprompt = 3;
 					sh.timeout = 0;
-					sh.exitval=sh_readline(&nullptr,0,1,0,1000*sh.st.tmout);
+					sh.exitval=sh_readline(&null_pointer,0,1,0,1000*sh.st.tmout);
 					sh.nextprompt = save_prompt;
 					if(sh.exitval||sfeof(sfstdin)||sferror(sfstdin))
 					{
@@ -2798,8 +2798,8 @@ pid_t _sh_fork(pid_t parent,int flags,int *jobid)
 		if(sh_isstate(SH_MONITOR))
 		{
 			/*
-			 * errno==EPERM means that an earlier processes
-			 * completed.  Make parent the job group ID.
+			 * errno == EPERM means that an earlier process has
+			 * finished running. Make the parent the job group ID.
 			 */
 			if(postid==0)
 				job.curpgid = parent;

--- a/src/lib/libast/features/lib
+++ b/src/lib/libast/features/lib
@@ -63,8 +63,8 @@ tst	tst_errno note{ errno can be assigned }end link{
 	#ifndef errno
 	extern int errno;
 	#endif
-	error() { }
-	strerror() { }
+	void error() { }
+	void strerror() { }
 	int main() { errno = 0; error(); strerror(); return 0; }
 }end
 

--- a/src/lib/libast/features/map.c
+++ b/src/lib/libast/features/map.c
@@ -419,10 +419,6 @@ main()
 	printf("#undef	free\n");
 	printf("#define free		_ast_free\n");
 	printf("extern void		free(void*);\n");
-#if _lib_mallinfo
-	printf("#undef	mallinfo\n");
-	printf("#define mallinfo	_ast_mallinfo\n");
-#endif
 	printf("#undef	malloc\n");
 	printf("#define malloc		_ast_malloc\n");
 	printf("extern void*		malloc(size_t);\n");

--- a/src/lib/libast/features/omitted
+++ b/src/lib/libast/features/omitted
@@ -1,6 +1,7 @@
 tst	note{ check for Win32 .exe botches }end output{
 	#include <unistd.h>
 	#include <fcntl.h>
+	#include <stdlib.h>
 	#include <sys/types.h>
 	#include <sys/stat.h>
 	static int

--- a/src/lib/libast/features/param.sh
+++ b/src/lib/libast/features/param.sh
@@ -2,7 +2,7 @@
 #                                                                      #
 #               This software is part of the ast package               #
 #          Copyright (c) 1985-2011 AT&T Intellectual Property          #
-#          Copyright (c) 2020-2022 Contributors to ksh 93u+m           #
+#          Copyright (c) 2020-2023 Contributors to ksh 93u+m           #
 #                      and is licensed under the                       #
 #                 Eclipse Public License, Version 2.0                  #
 #                                                                      #
@@ -14,6 +14,7 @@
 #                  David Korn <dgk@research.att.com>                   #
 #                   Phong Vo <kpv@research.att.com>                    #
 #                  Martijn Dekker <martijn@inlv.org>                   #
+#            Johnothan King <johnothanking@protonmail.com>             #
 #                                                                      #
 ########################################################################
 : generate "<sys/param.h> + <sys/types.h> + <sys/stat.h>" include sequence
@@ -42,7 +43,7 @@ for i in "#include <sys/param.h>" "#include <sys/param.h>
 #endif"
 do	echo "$i
 struct stat V_stat_V;
-F_stat_F() { V_stat_V.st_mode = 0; }" > $tmp.c
+void F_stat_F() { V_stat_V.st_mode = 0; }" > $tmp.c
 	if	$cc -c $tmp.c >/dev/null
 	then	echo "$i"
 		break

--- a/src/lib/libast/features/vmalloc
+++ b/src/lib/libast/features/vmalloc
@@ -8,11 +8,11 @@
 
 ref	-D_def_map_ast=1
 
-lib	atexit,getpagesize,mallinfo,mallopt,memalign,mstats
+lib	atexit,getpagesize,mallopt,memalign,mstats
 lib	onexit,pvalloc,strdup,valloc,vmalloc
 lib	_malloc,__malloc,__libc_malloc
 hdr	alloca,malloc,stat,stdlib,unistd,sys/shm
-mem	mallinfo.arena,mstats.bytes_total malloc.h
+mem	mstats.bytes_total malloc.h
 sys	stat
 typ	ssize_t
 
@@ -114,7 +114,7 @@ tst	mal_alloca note{ alloca is based on malloc() }end execute{
 }end
 
 tst	stk_down note{ stack grows downward }end execute{
-	static growdown()
+	static int growdown()
 	{	static char*	addr = 0;
 		char		array[4];
 		if(!addr)

--- a/src/lib/libast/sfio/sfswap.c
+++ b/src/lib/libast/sfio/sfswap.c
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 #include	"sfhdr.h"
@@ -28,8 +29,9 @@
 
 Sfio_t* sfswap(Sfio_t* f1, Sfio_t* f2)
 {
-	Sfio_t	tmp;
-	int	f1pool, f2pool, f1mode, f2mode, f1flags, f2flags;
+	Sfio_t		tmp;
+	int		f1pool, f2pool, f1flags, f2flags;
+	unsigned int	f1mode, f2mode;
 
 	if(!f1 || (f1->mode&SF_AVAIL) || (SFFROZEN(f1) && (f1->mode&SF_PUSH)) )
 		return NULL;

--- a/src/lib/libast/sfio/sfsync.c
+++ b/src/lib/libast/sfio/sfsync.c
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 #include	"sfhdr.h"
@@ -74,7 +75,7 @@ static int _sfall(void)
 
 int sfsync(Sfio_t* f)
 {
-	int	local, rv, mode, lock;
+	int	local, rv, lock;
 	Sfio_t*	origf;
 
 	if(!(origf = f) )
@@ -99,7 +100,9 @@ int sfsync(Sfio_t* f)
 	}
 
 	for(; f; f = f->push)
-	{	
+	{
+		unsigned int mode;
+
 		if((f->flags&SF_IOCHECK) && f->disc && f->disc->exceptf)
 			(void)(*f->disc->exceptf)(f,SF_SYNC,(void*)((int)1),f->disc);
 
@@ -114,8 +117,8 @@ int sfsync(Sfio_t* f)
 			goto next;
 
 		if((f->mode&SF_WRITE) && (f->next > f->data || (f->bits&SF_HOLE)) )
-		{	/* sync the buffer, make sure pool don't move */
-			int pool = f->mode&SF_POOL;
+		{	/* sync the buffer, make sure pool doesn't move */
+			unsigned int pool = f->mode&SF_POOL;
 			f->mode &= ~SF_POOL;
 			if(f->next > f->data && (SFWRALL(f), SFFLSBUF(f,-1)) < 0)
 				rv = -1;

--- a/src/lib/libast/vmalloc/malloc.c
+++ b/src/lib/libast/vmalloc/malloc.c
@@ -88,7 +88,6 @@ static Vmulong_t	_Vmdbtime = 0;
 #undef calloc
 #undef cfree
 #undef free
-#undef mallinfo
 #undef malloc
 #undef mallopt
 #undef memalign
@@ -737,7 +736,6 @@ extern void*	__libc_valloc(size_t n) { return valloc(n); }
 
 #include	<malloc.h>
 
-typedef struct mallinfo Mallinfo_t;
 typedef struct mstats Mstats_t;
 
 #if _lib_mallopt
@@ -747,24 +745,6 @@ extern int mallopt(int cmd, int value)
 	return 0;
 }
 #endif /*_lib_mallopt*/
-
-#if _lib_mallinfo && _mem_arena_mallinfo
-extern Mallinfo_t mallinfo(void)
-{
-	Vmstat_t	sb;
-	Mallinfo_t	mi;
-
-	VMFLINIT();
-	memset(&mi,0,sizeof(mi));
-	if(vmstat(Vmregion,&sb) >= 0)
-	{	mi.arena = sb.extent;
-		mi.ordblks = sb.n_busy+sb.n_free;
-		mi.uordblks = sb.s_busy;
-		mi.fordblks = sb.s_free;
-	}
-	return mi;
-}
-#endif /* _lib_mallinfo */
 
 #if _lib_mstats && _mem_bytes_total_mstats
 extern Mstats_t mstats(void)
@@ -818,7 +798,6 @@ extern void*	_ast_valloc(size_t n) { return valloc(n); }
 
 #if _hdr_malloc
 
-#undef	mallinfo
 #undef	mallopt
 #undef	mstats
 
@@ -832,15 +811,10 @@ extern void*	_ast_valloc(size_t n) { return valloc(n); }
 
 #include	<malloc.h>
 
-typedef struct mallinfo Mallinfo_t;
 typedef struct mstats Mstats_t;
 
 #if _lib_mallopt
 extern int	_ast_mallopt(int cmd, int value) { return mallopt(cmd, value); }
-#endif
-
-#if _lib_mallinfo && _mem_arena_mallinfo
-extern Mallinfo_t	_ast_mallinfo(void) { return mallinfo(); }
 #endif
 
 #if _lib_mstats && _mem_bytes_total_mstats

--- a/src/lib/libcmd/expr.c
+++ b/src/lib/libcmd/expr.c
@@ -104,7 +104,7 @@ static const char usage[] =
 	"[+2?Invalid expressions.]"
 	"[+>2?An error occurred.]"
 	"}"
-"[+SEE ALSO?\bregcomp\b(3), \bgrep\b(1), \bsh\b(1)]"
+"[+SEE ALSO?\bregex\b(3), \bgrep\b(1), \bsh\b(1)]"
 ;
 
 #include	<cmd.h>


### PR DESCRIPTION
Notable changes:
- Ported some minor `-Wsign-conversion` fixes from graphviz: 
https://gitlab.com/graphviz/graphviz/-/commit/6f536261 
https://gitlab.com/graphviz/graphviz/-/commit/24afd12d 
https://gitlab.com/graphviz/graphviz/-/commit/9ad95167 

- Fixed various implicit function and implicit int warnings (cf. https://github.com/ksh93/ksh/issues/587).

- Fixed a compiler error under `-std=gnu2x` by renaming a pointer called 'nullptr' to 'null_pointer'.

- Fixed a deprecated function warning on Linux by removing the unused `mallinfo` function.

- Reference the regex manpage as regex(3), not regcomp(3). Change pulled out of https://github.com/illumos/illumos-gate/commit/bbf21555 (with changes).