### PR TITLE
Fix compiling with strict C99 and C11

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,10 @@ This documents significant changes in the dev branch of ksh 93u+m.
 For full details, see the git log at: https://github.com/ksh93/ksh
 Uppercase BUG_* IDs are shell bug IDs as used by the Modernish shell library.
 
+2023-06-10:
+
+- Ksh can now compile on most operating systems when using -std=c99 in CCFLAGS.
+
 2023-06-09:
 
 - Fixed a bug where the 'break' and 'continue' commands stopped working after

--- a/bin/package
+++ b/bin/package
@@ -918,7 +918,7 @@ hostinfo() # attribute ...
 			cat > $tmp.c <<!
 #include <stdio.h>
 #include <pthread.h>
-int main()
+int main(void)
 {
 	printf("%d\n", pthread_num_processors_np());
 	return 0;
@@ -1484,11 +1484,11 @@ int main()
 				tmp=hi$$
 				trap 'set +o noglob; rm -rf $tmp.*' 0 1 2
 				cat > $tmp.a.c <<!
-extern int b();
-int main() { return b(); }
+extern int b(void);
+int main(void) { return b(); }
 !
 				cat > $tmp.b.c <<!
-int b() { return 0; }
+int b(void) { return 0; }
 !
 				abi=
 				if	$cc -c $tmp.a.c
@@ -1539,7 +1539,7 @@ int b() { return 0; }
 					cd "$TMPDIR"
 					tmp=hi$$
 					trap 'set +o noglob; exec rm -rf "$tmp".*' 0 1 2
-					echo 'int main() { return 0; }' > $tmp.a.c
+					echo 'int main(void) { return 0; }' > $tmp.a.c
 					checkcc
 					$cc $CCFLAGS -o $tmp.a.exe $tmp.a.c </dev/null >/dev/null 2>&1
 					file $tmp.a.exe 2>/dev/null | sed "s/$tmp\.a\.exe//g"  )
@@ -2749,7 +2749,7 @@ make|view)
 					;;
 				$s*)	$exec cd $INSTALLROOT/lib/package/gen
 					tmp=pkg$$
-					$exec eval "echo 'int main(){return 0;}' > $tmp.c"
+					$exec eval "echo 'int main(void){return 0;}' > $tmp.c"
 					if	$exec $s -o $tmp.exe $tmp.c >/dev/null 2>&1 &&
 						test -x $tmp.exe
 					then	case $HOSTTYPE in
@@ -2823,7 +2823,7 @@ make|view)
 	case $exec in
 	'')	cd $INSTALLROOT/lib/package/gen
 		tmp=pkg$$
-		echo 'int main(){return 0;}' > $tmp.c
+		echo 'int main(void){return 0;}' > $tmp.c
 		if	$CC -o $tmp.exe $tmp.c > /dev/null 2> $tmp.err &&
 			test -x $tmp.exe
 		then	: ok

--- a/src/cmd/INIT/C+probe
+++ b/src/cmd/INIT/C+probe
@@ -162,7 +162,7 @@ done
 mkdir suffix
 cd suffix
 for src in $probe_src
-do	echo "int main(){return 0;}" > ../test.$src
+do	echo "int main(void){return 0;}" > ../test.$src
 	rm -f test*
 	if	$cc -c ../test.$src
 	then	set test.*
@@ -195,7 +195,7 @@ case $src in
 c)	;;
 *)	echo '// (
 int
-main()
+main(void)
 {
 	class { public: int i; } j;
 	j.i = 0;
@@ -262,8 +262,8 @@ case $hosttype in
 esac
 
 echo '#include <stdio.h>
-int main(){printf("hello");return 0;}' > dynamic.$src
-echo 'extern int sfclose() { return 0; }' > fun.$src
+int main(void){printf("hello");return 0;}' > dynamic.$src
+echo 'extern int sfclose(void) { return 0; }' > fun.$src
 if	$cc -c dynamic.$src && $cc -c fun.$src
 then	eval set x $probe_so
 	while	:
@@ -397,7 +397,7 @@ done
 case $version_stamp in
 '')	eval set x $probe_version
 	shift
-	echo 'int main() { return 0; }' > version.i
+	echo 'int main(void) { return 0; }' > version.i
 	for o in "$@"
 	do	if	$cc -c $o version.i > version.out 2>&1
 		then	version_string=`sed -e '/ is /d' -e 's/;/ /g' version.out | sed -e 1q`
@@ -413,7 +413,7 @@ case $version_stamp in
 	;;
 esac
 
-echo 'int main(){return 0;}' > hosted.$src
+echo 'int main(void){return 0;}' > hosted.$src
 $cc -o hosted.$exe hosted.$src && ./hosted.$exe && hosted=1
 
 echo '#!'$sh'

--- a/src/cmd/INIT/db.c
+++ b/src/cmd/INIT/db.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1994-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2023 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -12,6 +12,7 @@
 *                                                                      *
 *                 Glenn Fowler <gsf@research.att.com>                  *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 /*
@@ -25,7 +26,7 @@
 #endif
 
 int
-main()
+main(void)
 {
 	DBM*	dbm = 0;
 

--- a/src/cmd/INIT/dl.c
+++ b/src/cmd/INIT/dl.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1994-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2023 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -12,6 +12,7 @@
 *                                                                      *
 *                 Glenn Fowler <gsf@research.att.com>                  *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 /*
@@ -23,7 +24,7 @@
 #endif
 
 int
-main()
+main(void)
 {
 	dlopen("libdl.so",0);
 	return 0;

--- a/src/cmd/INIT/gdbm.c
+++ b/src/cmd/INIT/gdbm.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1994-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2023 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -12,6 +12,7 @@
 *                                                                      *
 *                 Glenn Fowler <gsf@research.att.com>                  *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 /*
@@ -25,7 +26,7 @@
 #endif
 
 int
-main()
+main(void)
 {
 	DBM*	dbm = 0;
 

--- a/src/cmd/INIT/gdbm1.c
+++ b/src/cmd/INIT/gdbm1.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1994-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2023 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -12,6 +12,7 @@
 *                                                                      *
 *                 Glenn Fowler <gsf@research.att.com>                  *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 /*
@@ -25,7 +26,7 @@
 #endif
 
 int
-main()
+main(void)
 {
 	DBM*	dbm = 0;
 

--- a/src/cmd/INIT/gdbm2.c
+++ b/src/cmd/INIT/gdbm2.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1994-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2023 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -12,6 +12,7 @@
 *                                                                      *
 *                 Glenn Fowler <gsf@research.att.com>                  *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 /*
@@ -25,7 +26,7 @@
 #endif
 
 int
-main()
+main(void)
 {
 	DBM*	dbm = 0;
 

--- a/src/cmd/INIT/hello.c
+++ b/src/cmd/INIT/hello.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1994-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2023 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -12,9 +12,10 @@
 *                                                                      *
 *                 Glenn Fowler <gsf@research.att.com>                  *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 #ifndef printf
 #include <stdio.h>
 #endif
-int main() { int new = 0; printf("hello world\n"); return new;}
+int main(void) { int new = 0; printf("hello world\n"); return new;}

--- a/src/cmd/INIT/iconv.c
+++ b/src/cmd/INIT/iconv.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1994-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2023 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -12,6 +12,7 @@
 *                                                                      *
 *                 Glenn Fowler <gsf@research.att.com>                  *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 #ifndef iconv
@@ -19,7 +20,7 @@
 #endif
 
 int
-main()
+main(void)
 {
 	iconv(0, 0, 0, 0, 0);
 	return 0;

--- a/src/cmd/INIT/iffe.sh
+++ b/src/cmd/INIT/iffe.sh
@@ -2541,7 +2541,7 @@ int x;
 			lib=
 			p=
 			hit=0
-			echo "int main(){return(0);}" > $tmp.c
+			echo "int main(void){return(0);}" > $tmp.c
 			for x in $z
 			do	p=$x
 				case " $gotlib " in
@@ -3221,7 +3221,7 @@ $src
 							'')	#UNDENT...
 
 			reallystatictest=.
-			echo "$tst$nl$ext${nl}int main(){printf("hello");return(0);}" > ${tmp}s.c
+			echo "$tst$nl$ext${nl}int main(void){printf("hello");return(0);}" > ${tmp}s.c
 			rm -f ${tmp}s.exe
 			if	compile $cc -c ${tmp}s.c <&$nullin >&$nullout &&
 				compile $cc -o ${tmp}s.exe ${tmp}s.o <&$nullin >&$nullout 2>${tmp}s.e &&
@@ -3346,7 +3346,7 @@ $tst
 $ext
 $usr
 extern int $statictest;
-int main(){char* i = (char*)&$statictest; return ((unsigned int)i)^0xaaaa;}
+int main(void){char* i = (char*)&$statictest; return ((unsigned int)i)^0xaaaa;}
 "
 						rm -f $tmp.exe
 						if	compile $cc -o $tmp.exe $tmp.c <&$nullin >&$nullout && $executable $tmp.exe
@@ -3355,7 +3355,7 @@ int main(){char* i = (char*)&$statictest; return ((unsigned int)i)^0xaaaa;}
 								copy $tmp.c "$std
 $tst
 $ext
-int main(){printf("hello");return(0);}
+int main(void){printf("hello");return(0);}
 "
 								rm -f $tmp.exe
 								if	compile $cc -c $tmp.c <&$nullin >&$nullout &&
@@ -3462,7 +3462,7 @@ $pre
 #else
 #define _REF_	&
 #endif
-int main(){char* i = (char*) _REF_ $v; return ((unsigned int)i)^0xaaaa;}"
+int main(void){char* i = (char*) _REF_ $v; return ((unsigned int)i)^0xaaaa;}"
 					} > $tmp.c
 					is $o $v
 					rm -f $tmp.exe
@@ -3744,7 +3744,7 @@ $inc
 $pre
 $tst
 $ext
-int f(){int $w = 1;return($w);}" > $tmp.c
+int f(void){int $w = 1;return($w);}" > $tmp.c
 						if	compile $cc -c $tmp.c <&$nullin >&$nullout
 						then	failure
 							case $set in
@@ -3826,9 +3826,9 @@ $v i;
 #else
 typedef int (*_IFFE_fun)();
 #ifdef _IFFE_extern
-extern int $v();
+extern int $v(void);
 #endif
-static _IFFE_fun i=(_IFFE_fun)$v;int main(){return ((unsigned int)i)^0xaaaa;}
+static _IFFE_fun i=(_IFFE_fun)$v;int main(void){return ((unsigned int)i)^0xaaaa;}
 #endif
 "
 					d=-D_IFFE_extern
@@ -3866,8 +3866,8 @@ $ext
 $usr
 $pre
 $inc
-extern int foo();
-static int ((*i)())=foo;int main(){return(i==0);}
+extern int foo(void);
+static int ((*i)())=foo;int main(void){return(i==0);}
 "
 								compile $cc -c $tmp.c <&$nullin >&$nullout
 								intrinsic=$?
@@ -3974,7 +3974,7 @@ $tst
 $ext
 $inc
 static $p i;
-unsigned long f() { return (unsigned long)i; }" > $tmp.c
+unsigned long f(void) { return (unsigned long)i; }" > $tmp.c
 							if	compile $cc -c $tmp.c <&$nullin >&$nullout
 							then	c=1
 							else	c=0
@@ -4182,7 +4182,7 @@ $tst
 $ext
 $inc
 static $x$v i;
-$x$v f() {
+$x$v f(void) {
 $x$v v; i = 1; v = i;"
 						echo "i = v * i; i = i / v; v = v + i; i = i - v;"
 						case $v in
@@ -4196,17 +4196,17 @@ $pre
 $inc
 struct xxx { $x$v mem; };
 static struct xxx v;
-struct xxx* f() { return &v; }"
+struct xxx* f(void) { return &v; }"
 						;;
 					esac
 					case $x in
 					""|"struct "|"union ")
-						echo "int g() { return 0; }"
+						echo "int g(void) { return 0; }"
 						;;
-					*)	echo "int g() { return sizeof($x$v)<=sizeof($v); }" ;;
+					*)	echo "int g(void) { return sizeof($x$v)<=sizeof($v); }" ;;
 					esac
 					copy - "
-int main() {
+int main(void) {
 		f();
 		g();
 		printf(\"%u\\n\", sizeof($x$v));
@@ -4277,7 +4277,7 @@ $tst
 $ext
 $inc
 static $x$v i;
-$x$v f() {
+$x$v f(void) {
 $x$v v; i = 1; v = i;"
 						echo "i = v * i; i = i / v; v = v + i; i = i - v;"
 						case $v in
@@ -4293,13 +4293,13 @@ $ext
 $inc
 struct xxx { $x$v mem; };
 static struct xxx v;
-struct xxx* f() { return &v; }"
+struct xxx* f(void) { return &v; }"
 						;;
 					esac
 					case $x in
 					""|"struct "|"union ")
-						echo "int main() { f(); return 0; }" ;;
-					*)	echo "int main() { f(); return sizeof($x$v)<=sizeof($v); }" ;;
+						echo "int main(void) { f(); return 0; }" ;;
+					*)	echo "int main(void) { f(); return sizeof($x$v)<=sizeof($v); }" ;;
 					esac
 					} > $tmp.c
 					rm -f $tmp.exe

--- a/src/cmd/INIT/iffe.tst
+++ b/src/cmd/INIT/iffe.tst
@@ -896,7 +896,7 @@ TEST 06 'block side effects'
 		INPUT t.iffe $'iff -
 tst	output{
 	int
-	main()
+	main(void)
 	{
 		printf("HIT\\n");
 		return 0;
@@ -912,7 +912,7 @@ HIT'
 		INPUT t.iffe $'iff
 tst	- output{
 	int
-	main()
+	main(void)
 	{
 		printf("HIT\\n");
 		return 0;
@@ -925,7 +925,7 @@ tst	- output{
 		INPUT t.iffe $'iff
 tst	- output{
 	int
-	main()
+	main(void)
 	{
 		printf("HIT\\n");
 		return 1;
@@ -940,7 +940,7 @@ tst	- output{
 		INPUT t.iffe $'iff
 tst	- nooutput{
 	int
-	main()
+	main(void)
 	{
 		printf("HIT\\n");
 		return 1;

--- a/src/cmd/INIT/intl.c
+++ b/src/cmd/INIT/intl.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1994-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2023 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -12,6 +12,7 @@
 *                                                                      *
 *                 Glenn Fowler <gsf@research.att.com>                  *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 #ifndef gettext
@@ -19,7 +20,7 @@
 #endif
 
 int
-main()
+main(void)
 {
 	gettext(0);
 	return 0;

--- a/src/cmd/INIT/m.c
+++ b/src/cmd/INIT/m.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1994-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2023 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -12,6 +12,7 @@
 *                                                                      *
 *                 Glenn Fowler <gsf@research.att.com>                  *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 /*
@@ -23,7 +24,7 @@
 #endif
 
 int
-main()
+main(void)
 {
 	sin(0.0);
 	fmod(100.234, 11.0);

--- a/src/cmd/INIT/m2.c
+++ b/src/cmd/INIT/m2.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1994-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2023 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -12,6 +12,7 @@
 *                                                                      *
 *                 Glenn Fowler <gsf@research.att.com>                  *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 /*
@@ -21,7 +22,7 @@
 #include <math.h>
 
 int
-main()
+main(void)
 {
 	double	value = 0;
 	int	exp = 0;

--- a/src/cmd/INIT/m3.c
+++ b/src/cmd/INIT/m3.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1994-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2023 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -12,6 +12,7 @@
 *                                                                      *
 *                 Glenn Fowler <gsf@research.att.com>                  *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 /*
@@ -21,7 +22,7 @@
 #include <math.h>
 
 int
-main()
+main(void)
 {
 	long double	value = 0;
 	int		exp = 0;

--- a/src/cmd/INIT/m4.c
+++ b/src/cmd/INIT/m4.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1994-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2023 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -12,6 +12,7 @@
 *                                                                      *
 *                 Glenn Fowler <gsf@research.att.com>                  *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 /*
@@ -21,7 +22,7 @@
 #include <math.h>
 
 int
-main()
+main(void)
 {
 	double	value = 0;
 

--- a/src/cmd/INIT/m5.c
+++ b/src/cmd/INIT/m5.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1994-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2023 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -12,6 +12,7 @@
 *                                                                      *
 *                 Glenn Fowler <gsf@research.att.com>                  *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 /*
@@ -21,7 +22,7 @@
 #include <math.h>
 
 int
-main()
+main(void)
 {
 	long double	value = 0;
 

--- a/src/cmd/INIT/m6.c
+++ b/src/cmd/INIT/m6.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1994-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2023 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -12,6 +12,7 @@
 *                                                                      *
 *                 Glenn Fowler <gsf@research.att.com>                  *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 /*
@@ -23,7 +24,7 @@
 #include <math.h>
 
 int
-main()
+main(void)
 {
 	double	value = -0.0;
 

--- a/src/cmd/INIT/make.probe
+++ b/src/cmd/INIT/make.probe
@@ -55,28 +55,28 @@ probe_warn="-Wall -fullwarn -w3 '-A -A' +w1"
 
 echo '#pragma pp:version' > libpp.$src
 echo '#define dDflag on' > dDflag.$src
-echo 'int main(){return 0;}' > doti.$src
-echo 'int code(){return 0;} int main(){return code();}' > export.$src
+echo 'int main(void){return 0;}' > doti.$src
+echo 'int code(void){return 0;} int main(void){return code();}' > export.$src
 echo '#include <stdio.h>' > imstd.$src
 echo '#include "_i_.h"' > imusr.$src
 echo 'int x;' > _i_.h
 mkdir im
 echo '(' > im/stdio.h
 echo '#include "implc_x.h"
-int main(){f(1);return 0;}' > implc.$src
+int main(void){f(1);return 0;}' > implc.$src
 echo 'template <class T> void f(T){}' > implc_x.$src
 echo 'template <class T> void f(T);' > implc_x.h
-echo 'extern int NotalL() { return 0; }' > notall.$src
+echo 'extern int NotalL(void) { return 0; }' > notall.$src
 echo '#include <stdio.h>
 extern int i;
 int i = 1;
-extern int f() { return !i; }
-int main() { FILE* fp=stdin; return f(); }' > pic.$src
-echo 'int prefix(){return 0;}' > prefix.$src
+extern int f(void) { return !i; }
+int main(void) { FILE* fp=stdin; return f(); }' > pic.$src
+echo 'int prefix(void){return 0;}' > prefix.$src
 echo 'template<class T> int gt(T a, T b);
 template<class T> int gt(T a, T b) { return a > b; }
-int main () { return gt(2,1); }' > ptr.$src
-echo 'int main(){return 0;}' > require.$src
+int main (void) { return gt(2,1); }' > ptr.$src
+echo 'int main(void){return 0;}' > require.$src
 echo '#if mips && !sgi || __CYGWIN__ || __HAIKU__ || __APPLE__
 ( /* some systems choke on this probe */
 #else
