### PR TITLE
Prevent other ksh93 sessions from interfering with the full editor

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,12 @@ This documents significant changes in the dev branch of ksh 93u+m.
 For full details, see the git log at: https://github.com/ksh93/ksh
 Uppercase BUG_* IDs are shell bug IDs as used by the Modernish shell library.
 
+2023-06-12:
+
+- Fixed a bug where ^X^E in emacs or 'v' in vi, which invoke a full-screen
+  editor to edit the command line, could cause the wrong command line to be
+  edited if two shell sessions share a .sh_history file.
+
 2023-06-09:
 
 - Fixed a bug where the 'break' and 'continue' commands stopped working after

--- a/src/cmd/ksh93/edit/emacs.c
+++ b/src/cmd/ksh93/edit/emacs.c
@@ -1259,6 +1259,12 @@ static void xcommands(Emacs_t *ep,int count)
 					drawbuff[eol+1] = '\0';
 				}
 			}
+			if(hline == histlines && sh.hist_ptr)
+			{
+				hist_eof(sh.hist_ptr);
+				histlines = (int)sh.hist_ptr->histind;
+				hline = histlines;
+			}
 			if(ed_fulledit(ep->ed)==-1)
 				beep();
 			else

--- a/src/cmd/ksh93/edit/emacs.c
+++ b/src/cmd/ksh93/edit/emacs.c
@@ -1259,6 +1259,9 @@ static void xcommands(Emacs_t *ep,int count)
 					drawbuff[eol+1] = '\0';
 				}
 			}
+			/* If hist_eof is not used here, activity in a
+			 * separate session could result in the wrong
+			 * line being edited. */
 			if(hline == histlines && sh.hist_ptr)
 			{
 				hist_eof(sh.hist_ptr);

--- a/src/cmd/ksh93/edit/emacs.c
+++ b/src/cmd/ksh93/edit/emacs.c
@@ -1267,6 +1267,8 @@ static void xcommands(Emacs_t *ep,int count)
 				hist_eof(sh.hist_ptr);
 				histlines = (int)sh.hist_ptr->histind;
 				hline = histlines;
+				if(histlines >= sh.hist_ptr->histsize)
+					hist_flush(sh.hist_ptr);
 			}
 			if(ed_fulledit(ep->ed)==-1)
 				beep();

--- a/src/cmd/ksh93/edit/vi.c
+++ b/src/cmd/ksh93/edit/vi.c
@@ -694,6 +694,12 @@ static int cntlmode(Vi_t *vp)
 			}
 
 		vcommand:
+			if(curhline == histmax && sh.hist_ptr)
+			{
+				hist_eof(sh.hist_ptr);
+				histmax = (int)sh.hist_ptr->histind;
+				curhline = histmax;
+			}
 			if(ed_fulledit(vp->ed)==GOOD)
 				return BIGVI;
 			else

--- a/src/cmd/ksh93/edit/vi.c
+++ b/src/cmd/ksh93/edit/vi.c
@@ -694,6 +694,9 @@ static int cntlmode(Vi_t *vp)
 			}
 
 		vcommand:
+			/* If hist_eof is not used here, activity in a
+			 * separate session could result in the wrong
+			 * line being edited. */
 			if(curhline == histmax && sh.hist_ptr)
 			{
 				hist_eof(sh.hist_ptr);

--- a/src/cmd/ksh93/edit/vi.c
+++ b/src/cmd/ksh93/edit/vi.c
@@ -702,6 +702,8 @@ static int cntlmode(Vi_t *vp)
 				hist_eof(sh.hist_ptr);
 				histmax = (int)sh.hist_ptr->histind;
 				curhline = histmax;
+				if(histmax >= sh.hist_ptr->histsize)
+					hist_flush(sh.hist_ptr);
 			}
 			if(ed_fulledit(vp->ed)==GOOD)
 				return BIGVI;

--- a/src/cmd/ksh93/sh.1
+++ b/src/cmd/ksh93/sh.1
@@ -5301,6 +5301,11 @@ characters undoes this change.
 .BI ^Y
 Restore last item removed from line. (Yank item back to the line.)
 .TP 10
+.BI ^X^E
+Return the command 
+.BI "hist \-e ${\s-1VISUAL\s+1:\-${\s-1EDITOR\s+1:\-vi}}"
+in the input buffer.
+.TP 10
 .BI ^L
 Line feed and print current line.
 .TP 10

--- a/src/cmd/ksh93/sh.1
+++ b/src/cmd/ksh93/sh.1
@@ -5305,6 +5305,9 @@ Restore last item removed from line. (Yank item back to the line.)
 Return the command 
 .BI "hist \-e ${\s-1VISUAL\s+1:\-${\s-1EDITOR\s+1:\-vi}}"
 in the input buffer.
+(See
+.I "Command Re-entry\^"
+above.)
 .TP 10
 .BI ^L
 Line feed and print current line.
@@ -6066,6 +6069,9 @@ in the input buffer.
 If
 .I count\^
 is omitted, then the current line is used.
+(See
+.I "Command Re-entry\^"
+above.)
 .TP 10
 .BI ^L
 Line feed and print current line.

--- a/src/cmd/ksh93/sh.1
+++ b/src/cmd/ksh93/sh.1
@@ -5301,14 +5301,6 @@ characters undoes this change.
 .BI ^Y
 Restore last item removed from line. (Yank item back to the line.)
 .TP 10
-.BI ^X^E
-Return the command 
-.BI "hist \-e ${\s-1VISUAL\s+1:\-${\s-1EDITOR\s+1:\-vi}}"
-in the input buffer.
-(See
-.I "Command Re-entry\^"
-above.)
-.TP 10
 .BI ^L
 Line feed and print current line.
 .TP 10
@@ -6069,9 +6061,6 @@ in the input buffer.
 If
 .I count\^
 is omitted, then the current line is used.
-(See
-.I "Command Re-entry\^"
-above.)
 .TP 10
 .BI ^L
 Line feed and print current line.


### PR DESCRIPTION
In both line editors, it is possible to run the full editor on an unexpected command if more than one shell session is running simultaneously. To reproduce:

* Open two `ksh` sessions
* In one session, enter any command or comment.
* In the other session, without reaching a new line or using history navigation, attempt the full editor command.

The command entered in the first session will appear in the editor window rather than the contents of the command line in the second session. This happens because the history line in the second session is overwritten by the first session. Annoyance aside, the behavior could also easily result in an unexpected command being run (if, on seeing unexpected output, the user instinctively quits the editor without saving, for example). 

* {emacs,vi}.c: In case another shell session has used the current history line, when on the last history line, use `hist_eof` and adjust the maximum line and current line before calling `ed_fulledit`. In addition, use `hist_flush` before `ed_fulledit` if the history line is at least as high as `histsize`.