### PR TITLE
sh/expand.c: Don't kill the scantree loop when a candidate is undefined.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,12 @@ This documents significant changes in the dev branch of ksh 93u+m.
 For full details, see the git log at: https://github.com/ksh93/ksh
 Uppercase BUG_* IDs are shell bug IDs as used by the Modernish shell library.
 
+2023-06-05:
+
+- Fixed a bug in command completion: when a shell built-in or defined function
+  was preceded in alphabetical order by an undefined function (on FPATH or
+  after 'autoload'), the built-in or defined function failed to tab-complete.
+
 2023-06-04:
 
 - Fixed a bug in 'case', introduced in ksh 93t 2008-10-31, where extended

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -18,7 +18,7 @@
 
 #define SH_RELEASE_FORK	"93u+m"		/* only change if you develop a new ksh93 fork */
 #define SH_RELEASE_SVER	"1.1.0-alpha"	/* semantic version number: https://semver.org */
-#define SH_RELEASE_DATE	"2023-06-04"	/* must be in this format for $((.sh.version)) */
+#define SH_RELEASE_DATE	"2023-06-05"	/* must be in this format for $((.sh.version)) */
 #define SH_RELEASE_CPYR	"(c) 2020-2023 Contributors to ksh " SH_RELEASE_FORK
 
 /* Scripts sometimes field-split ${.sh.version}, so don't change amount of whitespace. */

--- a/src/cmd/ksh93/sh/expand.c
+++ b/src/cmd/ksh93/sh/expand.c
@@ -142,8 +142,7 @@ static int scantree(Dt_t *tree, const char *pattern, struct argnod **arghead)
 	struct argnod *ap;
 	int nmatch=0;
 	char *cp;
-	np = (Namval_t*)dtfirst(tree);
-	for(;np;(np = (Namval_t*)dtnext(tree,np)))
+	for(np=(Namval_t*)dtfirst(tree); np; np=(Namval_t*)dtnext(tree,np))
 	{
 		if(nv_isnull(np))
 			continue;

--- a/src/cmd/ksh93/sh/expand.c
+++ b/src/cmd/ksh93/sh/expand.c
@@ -143,8 +143,10 @@ static int scantree(Dt_t *tree, const char *pattern, struct argnod **arghead)
 	int nmatch=0;
 	char *cp;
 	np = (Namval_t*)dtfirst(tree);
-	for(;np && !nv_isnull(np);(np = (Namval_t*)dtnext(tree,np)))
+	for(;np;(np = (Namval_t*)dtnext(tree,np)))
 	{
+		if(nv_isnull(np))
+			continue;
 		if(strmatch(cp=nv_name(np),pattern))
 		{
 			(void)stkseek(sh.stk,ARGVAL);

--- a/src/cmd/ksh93/tests/pty.sh
+++ b/src/cmd/ksh93/tests/pty.sh
@@ -1249,5 +1249,21 @@ w cmd_complet\t
 r cmd_complete_me \r\n$
 !
 
+((SHOPT_VSH || SHOPT_ESH)) &&
+mkdir functest && FPATH=./functest && tst $LINENO <<"!"
+L function and builtin completion when a function is undefined
+# https://github.com/ksh93/ksh/issues/650
+
+p :test-1:
+w echo "function zzzzzzz { echo zzzzzzz; }" > functest/zzzzzzz
+p :test-2:
+w zzzzzzz
+p :test-3:
+w autoload aaaaaaa
+p :test-4:
+w zzz\t
+r ^:test-4: zzzzzzz \r\n$
+!
+
 # ======
 exit $((Errors<125?Errors:125))

--- a/src/cmd/ksh93/tests/pty.sh
+++ b/src/cmd/ksh93/tests/pty.sh
@@ -1257,7 +1257,7 @@ L function and builtin completion when a function is undefined
 
 d 40
 p :test-1:
-w _ksh_93u_m_cmdcomplete_test_; autoload _some_nonexistent_function_
+w _ksh_93u_m_cmdcomplete_test_; autoload _a_nonexistent_function_
 u ^RUN\r\n$
 p :test-2:
 w _ksh_93u_m_cmdcompl\t

--- a/src/cmd/ksh93/tests/pty.sh
+++ b/src/cmd/ksh93/tests/pty.sh
@@ -1250,19 +1250,18 @@ r cmd_complete_me \r\n$
 !
 
 ((SHOPT_VSH || SHOPT_ESH)) &&
-mkdir functest && FPATH=./functest && tst $LINENO <<"!"
+echo "function _ksh_93u_m_cmdcomplete_test_ { echo RUN; }" > _ksh_93u_m_cmdcomplete_test_ &&
+FPATH=$PWD tst $LINENO <<"!"
 L function and builtin completion when a function is undefined
 # https://github.com/ksh93/ksh/issues/650
 
+d 40
 p :test-1:
-w echo "function zzzzzzz { echo zzzzzzz; }" > functest/zzzzzzz
+w _ksh_93u_m_cmdcomplete_test_; autoload _some_nonexistent_function_
+u ^RUN\r\n$
 p :test-2:
-w zzzzzzz
-p :test-3:
-w autoload aaaaaaa
-p :test-4:
-w zzz\t
-r ^:test-4: zzzzzzz \r\n$
+w _ksh_93u_m_cmdcompl\t
+r :test-2: _ksh_93u_m_cmdcomplete_test_ \r\n$
 !
 
 # ======


### PR DESCRIPTION
In both line editors, when a shell builtin or defined function is preceded by an undefined function in alphabetical order, it will fail to tab complete. This happens because `scantree` in `expand.c` terminates upon encountering a null match candidate rather than continuing.

The bug predates `ksh93 u+m`.

`expand.c`: `scantree` ignores null matching candidates rather than terminating.