@@ -86,28 +86,28 @@ echo '#if mips && !sgi || __CYGWIN__ || __HAIKU__ || __APPLE__
 #define CONST
 #endif
 CONST char x[]={1,2,3,4,5,6,7,8,9,0};
-int main(){*(char*)x=0; return x[0];}
+int main(void){*(char*)x=0; return x[0];}
 #endif' > readonly.$src
-echo 'extern int sfclose(); extern int ShareD() { return sfclose(); }' > shared.$src
+echo 'extern int sfclose(void); extern int ShareD(void) { return sfclose(); }' > shared.$src
 echo '#define g(a,b) a ## b
 volatile int a;
 const int g(x,y)=1;
 extern int c(int);' > stdc.$src
-echo 'extern int f(); int main() { return f(); }' > sovmain.$src
-echo 'int f() { return 0; }' > sovlib.$src
+echo 'extern int f(void); int main(void) { return f(); }' > sovmain.$src
+echo 'int f(void) { return 0; }' > sovlib.$src
 echo '#include <stdio.h>
 int i;
-int main(){int j;j = i * 10;return j;}' > strip.$src
+int main(void){int j;j = i * 10;return j;}' > strip.$src
 echo 'template <class T> void f(T){}
-int main(){f(1);return 0;}' > toucho.$src
+int main(void){f(1);return 0;}' > toucho.$src
 echo 'extern type call(int);
-int main() { call(0); return 0; }' > tstlib.$src
-echo 'int main(){return 0;}' > warn.$src
-echo 'int f(){return 0;}' > warn1.$src
-echo 'int f(){}' > warn2.$src
-echo 'int f(){int i; return 0;}' > warn3.$src
-echo 'int f(){int i; return i;}' > warn4.$src
-echo 'int f(){return g();}' > warn5.$src
+int main(void) { call(0); return 0; }' > tstlib.$src
+echo 'int main(void){return 0;}' > warn.$src
+echo 'int f(void){return 0;}' > warn1.$src
+echo 'int f(void){}' > warn2.$src
+echo 'int f(void){int i; return 0;}' > warn3.$src
+echo 'int f(void){int i; return i;}' > warn4.$src
+echo 'int f(void){return g();}' > warn5.$src
 warn_enum="1 2 3 4 5"
 
 chmod -w *.$src
@@ -371,8 +371,8 @@ then	e=`wc -l e`
 	case $hosted:$cc_pic in
 	1:?*)   if	./pic.$exe
 		then	# this catches lynxos.ppc gcc that dumps -fpic and not -mshared
-			echo 'static int* f() { static int v; return &v; }
-int main() { f(); return 0; }' > picok.$src
+			echo 'static int* f(void) { static int v; return &v; }
+int main(void) { f(); return 0; }' > picok.$src
 			$cc $cc_pic -o picok.$exe picok.$src && ./picok.$exe || cc_pic=
 		else	cc_pic=
 		fi
@@ -565,7 +565,7 @@ case $cc_dll:$cc_pic:$so:$dynamic:$static in
 	: last chance dynamic checks
 	while	:
 	do
-		echo '__declspec(dllexport) int fun() { return 0; }' > exp.$src
+		echo '__declspec(dllexport) int fun(void) { return 0; }' > exp.$src
 		if	$cc -c $cc_dll_def exp.$src
 		then	rm -f xxx.dll xxx.lib
 			if	$cc -shared -Wl,--enable-auto-image-base -Wl,--out-implib=xxx.lib -o xxx.dll exp.$obj &&
@@ -944,10 +944,10 @@ case $shared in
 	esac
 	;;
 *)	case $lib_dll in
-	symbol)	echo 'extern int f();
-	int main() { f(); return 0; }' > main.$src
+	symbol)	echo 'extern int f(void);
+	int main(void) { f(); return 0; }' > main.$src
 		echo '#include <stdio.h>
-	int f() { printf("hello world"); return 0; }' > member.$src
+	int f(void) { printf("hello world"); return 0; }' > member.$src
 		if	$cc -c main.$src && $cc -c member.$src
 		then	echo f > lib.exp
 			rm -f lib.$obj main.exe
@@ -1017,14 +1017,14 @@ option)	case $hosttype in
 SYMBOL)	lib_dll=symbol
 	;;
 symbol)	echo "#include <stdio.h>
-extern int fun()
+extern int fun(void)
 {
 	puts(\"fun\");
 	return 0;
 }" > dllib.$src
-	echo "extern int fun();
+	echo "extern int fun(void);
 int
-main()
+main(void)
 {
 	return fun();
 }" > dlmain.$src

--- a/src/cmd/INIT/mamake.c
+++ b/src/cmd/INIT/mamake.c
@@ -102,7 +102,7 @@ static const char usage[] =
  */
 
 /* macOS */
-#if (defined(__APPLE__) || defined(__MACH__) || defined(NeXTBSD)) && !defined(_DARWIN_C_SOURCE)
+#if (defined(__APPLE__) && defined(__MACH__) && defined(NeXTBSD)) && !defined(_DARWIN_C_SOURCE)
 #define _DARWIN_C_SOURCE 1
 
 /* Solaris and illumos */
@@ -126,8 +126,8 @@ static const char usage[] =
 #define NULL    0
 #endif /* __SUNPRO_C */
 
-/* Linux */
-#elif defined(__linux__) && !defined(_GNU_SOURCE)
+/* Linux and Cygwin */
+#elif (defined(__linux__) || __CYGWIN__) && !defined(_GNU_SOURCE)
 #define _GNU_SOURCE 1
 
 /* QNX */

--- a/src/cmd/INIT/mamake.c
+++ b/src/cmd/INIT/mamake.c
@@ -93,7 +93,53 @@ static const char usage[] =
 #define elementsof(x)	(sizeof(x)/sizeof(x[0]))
 #define newof(p,t,n,x)	((p)?(t*)realloc((char*)(p),sizeof(t)*(n)+(x)):(t*)calloc(1,sizeof(t)*(n)+(x)))
 
+/*
+ * For compatibility with compiler flags such as -std=c99, feature macros
+ * must be enabled to prevent the build from failing at the very start.
+ * These are normally handled in src/lib/libast/features/standards; further
+ * information can be found there. Mamake shouldn't need all that much enabled,
+ * so not much is enabled here.
+ */
+
+/* macOS */
+#if (defined(__APPLE__) || defined(__MACH__) || defined(NeXTBSD)) && !defined(_DARWIN_C_SOURCE)
+#define _DARWIN_C_SOURCE 1
+
+/* Solaris and illumos */
+#elif defined(__sun)
+#define _XPG7
+#define _XPG6
+#define _XPG5
+#define _XPG4_2
+#define _XPG4
+#define _XPG3
+#define __EXTENSIONS__	1
+#define _XOPEN_SOURCE	9900
+#undef _POSIX_C_SOURCE
+/*
+ * Though POSIX says it must be allowed, Solaris Studio cc dislikes NULL, a.k.a.
+ * (void*)0, being used for function pointers. It warns, or in some cases it even
+ * throws an error. Just use 0 for NULL, as that is always acceptable in C.
+ */
+#if __SUNPRO_C
+#undef  NULL
+#define NULL    0
+#endif /* __SUNPRO_C */
+
+/* Linux */
+#elif defined(__linux__) && !defined(_GNU_SOURCE)
+#define _GNU_SOURCE 1
+
+/* QNX */
+#elif defined(__QNX__) && !defined(_QNX_SOURCE)
+#define _QNX_SOURCE 1
+
+/* Everything else (minus BSD, as the defaults there are acceptable) */
+#elif !(BSD && !__APPLE__ && !__MACH__ && !NeXTBSD) && !defined(_POSIX_C_SOURCE)
+#define _POSIX_C_SOURCE 21000101L
 #endif
+
+#endif /* _PACKAGE_ast */
 
 #include <stdio.h>
 #include <unistd.h>
@@ -259,7 +305,7 @@ extern char**		environ;
  */
 
 static void
-usage()
+usage(void)
 {
 	fprintf(stderr, "Usage: %s"
 		" [-iknFKNV]"
@@ -1595,7 +1641,7 @@ require(char* lib, int dontcare)
 		{
 			append(tmp, "set +v +x\n");
 			append(tmp, "cd \"${TMPDIR:-/tmp}\"\n");
-			append(tmp, "echo 'int main(){return 0;}' > x.${!-$$}.c\n");
+			append(tmp, "echo 'int main(void){return 0;}' > x.${!-$$}.c\n");
 			append(tmp, "${CC} ${CCFLAGS} -o x.${!-$$}.x x.${!-$$}.c ");
 			append(tmp, r);
 			append(tmp, " >/dev/null 2>&1\n");

--- a/src/cmd/INIT/nsl.c
+++ b/src/cmd/INIT/nsl.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1994-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2023 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -12,17 +12,17 @@
 *                                                                      *
 *                 Glenn Fowler <gsf@research.att.com>                  *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 /*
  * small test for -lnsl
  */
 
-
-extern void*	gethostbyname();
+#include <netdb.h>
 
 int
-main()
+main(void)
 {
 	return gethostbyname(0) == 0;
 }

--- a/src/cmd/INIT/package.sh
+++ b/src/cmd/INIT/package.sh
@@ -918,7 +918,7 @@ hostinfo() # attribute ...
 			cat > $tmp.c <<!
 #include <stdio.h>
 #include <pthread.h>
-int main()
+int main(void)
 {
 	printf("%d\n", pthread_num_processors_np());
 	return 0;
@@ -1484,11 +1484,11 @@ int main()
 				tmp=hi$$
 				trap 'set +o noglob; rm -rf $tmp.*' 0 1 2
 				cat > $tmp.a.c <<!
-extern int b();
-int main() { return b(); }
+extern int b(void);
+int main(void) { return b(); }
 !
 				cat > $tmp.b.c <<!
-int b() { return 0; }
+int b(void) { return 0; }
 !
 				abi=
 				if	$cc -c $tmp.a.c
@@ -1539,7 +1539,7 @@ int b() { return 0; }
 					cd "$TMPDIR"
 					tmp=hi$$
 					trap 'set +o noglob; exec rm -rf "$tmp".*' 0 1 2
-					echo 'int main() { return 0; }' > $tmp.a.c
+					echo 'int main(void) { return 0; }' > $tmp.a.c
 					checkcc
 					$cc $CCFLAGS -o $tmp.a.exe $tmp.a.c </dev/null >/dev/null 2>&1
 					file $tmp.a.exe 2>/dev/null | sed "s/$tmp\.a\.exe//g"  )
@@ -2749,7 +2749,7 @@ make|view)
 					;;
 				$s*)	$exec cd $INSTALLROOT/lib/package/gen
 					tmp=pkg$$
-					$exec eval "echo 'int main(){return 0;}' > $tmp.c"
+					$exec eval "echo 'int main(void){return 0;}' > $tmp.c"
 					if	$exec $s -o $tmp.exe $tmp.c >/dev/null 2>&1 &&
 						test -x $tmp.exe
 					then	case $HOSTTYPE in
@@ -2823,7 +2823,7 @@ make|view)
 	case $exec in
 	'')	cd $INSTALLROOT/lib/package/gen
 		tmp=pkg$$
-		echo 'int main(){return 0;}' > $tmp.c
+		echo 'int main(void){return 0;}' > $tmp.c
 		if	$CC -o $tmp.exe $tmp.c > /dev/null 2> $tmp.err &&
 			test -x $tmp.exe
 		then	: ok

--- a/src/cmd/INIT/socket.c
+++ b/src/cmd/INIT/socket.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1994-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2023 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -12,6 +12,7 @@
 *                                                                      *
 *                 Glenn Fowler <gsf@research.att.com>                  *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 /*
@@ -24,7 +25,7 @@
 #endif
 
 int
-main()
+main(void)
 {
 	return socket(0, 0, 0) < 0;
 }

--- a/src/cmd/INIT/w.c
+++ b/src/cmd/INIT/w.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1994-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2023 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -12,6 +12,7 @@
 *                                                                      *
 *                 Glenn Fowler <gsf@research.att.com>                  *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 #ifndef DONTCARE
@@ -20,7 +21,7 @@
 #endif
 
 int
-main()
+main(void)
 {
 	wchar_t	w = ' ';
 	return iswspace(w) == 0;

--- a/src/cmd/INIT/w2.c
+++ b/src/cmd/INIT/w2.c
@@ -19,7 +19,7 @@
 #include <wctype.h>
 
 int
-main()
+main(void)
 {
 	wchar_t	w = ' ';
 	return iswspace(w) == 0;

--- a/src/cmd/builtin/features/pty
+++ b/src/cmd/builtin/features/pty
@@ -21,7 +21,7 @@ tst - -lm - - output{
 	#include	<sys/types.h>
 	#include	<sys/stat.h>
 	#include	<sfio.h>
-	int main()
+	int main(void)
 	{
 		int		i;
 		struct stat	statb;

--- a/src/cmd/ksh93/README
+++ b/src/cmd/ksh93/README
@@ -254,8 +254,9 @@ failures (crashes, and/or important functionality does not work).
 
 *	AIX 7.1 on RISC (PowerPC)
 *	DragonFly BSD 5.8 on x86_64
+*	DragonFly BSD 6.4 on x86_64
 	FreeBSD 12.2 on x86_64
-	FreeBSD 13.0 on x86_64
+	FreeBSD 13.2 on x86_64
 	FreeBSD 12.2 on arm64 (thanks to hyenias for donating access to a Pi)
 	GNU/Linux: Alpine 3.12.3 (musl C library) on x86_64
 	GNU/Linux: CentOS 8.2 on x86_64
@@ -267,17 +268,18 @@ failures (crashes, and/or important functionality does not work).
 	GNU/Linux: Ubuntu 18.04 on armv7l (32-bit)
 	GNU/Linux: Ubuntu 20.04 on arm64
 	GNU/Linux: Void Linux (musl C library) on x86_64
-***	Haiku R1/beta3 on x86_64
+	GNU/Linux: Arch Linux on x86_64
+***	Haiku R1/beta4 on x86_64
 ***	HP-UX B.11.11 on pa-risc
 *	illumos: OmniOS 2020-08-19 (gcc) on x86_64
-	illumos: OmniOS r151040 (gcc) on x86_64
+	illumos: OmniOS r151046 (gcc) on x86_64
 	macOS 10.13.6 (High Sierra) on x86_64
 	macOS 10.14.6 (Mojave) on x86_64
 *	macOS 12.0.1 (Monterey) on arm64
 *	NetBSD 8.1 on x86_64
-*	NetBSD 9.2 on x86_64
+*	NetBSD 9.3 on x86_64
 *	OpenBSD 6.8 on x86_64
-	OpenBSD 7.0 on x86_64
+	OpenBSD 7.3 on x86_64
 *	QNX Neutrino 6.5.0 on i386
 *	Solaris 11.4 (gcc) on x86_64
 	Solaris 11.4 (Solaris Studio 12.5 cc) on x86_64

--- a/src/cmd/ksh93/features/locale
+++ b/src/cmd/ksh93/features/locale
@@ -9,7 +9,7 @@ tst	note{ do wctrans/towctrans work }end output{
 	#include <stdio.h>
 	#include <wchar.h>
 	#include <wctype.h>
-	int main()
+	int main(void)
 	{
 		wctrans_t toupper = wctrans("toupper"), tolower = wctrans("tolower");
 		int r = towctrans('q',toupper) == 'Q' && towctrans('Q',tolower) == 'q';

--- a/src/cmd/ksh93/features/math.sh
+++ b/src/cmd/ksh93/features/math.sh
@@ -44,11 +44,11 @@ eval `iffe $iffeflags -c "$cc" - typ long.double 2>&$stderr`
 
 : check ast_standards.h
 
-eval `iffe $iffeflags -F ast_standards.h -c "$cc" - tst use_ast_standards -lm 'note{' 'math.h needs ast_standards.h' '}end' 'link{' '#include <math.h>' '#ifndef isgreater' '#define isgreater(a,b) 0' '#endif' 'int main() { return isgreater(0.0,1.0); }' '}end'`
+eval `iffe $iffeflags -F ast_standards.h -c "$cc" - tst use_ast_standards -lm 'note{' 'math.h needs ast_standards.h' '}end' 'link{' '#include <math.h>' '#ifndef isgreater' '#define isgreater(a,b) 0' '#endif' 'int main(void) { return isgreater(0.0,1.0); }' '}end'`
 case $_use_ast_standards in
 1)	iffeflags="$iffeflags -F ast_standards.h" ;;
 esac
-eval `iffe $iffeflags -c "$cc" - tst use_ieeefp -lm 'note{' 'ieeefp.h plays nice' '}end' 'link{' '#include <math.h>' '#include <ieeefp.h>' 'int main() { return 0; }' '}end'`
+eval `iffe $iffeflags -c "$cc" - tst use_ieeefp -lm 'note{' 'ieeefp.h plays nice' '}end' 'link{' '#include <math.h>' '#include <ieeefp.h>' 'int main(void) { return 0; }' '}end'`
 case $_use_ieeefp in
 1)	iffehdrs="$iffehdrs ieeefp.h" ;;
 esac
@@ -251,7 +251,7 @@ do	eval x='$'_lib_${name}l y='$'_lib_${name} r='$'TYPE_${name} a='$'ARGS_${name}
 				sep=","
 			done
 			_it_links_=0
-			eval `iffe $iffeflags -c "$cc" - tst it_links_ note{ $F function links }end link{ "static $L $F($ta)$td${body}int main(){return $F($tc)!=0;}" }end sfio.h $iffehdrs $iffelibs 2>&$stderr`
+			eval `iffe $iffeflags -c "$cc" - tst it_links_ note{ $F function links }end link{ "static $L $F($ta)$td${body}int main(void){return $F($tc)!=0;}" }end sfio.h $iffehdrs $iffelibs 2>&$stderr`
 			case $_it_links_ in
 			1)	code="$code)$body"
 				echo "$code"

--- a/src/cmd/ksh93/features/poll
+++ b/src/cmd/ksh93/features/poll
@@ -17,12 +17,11 @@ tst	pipe_socketpair note{ use socketpair() for peekable pipe() }end execute{
 	#ifndef SHUT_WR
 	#define SHUT_WR		1
 	#endif
-	static void handler(sig)
-	int	sig;
+	static void handler(int sig)
 	{
 		_exit(0);
 	}
-	int main()
+	int main(void)
 	{
 		int		n;
 		int		pfd[2];
@@ -71,7 +70,7 @@ tst	socketpair_devfd note{ /dev/fd/N handles socketpair() }end execute{
 	#include <ast.h>
 	#include <sys/types.h>
 	#include <sys/socket.h>
-	int main()
+	int main(void)
 	{
 		int		devfd;
 		int		n;
@@ -98,7 +97,7 @@ tst	socketpair_shutdown_mode note{ fchmod() after socketpair() shutdown() }end e
 	#include <sys/types.h>
 	#include <sys/stat.h>
 	#include <sys/socket.h>
-	int main()
+	int main(void)
 	{
 		int		sfd[2];
 		struct stat	st0;

--- a/src/cmd/ksh93/features/sigfeatures
+++ b/src/cmd/ksh93/features/sigfeatures
@@ -34,7 +34,7 @@ cat{
 }end
 tst	output{
 	#include <signal.h>
-	int main()
+	int main(void)
 	{
 	#ifdef SIGRTMIN
 		printf("#undef	_SIGRTMIN\n");

--- a/src/cmd/ksh93/features/time
+++ b/src/cmd/ksh93/features/time
@@ -4,7 +4,7 @@ mem	timeval.tv_usec sys/time.h
 tst	lib_2_timeofday note{ 2 arg gettimeofday() }end link{
 	#include <sys/types.h>
 	#include <sys/time.h>
-	int main()
+	int main(void)
 	{
 		struct timeval tv;
 		struct timezone tz;
@@ -14,7 +14,7 @@ tst	lib_2_timeofday note{ 2 arg gettimeofday() }end link{
 tst	lib_1_timeofday note{ 1 arg gettimeofday() }end link{
 	#include <sys/types.h>
 	#include <sys/time.h>
-	int main()
+	int main(void)
 	{
 		struct timeval tv;
 		return gettimeofday(&tv);

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -18,7 +18,7 @@
 
 #define SH_RELEASE_FORK	"93u+m"		/* only change if you develop a new ksh93 fork */
 #define SH_RELEASE_SVER	"1.1.0-alpha"	/* semantic version number: https://semver.org */
-#define SH_RELEASE_DATE	"2023-06-09"	/* must be in this format for $((.sh.version)) */
+#define SH_RELEASE_DATE	"2023-06-10"	/* must be in this format for $((.sh.version)) */
 #define SH_RELEASE_CPYR	"(c) 2020-2023 Contributors to ksh " SH_RELEASE_FORK
 
 /* Scripts sometimes field-split ${.sh.version}, so don't change amount of whitespace. */

--- a/src/cmd/ksh93/mamexec
+++ b/src/cmd/ksh93/mamexec
@@ -153,7 +153,7 @@ do	IFS=$_ifs_
 			set -
 			mkdir /tmp/mam$$
 			cd /tmp/mam$$
-			echo 'main(){return 0;}' > main.c
+			echo 'main(void){return 0;}' > main.c
 			code=1
 			if	$CC -c main.c 2>/dev/null
 			then	if	$CC -L. main.o -lc 2>/dev/null

--- a/src/lib/libast/Mamfile
+++ b/src/lib/libast/Mamfile
@@ -1962,6 +1962,7 @@ make install
 					prev include/error.h
 					prev include/tm.h
 					prev tv.h
+					prev include/ast.h
 				done tm/tvsleep.c
 				exec - ${CC} ${mam_cc_FLAGS} ${CCFLAGS} -I. -Icomp -Iinclude -Istd -c tm/tvsleep.c
 			done tvsleep.o generated

--- a/src/lib/libast/comp/conf.sh
+++ b/src/lib/libast/comp/conf.sh
@@ -2,7 +2,7 @@
 #                                                                      #
 #               This software is part of the ast package               #
 #          Copyright (c) 1985-2011 AT&T Intellectual Property          #
-#          Copyright (c) 2020-2022 Contributors to ksh 93u+m           #
+#          Copyright (c) 2020-2023 Contributors to ksh 93u+m           #
 #                      and is licensed under the                       #
 #                 Eclipse Public License, Version 2.0                  #
 #                                                                      #
@@ -117,7 +117,7 @@ esac
 cat > $tmp.c <<!
 ${head}
 int
-main()
+main(void)
 {
 #if _ast_intmax_long
 	return 1;
@@ -136,7 +136,7 @@ fi
 cat > $tmp.c <<!
 ${head}
 int
-main()
+main(void)
 {
 #if _ast_intmax_long
 	return 1;
@@ -159,7 +159,7 @@ fi
 cat > $tmp.c <<!
 ${head}
 int
-main()
+main(void)
 {
 	unsigned int	u = 1U;
 	unsigned int	ul = 1UL;
@@ -1126,7 +1126,7 @@ ${head}
 #include <unistd.h>$systeminfo$headers
 ${tail}
 int
-main()
+main(void)
 {
 	printf("$f\n", ($t)$conf_name);
 	return 0;

--- a/src/lib/libast/comp/conf.tab
+++ b/src/lib/libast/comp/conf.tab
@@ -65,7 +65,7 @@ CHAR_MAX			C	XX 1 L
 CHAR_MIN			C	XX 1 L
 CHAR_TERM			POSIX	SC 2 FUW
 CHILD_MAX			POSIX	SC 1 CDLMUX	6	cc{
-	int main()
+	int main(void)
 	{
 		int	i;
 		int	n;
@@ -130,7 +130,7 @@ IP_SECOPTS			C	QQ 1 L
 JOB_CONTROL			POSIX	SC 1 FUW	cc{
 	#include "FEATURE/wait"
 	#if _ok_wif
-	int main()
+	int main(void)
 	{
 		printf("1");
 		return 0;
@@ -202,7 +202,7 @@ MSEM_LOCKID			C	QQ 1 L
 MULTI_PROCESS			POSIX	SC 1 FU
 NACLS_MAX			SVID	SC 1 0
 NAME_MAX			POSIX	PC 1 LMU	14	cc{
-	int main()
+	int main(void)
 	{
 	#ifdef MAXNAMLEN
 		printf("%d", MAXNAMLEN);
@@ -250,7 +250,7 @@ NAME_MAX			POSIX	PC 1 LMU	14	cc{
 }
 NGROUPS_MAX			POSIX	SC 1 CDLMU	8	cc{
 	#if _lib_getgroups
-	int main()
+	int main(void)
 	{
 		int	n;
 		gid_t	g;
@@ -286,13 +286,13 @@ NZERO				XOPEN	XX 1 L		20
 OPEN_MAX			POSIX	SC 1 CDLMUX	16	cc{
 	#if _lib_getdtablesize
 	extern int		getdtablesize(void);
-	int main()
+	int main(void)
 	{
 		printf("%d", getdtablesize());
 		return 0;
 	}
 	#else
-	int main()
+	int main(void)
 	{
 		int	i;
 		int	n;
@@ -318,7 +318,7 @@ OS_BASE				SVID	SI 1 O
 OS_PROVIDER			SVID	SI 1 O
 OS_VERSION			AES	SC 1 FSU
 PAGESIZE			POSIX	SC 1 MU		PAGESIZE PAGE_SIZE 4096	cc{
-	int main()
+	int main(void)
 	{
 	#if _WIN32
 		printf("%ld", 64*1024L);
@@ -390,7 +390,7 @@ PBS_MESSAGE			POSIX	SC 2 FUW
 PBS_TRACK			POSIX	SC 2 FUW
 PHYS_PAGES			SUN	SC 1 0
 PID_MAX				SVID	SC 1 LMU	30000	cc{
-	int main()
+	int main(void)
 	{
 		long	v;
 		int	fd;
@@ -455,7 +455,7 @@ RE_DUP_MAX			POSIX	SC 2 LMN	255
 RTSIG_MAX			POSIX	SC 1 LMU	8
 SAVED_IDS			POSIX	SC 1 FUW	cc{
 	#if _lib_setuid && !_lib_setreuid
-	int main()
+	int main(void)
 	{
 		printf("1");
 		return 0;
@@ -522,7 +522,7 @@ STREAM_MAX			POSIX	SC 1 LMU	OPEN_MAX 8
 STREAMS				XOPEN	SC 1 FSUW
 SW_DEV				POSIX	SC 2 CFUW
 SYMLINK_MAX			POSIX	PC 1 LMU	255	cc{
-	int main()
+	int main(void)
 	{
 		printf("%d", PATH_MAX-1);
 		return 0;

--- a/src/lib/libast/comp/omitted.c
+++ b/src/lib/libast/comp/omitted.c
@@ -1109,7 +1109,7 @@ bzero(void* b, size_t n)
 #endif
 
 int
-getpagesize()
+getpagesize(void)
 {
 	return _AST_PAGESIZE;
 }

--- a/src/lib/libast/features/align.c
+++ b/src/lib/libast/features/align.c
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 /*
@@ -55,7 +56,7 @@ static union _u_	u;
 static union _u_	v;
 
 int
-main()
+main(void)
 {
 	int		i;
 	int		j;

--- a/src/lib/libast/features/aso
+++ b/src/lib/libast/features/aso
@@ -2,7 +2,7 @@
 
 if	aso note{ gcc 4.1+ 64 bit memory atomic operations model }end link{
 		#include "FEATURE/common"
-		int main()
+		int main(void)
 		{
 			uint64_t i = 0;
 			uint32_t j = 0;
@@ -31,7 +31,7 @@ if	aso note{ gcc 4.1+ 64 bit memory atomic operations model }end link{
 	}
 elif	aso note{ gcc 4.1+ 32 bit memory atomic operations model }end link{
 		#include "FEATURE/common"
-		int main()
+		int main(void)
 		{
 			uint32_t i = 0;
 			uint16_t j = 0;
@@ -53,7 +53,7 @@ elif	aso note{ gcc 4.1+ 32 bit memory atomic operations model }end link{
 elif	aso note{ <atomic.h> atomic_cas_64 }end link{
 		#include "FEATURE/common"
 		#include <atomic.h>
-		int main()
+		int main(void)
 		{
 			uint64_t i = 0;
 			uint32_t j = 1;
@@ -82,7 +82,7 @@ elif	aso note{ <atomic.h> atomic_cas_64 }end link{
 elif	aso note{ <atomic.h> atomic_cas_32 }end link{
 		#include "FEATURE/common"
 		#include <atomic.h>
-		int main()
+		int main(void)
 		{
 			uint32_t i = 0;
 			return atomic_cas_32(&i, 0, 1) != 0 || (atomic_add_32_nv(&i, 1) - 1) != 1;
@@ -103,7 +103,7 @@ elif	aso note{ <atomic.h> atomic_cas_32 }end link{
 elif	aso -latomic note{ <atomic.h> atomic_cas_64 with -latomic }end link{
 		#include "FEATURE/common"
 		#include <atomic.h>
-		int main()
+		int main(void)
 		{
 			uint64_t i = 0;
 			uint32_t j = 1;
@@ -133,7 +133,7 @@ elif	aso -latomic note{ <atomic.h> atomic_cas_64 with -latomic }end link{
 elif	aso note{ <atomic.h> atomic_cas_32 with -latomic }end link{
 		#include "FEATURE/common"
 		#include <atomic.h>
-		int main()
+		int main(void)
 		{
 			uint32_t i = 0;
 			return atomic_cas_32(&i, 0, 1) != 0 || (atomic_add_32_nv(&i, 1) - 1) != 1;
@@ -155,7 +155,7 @@ elif	aso note{ <atomic.h> atomic_cas_32 with -latomic }end link{
 elif	aso note{ <atomic.h> cas64 }end link{
 		#include "FEATURE/common"
 		#include <atomic.h>
-		int main()
+		int main(void)
 		{
 			uint64_t i = 0;
 			uint32_t j = 1;
@@ -184,7 +184,7 @@ elif	aso note{ <atomic.h> cas64 }end link{
 elif	aso note{ <atomic.h> just cas64 }end link{
 		#include "FEATURE/common"
 		#include <atomic.h>
-		int main()
+		int main(void)
 		{
 			uint64_t i = 0;
 			uint32_t j = 1;
@@ -207,7 +207,7 @@ elif	aso note{ <atomic.h> just cas64 }end link{
 elif	aso note{ <atomic.h> cas32 }end link{
 		#include "FEATURE/common"
 		#include <atomic.h>
-		int main()
+		int main(void)
 		{
 			uint32_t i = 0;
 			return cas32(&i, 0, 1) != 0 || (atomic_add_32_nv(&i, 1) - 1) != 1;
@@ -228,7 +228,7 @@ elif	aso note{ <atomic.h> cas32 }end link{
 elif	aso note{ <atomic.h> just cas32 }end link{
 		#include "FEATURE/common"
 		#include <atomic.h>
-		int main()
+		int main(void)
 		{
 			uint32_t j = 1;
 			uint16_t k = 1;
@@ -244,7 +244,7 @@ elif	aso note{ <atomic.h> just cas32 }end link{
 	}
 elif	aso note{ winix Interlocked }end link{
 		#include <windows.h>
-		int main()
+		int main(void)
 		{
 			LONG		i = 0;
 			LONGLONG	j = 0;
@@ -350,7 +350,7 @@ elif	aso note{ winix Interlocked }end link{
 	}
 elif	aso note{ AIX fetch and add }end link{
 		#include <sys/atomic_op.h>
-		int main()
+		int main(void)
 		{
 			int i = 0;
 			return fetch_and_add((atomic_p)&i,1);
@@ -367,7 +367,7 @@ elif	aso note{ AIX fetch and add }end link{
 		#endif
 	}
 elif	aso note{ MIPS compare and swap }end link{
-		int main()
+		int main(void)
 		{
 			int i = 1;
 			return __compare_and_swap(&i, 0, 1) != 1;
@@ -415,7 +415,7 @@ elif	aso note{ i386|i386-64 asm compare and swap }end link{
 
 		#endif
 
-		int main()
+		int main(void)
 		{
 			uint32_t	i = 0;
 			uint64_t	j = 0;
@@ -491,7 +491,7 @@ elif	aso note{ ia64 asm compare and swap }end link{
 			return r;
 		}
 
-		int main()
+		int main(void)
 		{
 			uint32_t	i = 0;
 			uint64_t	j = 0;
@@ -575,7 +575,7 @@ elif	aso note{ ppc asm compare and swap }end link{
 			return r ? *p : o;
 		}
 
-		int main()
+		int main(void)
 		{
 			uint32_t	i = 0;
 			uint64_t	j = 0;

--- a/src/lib/libast/features/asometh
+++ b/src/lib/libast/features/asometh
@@ -5,7 +5,7 @@ aso fcntl note{ fcntl(F_SETLCK[W]) work }end link{
 		#include <unistd.h>
 		#include <fcntl.h>
 
-		int main()
+		int main(void)
 		{
 			struct flock	lock;
 
@@ -25,7 +25,7 @@ aso semaphore note{ semget semop semctl work }end link{
 		#include <sys/ipc.h>
 		#include <sys/sem.h>
 
-		int main()
+		int main(void)
 		{
 			int		id;
 			struct sembuf	sem;

--- a/src/lib/libast/features/botch.c
+++ b/src/lib/libast/features/botch.c
@@ -34,7 +34,7 @@ extern int		getgroups(int, gid_t*);
 #endif
 
 int
-main()
+main(void)
 {
 #if _lib_getgroups
 	if (sizeof(int) > sizeof(gid_t))

--- a/src/lib/libast/features/ccode
+++ b/src/lib/libast/features/ccode
@@ -1,5 +1,5 @@
 tst output{
-	int main()
+	int main(void)
 	{
 		printf("\n");
 		printf("#define CC_ASCII	1		/* ISO-8859-1			*/\n");

--- a/src/lib/libast/features/common
+++ b/src/lib/libast/features/common
@@ -43,12 +43,6 @@ cat{
 	#undef	Void_t
 	#define	Void_t		void
 
-	/* disable non-standard Linux/GNU inlines */
-	#ifdef __GNUC__	
-	#	undef	__OPTIMIZE_SIZE__
-	#	define	__OPTIMIZE_SIZE__	1
-	#endif
-
 	/* __INLINE__, if defined, is the inline keyword */
 	#if !defined(__INLINE__) && defined(_WIN32) && !defined(__GNUC__)
 	#	define __INLINE__	__inline
@@ -173,7 +167,7 @@ tst	- -DN=1 - -DN=2 - -DN=3 - -DN=4 - -DN=5 - -DN=6 - -DN=7 - -DN=8 - -DN=0 outp
 	static int	int_size[] = { 1, 2, 4, 8 };
 	
 	int
-	main()
+	main(void)
 	{
 		int	t;
 		int	s;
@@ -262,7 +256,7 @@ tst	- output{
 	};
 	
 	int
-	main()
+	main(void)
 	{
 		int	t;
 
@@ -313,7 +307,7 @@ tst	- -DN=1 - -DN=0 output{
 	};
 	
 	int
-	main()
+	main(void)
 	{
 		int	t;
 		int	m = 1;
@@ -458,7 +452,7 @@ tst	- -DTRY=1 - -DTRY=1 -Dvoid=char - -DTRY=2 - -DTRY=3 - -DTRY=4 output{
 	}
 	#endif
 	int
-	main()
+	main(void)
 	{
 		int	r;
 

--- a/src/lib/libast/features/common
+++ b/src/lib/libast/features/common
@@ -64,15 +64,11 @@ cat{
 
 	#if !_std_noreturn
 	#if defined(__GNUC__) && (__GNUC__ > 2 || (__GNUC__ == 2 && __GNUC_MINOR__ > 4))
-	#if __CYGWIN__
 	/*
-	 * On Cygwin, for whatever reason, -std=c99 breaks the compile unless
-	 * noreturn is specifically '__attribute__((__noreturn__))'.
+	 * Note: Cygwin needs noreturn to be __noreturn__ to avoid
+	 * a build failure when using -std=c99.
 	 */
 	#define noreturn __attribute__((__noreturn__))
-	#else
-	#define noreturn __attribute__((noreturn))
-	#endif
 	#else
 	#define noreturn
 	#endif /* __GNUC__ */

--- a/src/lib/libast/features/common
+++ b/src/lib/libast/features/common
@@ -64,7 +64,15 @@ cat{
 
 	#if !_std_noreturn
 	#if defined(__GNUC__) && (__GNUC__ > 2 || (__GNUC__ == 2 && __GNUC_MINOR__ > 4))
+	#if __CYGWIN__
+	/*
+	 * On Cygwin, for whatever reason, -std=c99 breaks the compile unless
+	 * noreturn is specifically '__attribute__((__noreturn__))'.
+	 */
+	#define noreturn __attribute__((__noreturn__))
+	#else
 	#define noreturn __attribute__((noreturn))
+	#endif
 	#else
 	#define noreturn
 	#endif /* __GNUC__ */

--- a/src/lib/libast/features/errno
+++ b/src/lib/libast/features/errno
@@ -1,6 +1,6 @@
 tst	dat_sys_nerr note{ sys_nerr in default libs }end compile{
 	extern int sys_nerr;
-	int f()
+	int f(void)
 	{
 		return sys_nerr > 0;
 	}
@@ -8,7 +8,7 @@ tst	dat_sys_nerr note{ sys_nerr in default libs }end compile{
 
 tst	def_errno_sys_nerr note{ sys_nerr declared in errno.h }end compile{
 	#include <errno.h>
-	int f()
+	int f(void)
 	{
 		return sys_nerr > 0;
 	}
@@ -16,7 +16,7 @@ tst	def_errno_sys_nerr note{ sys_nerr declared in errno.h }end compile{
 
 tst	dat_sys_errlist note{ sys_errlist in default libs }end compile{
 	extern char* sys_errlist[];
-	int f()
+	int f(void)
 	{
 		return *sys_errlist[1] != 0;
 	}
@@ -24,7 +24,7 @@ tst	dat_sys_errlist note{ sys_errlist in default libs }end compile{
 
 tst	def_errno_sys_errlist note{ sys_errlist declared in errno.h }end compile{
 	#include <errno.h>
-	int f()
+	int f(void)
 	{
 		return *sys_errlist[1] != 0;
 	}

--- a/src/lib/libast/features/fcntl.c
+++ b/src/lib/libast/features/fcntl.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2012 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2023 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 /*
@@ -49,7 +50,7 @@
 #include "FEATURE/tty"
 
 int
-main()
+main(void)
 {
 	int		f_local = 0;
 	int		f_lck = 0;

--- a/src/lib/libast/features/float
+++ b/src/lib/libast/features/float
@@ -26,7 +26,7 @@ lib	fpclassify -lm note{ fpclassify present and works }end link{
 		#include <stdlib.h>
 		#include <unistd.h>
 		#include <math.h>
-		int main() { return fpclassify(-0.0); }
+		int main(void) { return fpclassify(-0.0); }
 	}end
 lib	isinf -lm note{ isinf present and works }end link{
 		#include <sys/types.h>
@@ -34,7 +34,7 @@ lib	isinf -lm note{ isinf present and works }end link{
 		#include <stdlib.h>
 		#include <unistd.h>
 		#include <math.h>
-		int main() { return isinf(-0.0); }
+		int main(void) { return isinf(-0.0); }
 	}end
 lib	isnan -lm note{ isnan present and works }end link{
 		#include <sys/types.h>
@@ -42,7 +42,7 @@ lib	isnan -lm note{ isnan present and works }end link{
 		#include <stdlib.h>
 		#include <unistd.h>
 		#include <math.h>
-		int main() { return isnan(-0.0); }
+		int main(void) { return isnan(-0.0); }
 	}end
 lib	signbit -lm note{ signbit present and works }end link{
 		#include <sys/types.h>
@@ -50,13 +50,13 @@ lib	signbit -lm note{ signbit present and works }end link{
 		#include <stdlib.h>
 		#include <unistd.h>
 		#include <math.h>
-		int main() { return signbit(-0.0); }
+		int main(void) { return signbit(-0.0); }
 	}end
 
 tst	ast_no_um2fm note{ no unsigned intmax => floatmax cast }end nolink{
 	#include "FEATURE/common"
 	int
-	main()
+	main(void)
 	{
 		_ast_fltmax_t		f = 0;
 		unsigned _ast_intmax_t	i = 0;
@@ -68,7 +68,7 @@ tst	ast_no_um2fm note{ no unsigned intmax => floatmax cast }end nolink{
 
 tst	ast_mpy_overflow_fpe note{ fpe on mpy overflow }end noexecute{
 	int
-	main()
+	main(void)
 	{
 		float	f;
 		float	p;
@@ -87,7 +87,7 @@ tst	ast_mpy_overflow_fpe note{ fpe on mpy overflow }end noexecute{
 
 tst	ast_div_underflow_fpe note{ fpe on div underflow }end noexecute{
 	int
-	main()
+	main(void)
 	{
 		float	f;
 		float	p;
@@ -285,7 +285,7 @@ tst	- note{ missing floating point limits }end output{
 	}
 	#endif
 	int
-	main()
+	main(void)
 	{
 		int		i;
 		int		s;
@@ -921,7 +921,7 @@ tst	- note{ double exponent bitfoolery }end output{
 		double			f;
 	} _ast_dbl_exp_t;
 	int
-	main()
+	main(void)
 	{
 		int			i;
 		int			j;
@@ -958,7 +958,7 @@ tst	- note{ long double exponent bitfoolery }end output{
 		_ast_fltmax_t		f;
 	} _ast_fltmax_exp_t;
 	int
-	main()
+	main(void)
 	{
 		int			i;
 		int			j;
@@ -989,7 +989,7 @@ tst	- note{ long double exponent bitfoolery }end output{
 tst	- -DN=1 - -DN=2 note{ _ast_fltmax_t maximum integral type }end output{
 	#include <stdio.h>
 	int
-	main()
+	main(void)
 	{
 	#if N == 1
 		unsigned long long	m;
@@ -1052,7 +1052,7 @@ tst	- -DSCAN=1 - -lm -DSTRTO=1 - -DMAC=1 - -DDIV=1 - -DEXP=1 - -DADD=1 - -DMPY=1
 		printf("\n");
 	}
 	int
-	main()
+	main(void)
 	{
 	#if SCAN || STRTO
 	#undef	NAN
@@ -1245,7 +1245,7 @@ if	need_ast_pow_macros -lm note{ are IEEE pow macro replacements needed }end exe
 	#include <stdlib.h>
 	#include <unistd.h>
 	#include <math.h>
-	int main() { return pow(1.0, 1.0 / 0.0) == 1.0; }
+	int main(void) { return pow(1.0, 1.0 / 0.0) == 1.0; }
 }end {
 	#define powf(x,y)	(((x)==1.0)?1.0:powf((x),(y)))
 	#define pow(x,y)	(((x)==1.0)?1.0:pow((x),(y)))
@@ -1259,7 +1259,7 @@ elif	tst need_ast_pow_funs -lm note{ are IEEE pow function replacements needed }
 	#include <math.h>
 	/* This bit of obfuscation defeats GCC's code optimizer. */
 	double (*volatile _ast_ppow)(double,double);
-	int main () { _ast_ppow = &pow; return (*_ast_ppow)(1.0, 1.0 / 0.0) == 1.0; }
+	int main (void) { _ast_ppow = &pow; return (*_ast_ppow)(1.0, 1.0 / 0.0) == 1.0; }
 }end {
 	float			_ast_powf(float x, float y);
 	double			_ast_pow(double x, double y);

--- a/src/lib/libast/features/fs
+++ b/src/lib/libast/features/fs
@@ -168,7 +168,7 @@ lib	getfsstat_statfs note{ getfsstat uses statfs }end compile{
 	int
 	gfs(struct statfs* fs)
 	{
-		fs->f_flag = 0;
+		fs->f_flags = 0;
 		return getfsstat(fs, sizeof(struct statfs), MNT_WAIT);
 	}
 }end pass{

--- a/src/lib/libast/features/fs
+++ b/src/lib/libast/features/fs
@@ -13,7 +13,7 @@ lcl	xstat link{
 	#endif
 	}
 	int
-	main()
+	main(void)
 	{
 		struct stat	st;
 		return stat(".",&st) < 0;
@@ -101,7 +101,7 @@ mem	statfs.f_files,statfs.f_bavail sys/types.h - sys/statfs.h - sys/vfs.h - sys/
 mem	statvfs.f_basetype,statvfs.f_frsize sys/types.h sys/statvfs.h
 
 ary	f_reserved7 sys/types.h sys/statvfs.h note{ statvfs.f_reserved7 can double for statvfs.f_basetype }end compile{
-	int f(vp)struct statvfs* vp;{return vp->f_reserved7[0] = 1;}
+	int f(struct statvfs *vp){return vp->f_reserved7[0] = 1;}
 }end
 
 lib	getfsstat,getmntent,getmntinfo,mntctl,mntopen,mntread,mntclose,setmntent
@@ -119,7 +119,7 @@ lib	statfs4 sys/types.h - sys/statfs.h - sys/vfs.h - sys/mount.h compile{
 	#if _sys_mount
 	#include <sys/mount.h>
 	#endif
-	int f()
+	int f(void)
 	{
 		struct statfs fs;
 		return statfs("/",&fs,sizeof(fs),0);
@@ -179,28 +179,39 @@ cat{
 	extern int	fstatvfs(int, struct statvfs*);
 	extern int	statvfs(const char*, struct statvfs*);
 	#endif
+
+	/*
+	 * NetBSD only provides getfsstat for binary compatibility, and
+	 * does not expose it in the system headers. Using it will
+	 * cause the build to fail with C99 because of an implicit
+	 * function error. We don't actually need this function,
+	 * so it's better to just avoid using it.
+	 */
+	#if defined(__NetBSD__)
+	#undef _lib_getfsstat
+	#endif
 }end
 
 str	st_fstype sys/types.h sys/stat.h note{ stat.st_fstype is a string }end compile{
-	int f(st)struct stat* st;{return st->st_fstype[0];}
+	int f(struct stat *st){return st->st_fstype[0];}
 }end
 
 int	st_fstype sys/types.h sys/stat.h note{ stat.st_fstype is an int }end compile{
-	int f(st)struct stat* st;{return st->st_fstype = 1;}
+	int f(struct stat *st){return st->st_fstype = 1;}
 }end
 
 int	st_spare1 sys/types.h sys/stat.h note{ stat.st_spare1 is an int }end compile{
-	int f(st)struct stat* st;{return st->st_spare1 = 1;}
+	int f(struct stat *st){return st->st_spare1 = 1;}
 }end
 
 ary	st_spare4 sys/types.h sys/stat.h note{ stat.st_spare4 is an array }end compile{
-	int f(st)struct stat* st;{return st->st_spare4[0] = 1;}
+	int f(struct stat *st){return st->st_spare4[0] = 1;}
 }end
 
 ary	st_extra sys/types.h sys/stat.h note{ stat.st_extra is an array }end compile{
-	int f(st)struct stat* st;{return st->st_extra[0] = 1;}
+	int f(struct stat *st){return st->st_extra[0] = 1;}
 }end
 
 ary	st_pad4 sys/types.h sys/stat.h note{ stat.st_pad4 is an array }end compile{
-	int f(st)struct stat* st;{return st->st_pad4[0] = 1;}
+	int f(struct stat *st){return st->st_pad4[0] = 1;}
 }end

--- a/src/lib/libast/features/fs
+++ b/src/lib/libast/features/fs
@@ -104,7 +104,7 @@ ary	f_reserved7 sys/types.h sys/statvfs.h note{ statvfs.f_reserved7 can double f
 	int f(struct statvfs *vp){return vp->f_reserved7[0] = 1;}
 }end
 
-lib	getfsstat,getmntent,getmntinfo,mntctl,mntopen,mntread,mntclose,setmntent
+lib	getmntent,getmntinfo,mntctl,mntopen,mntread,mntclose,setmntent
 lib	w_getmntent
 lib	statfs,statvfs
 
@@ -139,13 +139,42 @@ lib	getmntinfo_statvfs note{ getmntinfo uses statvfs -- since when? }end compile
 
 lib	getfsstat_statvfs note{ getfsstat uses statvfs -- just in case it is confused like getmntinfo }end compile{
 	#include <sys/types.h>
+	#if _sys_mount
 	#include <sys/mount.h>
+	#endif
 	int
 	gfs(struct statvfs* fs)
 	{
 		fs->f_flag = 0;
 		return getfsstat(fs, sizeof(struct statvfs), MNT_WAIT);
 	}
+}end pass{
+	cat <<!
+	#define _lib_getfsstat 1	/* getfsstat() uses statvfs and compiles successfully */
+	!
+}end
+
+lib	getfsstat_statfs note{ getfsstat uses statfs }end compile{
+	#include <sys/types.h>
+	#if _sys_mount
+	#include <sys/mount.h>
+	#endif
+	#if _sys_param
+	#include <sys/param.h>
+	#endif
+	#if _sys_ucred
+	#include <sys/ucred.h>
+	#endif
+	int
+	gfs(struct statfs* fs)
+	{
+		fs->f_flag = 0;
+		return getfsstat(fs, sizeof(struct statfs), MNT_WAIT);
+	}
+}end pass{
+	cat <<!
+	#define _lib_getfsstat 1	/* getfsstat() uses statfs and compiles successfully */
+	!
 }end
 
 cat{
@@ -178,17 +207,6 @@ cat{
 	};
 	extern int	fstatvfs(int, struct statvfs*);
 	extern int	statvfs(const char*, struct statvfs*);
-	#endif
-
-	/*
-	 * NetBSD only provides getfsstat for binary compatibility, and
-	 * does not expose it in the system headers. Using it will
-	 * cause the build to fail with C99 because of an implicit
-	 * function error. We don't actually need this function,
-	 * so it's better to just avoid using it.
-	 */
-	#if defined(__NetBSD__)
-	#undef _lib_getfsstat
 	#endif
 }end
 

--- a/src/lib/libast/features/hack
+++ b/src/lib/libast/features/hack
@@ -42,7 +42,7 @@ tst	- -DVAL=0 - -DVAL=1 - -DVAL=2 note{ probing need for va_listval() workaround
 		}
 		va_end(ap);
 	}
-	int main()
+	int main(void)
 	{
 		foo(0,"one",2);
 		printf("#define _need_va_listval_workaround %d\n",VAL);

--- a/src/lib/libast/features/iconv
+++ b/src/lib/libast/features/iconv
@@ -17,7 +17,7 @@ tst	output{
 	#endif
 
 	int
-	main()
+	main(void)
 	{
 		char*	lib;
 

--- a/src/lib/libast/features/lib
+++ b/src/lib/libast/features/lib
@@ -12,7 +12,7 @@ hdr	wchar note{ <wchar.h> and isw*() really work }end execute{
 	#include <wctype.h>
 	#endif
 	int
-	main()
+	main(void)
 	{
 		wchar_t	w = 'a';
 		return iswalnum(w) == 0;
@@ -63,9 +63,9 @@ tst	tst_errno note{ errno can be assigned }end link{
 	#ifndef errno
 	extern int errno;
 	#endif
-	void error() { }
-	void strerror() { }
-	int main() { errno = 0; error(); strerror(); return 0; }
+	void error(void) { }
+	void strerror(void) { }
+	int main(void) { errno = 0; error(); strerror(); return 0; }
 }end
 
 tst	lib_poll_fd_1 note{ fd is first arg to poll() }end execute{
@@ -73,7 +73,7 @@ tst	lib_poll_fd_1 note{ fd is first arg to poll() }end execute{
 	#include <unistd.h>
 	extern int	pipe(int*);
 	int
-	main()
+	main(void)
 	{	int		rw[2];
 		struct pollfd	fd;
 		if (pipe(rw) < 0) return 1;
@@ -92,7 +92,7 @@ tst	lib_poll_fd_2 note{ fd is second arg to poll() }end execute{
 	#include <unistd.h>
 	extern int	pipe(int*);
 	int
-	main()
+	main(void)
 	{	int		rw[2];
 		struct pollfd	fd;
 		if (pipe(rw) < 0) return 1;
@@ -115,7 +115,7 @@ tst	lib_poll_notimer note{ poll with no fds ignores timeout }end execute{
 	extern time_t	time(time_t*);
 	#define TIMEOUT		4
 	int
-	main()
+	main(void)
 	{
 		unsigned long	start;
 		unsigned long	finish;
@@ -133,7 +133,7 @@ tst	lib_select sys/select.h note{ select() has standard 5 arg interface }end lin
 	#include <sys/time.h>
 	#include <sys/socket.h>
 	int
-	main()
+	main(void)
 	{	struct timeval	tmb;
 		fd_set		rd;
 		FD_ZERO(&rd);
@@ -148,7 +148,7 @@ tst	lib_select sys/select.h note{ select() has standard 5 arg interface }end lin
 tst	sys_select note{ select() requires <sys/select.h> }end link{
 	#include <sys/select.h>
 	int
-	main()
+	main(void)
 	{	struct timeval	tmb;
 		fd_set		rd;
 		FD_ZERO(&rd);
@@ -166,7 +166,7 @@ tst	pipe_rw note{ full duplex pipes }end execute{
 	extern int	strcmp(const char*, const char*);
 	extern int	write(int, void*, int);
 	int
-	main()
+	main(void)
 	{
 	#if defined(__sgi) || defined(_sgi) || defined(sgi)
 		/* boot tuneable pipes force one way for bin compatibility */
@@ -201,9 +201,7 @@ tst	lib_posix_spawn unistd.h stdlib.h spawn.h -Dfork=______fork note{ posix_spaw
 	pid_t _fork(void) { NOTE("uses _fork()"); return -1; }
 	pid_t __fork(void) { NOTE("uses __fork()"); return -1; }
 	int
-	main(argc, argv)
-	int	argc;
-	char**	argv;
+	main(int argc, char **argv)
 	{
 		char*			s;
 		pid_t			pid;
@@ -309,9 +307,7 @@ tst	lib_spawn_mode unistd.h stdlib.h note{ first spawn arg is mode and it works 
 	#define P_NOWAIT _P_NOWAIT
 	#endif
 	int
-	main(argc, argv)
-	int	argc;
-	char**	argv;
+	main(int argc, char **argv)
 	{
 		int	status;
 		char*	cmd[3];
@@ -333,7 +329,7 @@ tst	stream_peek note{ ioctl(I_PEEK) works on pipe() }end execute{
 	#include <unistd.h>
 	#include <stropts.h>
 	int
-	main()
+	main(void)
 	{	struct strpeek	peek;
 		int		fds[2];
 		char		ctlbuf[32];
@@ -353,7 +349,7 @@ tst	socket_peek note{ recv(MSG_PEEK) works on socketpair() }end execute{
 	#include <sys/types.h>
 	#include <sys/socket.h>
 	int
-	main()
+	main(void)
 	{	
 		int		i;
 		int		fds[2];
@@ -391,7 +387,7 @@ tst	lib_memcmp string.h note{ standard memcmp interface that works }end execute{
 	char		a[L] = { '0' };
 	char		b[L] = { '1' };
 	int
-	main()
+	main(void)
 	{
 		return memcmp(a, b, L) >= 0;
 	}
@@ -459,7 +455,7 @@ tst	lib_memccpy string.h unistd.h stdlib.h fcntl.h signal.h sys/types.h sys/stat
 	#endif
 
 	int
-	main ()
+	main(void)
 	{
 		char	buf[1024];
 	#ifdef MAP_PRIVATE
@@ -523,7 +519,7 @@ tst	lib_utime_now note{ utime works with 0 time vector }end execute{
 	#include <sys/types.h>
 	extern int	utime(const char*, void*);
 	int
-	main()
+	main(void)
 	{
 		return utime(".", NULL) == -1;
 	}
@@ -544,28 +540,28 @@ tst	cross{
 std	cleanup note{ stuck with standard _cleanup }end noexecute{
 	extern void exit(int);
 	extern void _exit(int);
-	extern void _cleanup();
-	void _cleanup() { _exit(0); }
-	int main() { printf("cleanup\n"); exit(1); }
+	extern void _cleanup(void);
+	void _cleanup(void) { _exit(0); }
+	int main(void) { printf("cleanup\n"); exit(1); }
 }end
 
 std	remove note{ stuck with standard remove() }end nostatic{
 	extern int unlink(const char*);
 	int remove(const char* path) { return 0; }
-	int main() { return unlink("foo"); }
+	int main(void) { return unlink("foo"); }
 }end
 
 std	signal note{ stuck with standard signal }end nolink{
-	extern int abort();
-	int signal() { return 0; }
-	int main() { signal(); abort(); return 0; }
+	extern void abort(void);
+	int signal(void) { return 0; }
+	int main(void) { signal(); abort(); return 0; }
 }end
 
 std	strcoll note{ standard strcoll works }end execute{
 	#include <string.h>
 	#define S	"hello world"
 	int
-	main()
+	main(void)
 	{
 		char	s[] = S;
 		char	t[] = S;
@@ -575,23 +571,23 @@ std	strcoll note{ standard strcoll works }end execute{
 
 std	strtod stdlib.h note{ stuck with standard strtod }end nostatic{
 	double strtod(const char* s, char** e) { return 0.0; }
-	int main() { printf(""); return strtod("1",0) != 0; }
+	int main(void) { printf(""); return strtod("1",0) != 0; }
 }end
 
 std	strtold stdlib.h note{ stuck with standard strtold }end nostatic{
 	long double strtold(const char* s, char** e) { return 0.0; }
-	int main() { printf(""); return strtold("1",0) != 0; }
+	int main(void) { printf(""); return strtold("1",0) != 0; }
 }end
 
 std	strtol note{ stuck with standard strtol }end nostatic{
 	extern long atol(const char*);
 	long strtol(const char* s, char** e, int b) { return 0; }
-	int main() { printf(""); return (atol("1") + strtol("1",NULL,0)) != 0; }
+	int main(void) { printf(""); return (atol("1") + strtol("1",NULL,0)) != 0; }
 }end
 
 tst	- output{
 	int
-	main()
+	main(void)
 	{
 	#if _lib_posix_spawn || _lib_spawn_mode || _lib_spawn && _hdr_spawn && _mem_pgroup_inheritance
 		printf("#if !_AST_no_spawnveg\n");

--- a/src/lib/libast/features/limits.c
+++ b/src/lib/libast/features/limits.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2023 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 /*
@@ -69,7 +70,7 @@
 #undef	getpagesize
 #undef	getdtablesize   
 
-int main()
+int main(void)
 {
 	char			c;
 	unsigned char		uc;

--- a/src/lib/libast/features/map.c
+++ b/src/lib/libast/features/map.c
@@ -37,7 +37,7 @@
 #endif
 
 int
-main()
+main(void)
 {
 	printf("/*\n");
 	printf(" * prototypes provided for standard interfaces hijacked\n");

--- a/src/lib/libast/features/mmap
+++ b/src/lib/libast/features/mmap
@@ -127,7 +127,7 @@ tst	mmap_anon note{ use mmap MAP_ANON to get raw memory }end execute{
 	#define MAP_ANON	MAP_ANONYMOUS
 	#endif
 	int
-	main()
+	main(void)
 	{	void	*addr;
 		addr = mmap(0,1024*1024,PROT_READ|PROT_WRITE,MAP_ANON|MAP_PRIVATE,-1,0);
 		return (addr && addr != (void*)(-1)) ? 0 : 1;
@@ -143,7 +143,7 @@ tst	mmap_devzero note{ use mmap on /dev/zero to get raw memory }end execute{
 	#include <sys/types.h>
 	#include <sys/mman.h>
 	int
-	main()
+	main(void)
 	{	int	fd;
 		void	*addr;
 		if((fd = open("/dev/zero", O_RDWR)) < 0)

--- a/src/lib/libast/features/mode.c
+++ b/src/lib/libast/features/mode.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2023 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 /*
@@ -30,7 +31,7 @@
 #include <modecanon.h>
 
 int
-main()
+main(void)
 {
 	int	n;
 	int	idperm;

--- a/src/lib/libast/features/ndbm
+++ b/src/lib/libast/features/ndbm
@@ -1,7 +1,7 @@
 if	tst -ldb note{ sleepycat ndbm compatibility }end link{
 		#define DB_DBM_HSEARCH	1
 		#include <db.h>
-		int main()
+		int main(void)
 		{
 			DBM*	dbm = 0;
 			dbm_close(dbm);

--- a/src/lib/libast/features/nl_types
+++ b/src/lib/libast/features/nl_types
@@ -12,7 +12,7 @@ tst	output{
 	#endif
 
 	int
-	main()
+	main(void)
 	{
 		printf("#include <limits.h>\n");
 	#if _hdr_nl_types && defined(_nxt_nl_types_str)

--- a/src/lib/libast/features/param.sh
+++ b/src/lib/libast/features/param.sh
@@ -43,7 +43,7 @@ for i in "#include <sys/param.h>" "#include <sys/param.h>
 #endif"
 do	echo "$i
 struct stat V_stat_V;
-void F_stat_F() { V_stat_V.st_mode = 0; }" > $tmp.c
+void F_stat_F(void) { V_stat_V.st_mode = 0; }" > $tmp.c
 	if	$cc -c $tmp.c >/dev/null
 	then	echo "$i"
 		break

--- a/src/lib/libast/features/sfinit.c
+++ b/src/lib/libast/features/sfinit.c
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 /*
@@ -24,7 +25,7 @@
 #include "FEATURE/float"
 
 int
-main()
+main(void)
 {
 	int		i;
 #if _ast_fltmax_double

--- a/src/lib/libast/features/sfio
+++ b/src/lib/libast/features/sfio
@@ -9,7 +9,7 @@ typ	struct.sf_hdtr sys/socket.h
 tst	- note{ number of bits in pointer }end output{
 	#include <stdio.h>
 	int
-	main()
+	main(void)
 	{
 		printf("#define _ptr_bits	%d\n", sizeof(char*) * 8);
 		return 0;
@@ -23,7 +23,7 @@ tst	tmp_rmfail note{ open files cannot be removed }end execute{
 	#include <string.h>
 	#include <time.h>
 	int
-	main()
+	main(void)
 	{
 		int		n;
 		char*		s;
@@ -76,7 +76,7 @@ tst	tmp_rmfail note{ open files cannot be removed }end execute{
 
 more void_int note{ voidptr is larger than int }end execute{
 	int
-	main()
+	main(void)
 	{
 		return sizeof(char*) > sizeof(int) ? 0 : 1;
 	}
@@ -84,7 +84,7 @@ more void_int note{ voidptr is larger than int }end execute{
 
 more long_int note{ long is larger than int }end execute{
 	int
-	main()
+	main(void)
 	{
 		return sizeof(long) > sizeof(int) ? 0 : 1;
 	}
@@ -92,7 +92,7 @@ more long_int note{ long is larger than int }end execute{
 
 tst	vax_asm note{ layout ok for vax string operations }end execute{
 	int
-	main()
+	main(void)
 	{
 	#ifndef vax
 		return absurd = -1;
@@ -117,7 +117,7 @@ tst	lib_cvt note{ native floating point conversions ok }end link{
 	extern char* fcvt(double, int, int*, int*);
 	extern double strtod(const char*, char**);
 	int
-	main()
+	main(void)
 	{
 		ecvt(0.0, 0, 0, 0);
 		fcvt(0.0, 0, 0, 0);
@@ -131,9 +131,7 @@ tst	xopen_stdio note{ Stdio fseek/fflush are X/Open-compliant }end execute{
 	#include <unistd.h>
 	#define Failed(file)	(unlink(file),1)
 	int
-	main(argc, argv)
-	int	argc;
-	char**	argv;
+	main(int argc, char **argv)
 	{	FILE	*f1, *f2;
 		char	file[1024], buf[1024], *f, *t;
 		int	i, fd;

--- a/src/lib/libast/features/sig.sh
+++ b/src/lib/libast/features/sig.sh
@@ -14,6 +14,7 @@
 #                  David Korn <dgk@research.att.com>                   #
 #                   Phong Vo <kpv@research.att.com>                    #
 #                  Martijn Dekker <martijn@inlv.org>                   #
+#            Johnothan King <johnothanking@protonmail.com>             #
 #                                                                      #
 ########################################################################
 : generate sig features
@@ -46,7 +47,7 @@ echo "#include <signal.h>
 #ifdef TYPE
 typedef TYPE (*Sig_handler_t)(ARG);
 #endif
-Sig_handler_t f()
+Sig_handler_t f(void)
 {
 	Sig_handler_t	handler;
 	handler = signal(1, SIG_IGN);

--- a/src/lib/libast/features/signal.c
+++ b/src/lib/libast/features/signal.c
@@ -289,7 +289,7 @@ extern char*		strsignal(int);
 #endif
 
 int
-main()
+main(void)
 {
 	int	i;
 	int	j;

--- a/src/lib/libast/features/sizeof
+++ b/src/lib/libast/features/sizeof
@@ -1,7 +1,7 @@
 tst	- note{ sizeof(integral-type) }end output{
 	#include "FEATURE/common"
 	int
-	main()
+	main(void)
 	{
 		printf("#define _ast_sizeof_char	%d\n", sizeof(char));
 		printf("#define _ast_sizeof_short	%d\n", sizeof(short));

--- a/src/lib/libast/features/stdio
+++ b/src/lib/libast/features/stdio
@@ -100,7 +100,7 @@ output{
 	#define TMP_MAX		33520641
 	#endif
 	int
-	main()
+	main(void)
 	{
 		printf("#ifndef FILENAME_MAX\n");
 		printf("#define FILENAME_MAX	%d\n", FILENAME_MAX);

--- a/src/lib/libast/features/sys
+++ b/src/lib/libast/features/sys
@@ -81,7 +81,7 @@ typ ldiv_t fail{
 tst	typ_signed_size_t output{
 	#include <sys/types.h>
 	int
-	main()
+	main(void)
 	{
 		unsigned long u = ~0;
 		size_t s = ~0;

--- a/src/lib/libast/features/syscall
+++ b/src/lib/libast/features/syscall
@@ -1,7 +1,7 @@
 lib	sysgetcwd note{ syscall(SYS_getcwd,buf,len) implemented }end link{
 	#include <sys/syscall.h>
 	#include <unistd.h>
-	int main()
+	int main(void)
 	{
 		char	buf[256];
 		return syscall(SYS_getcwd, buf, sizeof(buf)) < 0;

--- a/src/lib/libast/features/tmlib
+++ b/src/lib/libast/features/tmlib
@@ -6,7 +6,7 @@ _cc_export_dynamic = note{ probe CC.EXPORT.DYNAMIC supported }end run{
 
 tst	tzset_environ note{ tzset() bypasses user getenv() }end execute{
 	#if !_cc_export_dynamic
-	int main()
+	int main(void)
 	{
 		return 0;
 	}
@@ -18,7 +18,7 @@ tst	tzset_environ note{ tzset() bypasses user getenv() }end execute{
 	{
 		return "foo0bar";
 	}
-	int main()
+	int main(void)
 	{
 		tzset();
 		return tzname[0] && !strcmp(tzname[0], "foo") &&

--- a/src/lib/libast/features/tvlib
+++ b/src/lib/libast/features/tvlib
@@ -1,11 +1,11 @@
 hdr	time
 lib	clock_settime,gettimeofday,settimeofday,stime,utimes
 lib	nanosleep,usleep
-lib	utimensat -D_ATFILE_SOURCE sys/stat.h note{ complete utimensat implementation }end link{
+lib	utimensat sys/stat.h note{ complete utimensat implementation }end link{
 	#include <fcntl.h>
 	static struct timespec	ts[2];
 	int
-	main()
+	main(void)
 	{
 		ts[0].tv_nsec = UTIME_NOW;
 		ts[1].tv_nsec = UTIME_OMIT;
@@ -25,7 +25,7 @@ endif
 lib	clock_gettime execute{
 	#include <time.h>
 	int
-	main()
+	main(void)
 	{
 		struct timespec	tv;
 		return clock_gettime(CLOCK_REALTIME, &tv) != 0;
@@ -37,7 +37,7 @@ lib	utimets link{
 	#include <sys/time.h>
 	static struct timespec	tv;
 	int
-	main()
+	main(void)
 	{
 		return utimets(".", &tv) != 0;
 	}
@@ -52,7 +52,7 @@ tst	prefer_poll note{ is select less precise than 1 ms }end execute{
 	# include <sys/socket.h>
 	#endif
 	int
-	main()
+	main(void)
 	{
 		struct timeval tvSleep = { 0, 1 }, tvBefore, tvAfter;
 		int i;
@@ -79,7 +79,7 @@ tst	- -DN=1 - -DN=2 - -DN=3 - -DN=4 output{
 	#include <sys/types.h>
 	#include <sys/time.h>
 	int
-	main()
+	main(void)
 	{
 		struct timeval	tv;
 #if N == 1

--- a/src/lib/libast/features/vmalloc
+++ b/src/lib/libast/features/vmalloc
@@ -21,7 +21,7 @@ tst	mem_sbrk note{ brk()/sbrk() work as expected }end execute{
 	#include        <unistd.h>
 	#undef	uchar
 	#define	uchar	unsigned char
-	int main()
+	int main(void)
 	{	uchar	*brk0, *brk1;
 
 		/* allocate a big chunk */
@@ -46,7 +46,7 @@ tst	mem_sbrk note{ brk()/sbrk() work as expected }end execute{
 
 tst	map_malloc note{ map malloc to _ast_malloc }end noexecute{
 	#if __CYGWIN__ || __HAIKU__
-	int main() { return 1; }
+	int main(void) { return 1; }
 	#else
 	static int user = 0;
 	#if _lib_strdup
@@ -70,17 +70,17 @@ tst	map_malloc note{ map malloc to _ast_malloc }end noexecute{
 	extern void* _malloc(unsigned int n) { MALLOC(n); }
 	extern void* __malloc(unsigned int n) { MALLOC(n); }
 	extern void* __libc_malloc(unsigned int n) { MALLOC(n); }
-	int main() { user = 1; return !INTERCEPTED(LOCAL()); }
+	int main(void) { user = 1; return !INTERCEPTED(LOCAL()); }
 	#endif
 }end
 
 tst	map_malloc note{ map malloc to _ast_malloc -- wimp-o mach? }end noexecute{
 	#if _map_malloc
-	int main() { return 0; }
+	int main(void) { return 0; }
 	#else
 	#include <stdlib.h>
 	void* calloc(size_t n, size_t m) { exit(1); }
-	int main() { return 0; }
+	int main(void) { return 0; }
 	#endif
 }end
 
@@ -89,14 +89,14 @@ lib	alloca note{ alloca exists }end link{
 	#include	<alloca.h>
 	#endif
 	int
-	main()
+	main(void)
 	{	alloca(10);
 	}
 }end
 
 tst	mal_alloca note{ alloca is based on malloc() }end execute{
 	#if __CYGWIN__ || __HAIKU__
-	int main() { return 1; }
+	int main(void) { return 1; }
 	#else
 	#if _hdr_alloca
 	#include	<alloca.h>
@@ -106,7 +106,7 @@ tst	mal_alloca note{ alloca is based on malloc() }end execute{
 	{	exit(0);
 		return 0;
 	}
-	int main()
+	int main(void)
 	{	alloca(10);
 		return 1;
 	}
@@ -114,7 +114,7 @@ tst	mal_alloca note{ alloca is based on malloc() }end execute{
 }end
 
 tst	stk_down note{ stack grows downward }end execute{
-	static int growdown()
+	static int growdown(void)
 	{	static char*	addr = 0;
 		char		array[4];
 		if(!addr)
@@ -125,7 +125,7 @@ tst	stk_down note{ stack grows downward }end execute{
 			return 0;
 		else	return 1;	
 	}
-	int main() { return growdown() ? 0 : 1; }
+	int main(void) { return growdown() ? 0 : 1; }
 }end
 
 tst	malloc_hook note{ GNU malloc hooks work }end execute{
@@ -169,7 +169,7 @@ tst	malloc_hook note{ GNU malloc hooks work }end execute{
 
 	void    (*__malloc_initialize_hook)(void) = test_initialize_hook;
 
-	int main()
+	int main(void)
 	{
 	        void*   p;
 

--- a/src/lib/libast/include/ast.h
+++ b/src/lib/libast/include/ast.h
@@ -266,14 +266,14 @@ typedef struct
 #define NoP(x)		do (void)(x); while(0)	/* for silencing "unused parameter" warnings */
 
 #if !defined(NoF)
-#define NoF(x)		void _DATA_ ## x () {}
+#define NoF(x)		void _DATA_ ## x (void) {}
 #if !defined(_DATA_)
 #define _DATA_
 #endif
 #endif
 
 #if !defined(NoN)
-#define NoN(x)		void _STUB_ ## x () {}
+#define NoN(x)		void _STUB_ ## x (void) {}
 #if !defined(_STUB_)
 #define _STUB_
 #endif

--- a/src/lib/libast/include/ast_windows.h
+++ b/src/lib/libast/include/ast_windows.h
@@ -31,6 +31,15 @@
 
 #undef	SF_ERROR			/* clash in <oaidl.h>		*/
 
+/*
+ * For some reason, DECLSPEC_NORETURN breaks when compiling with
+ * -std=c99. C11 does not have this problem, so for C99 and below
+ * avoid this problem by avoiding use of __declspec().
+ */
+#if __STDC_VERSION__ < 201112L
+#define DECLSPEC_NORETURN __attribute__((__noreturn__))
+#endif
+
 #include <windows.h>
 
 #endif

--- a/src/lib/libast/include/ast_windows.h
+++ b/src/lib/libast/include/ast_windows.h
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2023 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -37,8 +37,12 @@
  * avoid this problem by avoiding use of __declspec().
  */
 #if __STDC_VERSION__ < 201112L
+#if defined(__GNUC__) && (__GNUC__ > 2 || (__GNUC__ == 2 && __GNUC_MINOR__ > 4))
 #define DECLSPEC_NORETURN __attribute__((__noreturn__))
+#else
+#define DECLSPEC_NORETURN
 #endif
+#endif /* __STDC_VERSION__ */
 
 #include <windows.h>
 

--- a/src/lib/libast/man/tm.3
+++ b/src/lib/libast/man/tm.3
@@ -729,7 +729,7 @@ Low level support functions and data are described in
 .SH EXAMPLES
 .EX
 #include <tm.h>
-main() {
+int main(void) {
     int       i;
     time_t    t;
     char      buf[128];

--- a/src/lib/libast/man/tmx.3
+++ b/src/lib/libast/man/tmx.3
@@ -624,7 +624,7 @@ Low level support functions and data are described in
 .SH EXAMPLES
 .EX
 #include <tm.h>
-main() {
+int main(void) {
     int       i;
     time_t    t;
     char      buf[128];

--- a/src/lib/libast/misc/recfmt.c
+++ b/src/lib/libast/misc/recfmt.c
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 
@@ -138,24 +139,3 @@ recfmt(const void* buf, size_t size, off_t total)
 	free(q);
 	return n ? REC_F_TYPE(n) : REC_N_TYPE();
 }
-
-#if MAIN
-
-main()
-{
-	void*	s;
-	size_t	size;
-	off_t	total;
-
-	if (!(s = sfreserve(sfstdin, SF_UNBOUND, 0)))
-	{
-		sfprintf(sfstderr, "read error\n");
-		return 1;
-	}
-	size = sfvalue(sfstdin);
-	total = sfsize(sfstdin);
-	sfprintf(sfstdout, "%d\n", recfmt(s, size, total));
-	return 0;
-}
-
-#endif

--- a/src/lib/libast/port/astmath.c
+++ b/src/lib/libast/port/astmath.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2023 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 /*
@@ -31,7 +32,7 @@
 #include <math.h>
 
 int
-main()
+main(void)
 {
 #if N & 1
 	long double	value = 0;

--- a/src/lib/libast/port/mnt.c
+++ b/src/lib/libast/port/mnt.c
@@ -130,14 +130,6 @@ set(Header_t* hp, const char* fs, const char* dir, const char* type, const char*
 
 /*
  * 4.4 BSD getmntinfo
- *
- * what a crappy interface
- * data returned in static buffer -- ok
- * big chunk of allocated memory that cannot be freed -- come on
- * *and* NetBSD changed the interface somewhere along the line to a
- * private interface? par for the BSD course
- *
- * we assume getfsstat may suffer the same statfs/statvfs confusion
  */
 
 #include <sys/param.h>		/* expect some macro redefinitions here */

--- a/src/lib/libast/port/mnt.c
+++ b/src/lib/libast/port/mnt.c
@@ -134,8 +134,8 @@ set(Header_t* hp, const char* fs, const char* dir, const char* type, const char*
  * what a crappy interface
  * data returned in static buffer -- ok
  * big chunk of allocated memory that cannot be freed -- come on
- * *and* NetBSD changed the interface somewhere along the line
- * private interface? my bad -- public interface? par for the BSD course
+ * *and* NetBSD changed the interface somewhere along the line to a
+ * private interface? par for the BSD course
  *
  * we assume getfsstat may suffer the same statfs/statvfs confusion
  */

--- a/src/lib/libast/sfio/sfcvt.c
+++ b/src/lib/libast/sfio/sfcvt.c
@@ -49,6 +49,15 @@ static char		*Zero = "0";
 #if !_lib_isnanl
 #undef	isnanl
 #define isnanl(n)	isnan(n)
+#elif defined(__HAIKU__) && __STDC_VERSION__ >= 199901L
+/*
+ * On Haiku, no definition of isnanl() is provided by the math.h
+ * header file (at /boot/system/develop/headers/posix/math.h).
+ * As a result, using it causes an implicit function error that
+ * kills the build with C99. The fpclassify function works just
+ * fine, so that's used instead.
+ */
+#define isnanl(n)	(fpclassify(n)==FP_NAN)
 #endif
 #endif
 

--- a/src/lib/libast/sfio/sfsetbuf.c
+++ b/src/lib/libast/sfio/sfsetbuf.c
@@ -50,7 +50,7 @@ struct stat
 
 #if SFSETLINEMODE
 
-static int sfsetlinemode()
+static int sfsetlinemode(void)
 {	char*			astsfio;
 	char*			endw;
 

--- a/src/lib/libast/sfio/sftable.c
+++ b/src/lib/libast/sfio/sftable.c
@@ -479,7 +479,7 @@ static const unsigned char	ldbl_inf[] = { _ast_ldbl_inf_init };
 #endif
 
 /* function to initialize conversion tables */
-static int sfcvinit()
+static int sfcvinit(void)
 {	int		d, l;
 
 	for(d = 0; d <= SF_MAXCHAR; ++d)

--- a/src/lib/libast/tm/tvsleep.c
+++ b/src/lib/libast/tm/tvsleep.c
@@ -15,9 +15,11 @@
 *                     Phong Vo <phongvo@gmail.com>                     *
 *                  Martijn Dekker <martijn@inlv.org>                   *
 *                  Lev Kujawski <int21h@mailbox.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 
+#include <ast.h>
 #include <assert.h>
 #include <tv.h>
 #include <tm.h>

--- a/src/lib/libast/tm/tvtouch.c
+++ b/src/lib/libast/tm/tvtouch.c
@@ -14,6 +14,7 @@
 *                    David Korn <dgkorn@gmail.com>                     *
 *                     Phong Vo <phongvo@gmail.com>                     *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 /*
@@ -24,10 +25,6 @@
  */
 
 #define utime		______utime
-
-#ifndef _ATFILE_SOURCE
-#define _ATFILE_SOURCE	1
-#endif
 
 #include <ast.h>
 #include <ls.h>

--- a/src/lib/libast/vmalloc/malloc.c
+++ b/src/lib/libast/vmalloc/malloc.c
@@ -279,7 +279,7 @@ static void addfreelist(Regfree_t* data)
 	}
 }
 
-static void clrfreelist()
+static void clrfreelist(void)
 {
 	Regfree_t	*list, *next;
 	Vmalloc_t	*vm;

--- a/src/lib/libast/vmalloc/vmdebug.c
+++ b/src/lib/libast/vmalloc/vmdebug.c
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 
@@ -48,7 +49,7 @@ static void*	Dbwatch[S_WATCH];
 
 static int Dbinit = 0;
 #define DBINIT()	(Dbinit ? 0 : (dbinit(), Dbinit=1) )
-static void dbinit()
+static void dbinit(void)
 {	int	fd;	
 	if((fd = vmtrace(-1)) >= 0)
 		vmtrace(fd);

--- a/src/lib/libcmd/features/symlink
+++ b/src/lib/libcmd/features/symlink
@@ -3,7 +3,7 @@ lib	lchmod note{ lchmod implemented }end execute{
 	#include <sys/stat.h>
 	#include <errno.h>
 	int
-	main()
+	main(void)
 	{
 		lchmod("No-FiLe", 0);
 		return errno != ENOENT;
@@ -15,7 +15,7 @@ lib	lchown note{ lchown implemented }end execute{
 	#include <sys/stat.h>
 	#include <errno.h>
 	int
-	main()
+	main(void)
 	{
 		lchown("No-FiLe", 0, 0);
 		return errno != ENOENT;

--- a/src/lib/libdll/features/dll
+++ b/src/lib/libdll/features/dll
@@ -7,7 +7,7 @@ tst	dll_DYNAMIC link{
 	#include <link.h>
 	extern struct link_dynamic _DYNAMIC;
 	int
-	main()
+	main(void)
 	{
 		return _DYNAMIC.ld_version;
 	}
@@ -87,7 +87,7 @@ tst	- -lm - - output{
 	#include <rld_interface.h>
 	#endif
 	int
-	main()
+	main(void)
 	{
 		int		i;
 	#if _hdr_rld_interface


### PR DESCRIPTION
This pull request fixes compilation of ksh with strict C99 and strict C11. It has been tested on the following operating systems (amd64):
- Arch Linux (w/ glibc 2.37)
- Void Linux (w/ musl libc 1.1.24)
- FreeBSD 13.2
- DragonFly BSD 6.4
- NetBSD 9.3
- OpenBSD 7.3
- OmniOS CE r151046
- Haiku R1/beta4

Additionally, -std=c11 has been fixed on Cygwin, ~but due to some sort of bug or incompatibility in the Win32 API -std=c99 doesn't compile:~ -std=c99 is now fixed on Cygwin, see latest commit.

The following operating systems have not been tested yet, as I currently don't have access to any of them:
- ~macOS~ Tested by @pghvlaans.
- ~Oracle Solaris~ Tested by @McDutchie.
- ~QNX~ Tested by @McDutchie.
- HP/UX
- AIX
- UnixWare

For testing, I used a cc wrapper that passes all the required compiler flags. Example script:
```sh
#!/bin/sh
# Note: Don't extend the argument list to multiple lines with \
exec cc -std=c99 -Werror=implicit-function-declaration -Werror=implicit-int -Werror=int-conversion -Werror=old-style-definition "$@"
```
The compilers tested consist of many versions of gcc, ranging from GCC 8 up to the current 14.0 git commit. In a similar vein, Clang has been tested on versions ranging from 13.0.0 to the current 17.0 git commit; tcc's latest git commit was also tested.

Changes:
- Removed all old style function definitions and updated them for compatibility with C99 and C23. This is primarily done by changing e.g. `int main()` to `int main(void)`. There were also a few obsolete K&R C constructs that needed modernization.

- Fixed the avalanche of -Wbuiltin-macro-redefined warnings in LLVM 17. Clang 17 (git version) was spamming the terminal with an avalanche of -Wbuiltin-macro-redefined warnings during the build. This was caused by pre-existing hackery that force defined -Os in the C code itself. This is unnecessary and thus the best way to fix the warning avalanche is to remove the macro hackery.

- Fixed mamake compile when using -std=c*. The mamake compile broke because POSIX functionality was disabled by the compiler flag. Code from src/lib/libast/features/standards for enabling feature macros has been reused here to fix the build with -std=c99.

- The build failed in tvsleep.c because of borked header includes. Fixed easily enough by adding an include for ast.h (and updating the requisite mamfile).

- Removed incorrect usage of `_ATFILE_SOURCE`. When compiling on Linux with Clang 17, iffe failed to detect the utimensat function correctly. This was caused by blatantly incorrect usage of `_ATFILE_SOURCE`. If this actually needed to be defined, the correct location for it is in src/lib/libast/features/standards. However, the current macros enable this by default on illumos and glibc 2.10+ via `__EXTENSIONS__` and `_GNU_SOURCE` respectively, making it at best redundant to manually define it, or (in this case) harmful.

- Fixed -std=c99 on NetBSD by avoiding the getfsstat function. The getfsstat function is only provided on NetBSD for binary compatibility and nothing else. As a result, it is not exposed in the headers and using it will cause an implicit function error, killing the build with C99. Iffe detects this function because it does exist on NetBSD, and the comments in mnt.c imply this is intentional. Despite that, using the function on NetBSD via an implicit call is impossible in C99, the function is deprecated, and we don't actually need to use it, so it's best to just avoid getfsstat by undefining the iffe macro for it.

- Fix compiling with -std=c99 on Haiku. On Haiku, the math.h header doesn't have an extern or definition for isnanl, which causes the build to fail with C99. The fpclassify function works just fine, so that's a better choice here than isnanl.

- Removed an unused program from src/lib/libast/misc/recfmt.c that suffered from bitrot.

- Since quite a few operating systems were tested as of this commit, the list of tested operating systems in src/cmd/ksh93/README has been updated to reflect this.

Resolves: https://github.com/ksh93/ksh/issues/587