### PR TITLE
emacs.c: Suppress hist output to command line with ^X^E.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,8 @@ Uppercase BUG_* IDs are shell bug IDs as used by the Modernish shell library.
   editor to edit the command line, could cause the wrong command line to be
   edited if two shell sessions share a .sh_history file.
 
+- In the emacs line editor, ^X^E no longer echos the hist command it invokes.
+
 2023-06-10:
 
 - Ksh can now compile on most operating systems when using -std=c99 in CCFLAGS.

--- a/src/cmd/ksh93/edit/emacs.c
+++ b/src/cmd/ksh93/edit/emacs.c
@@ -114,6 +114,7 @@ typedef struct _emacs_
 	char	scvalid;	/* Screen is up to date */
 	char	lastdraw;	/* last update type */
 	int	offset;		/* Screen offset */
+	char	ehist;		/* hist handling required */
 	enum
 	{
 		CRT=0,	/* Crt terminal */
@@ -205,6 +206,7 @@ int ed_emacsread(void *context, int fd,char *buff,int scend, int reedit)
 	Prompt = prompt;
 	ep->screen = Screen;
 	ep->lastdraw = FINAL;
+	ep->ehist = 0;
 	if(tty_raw(ERRIO,0) < 0)
 	{
 		 return reedit ? reedit : ed_read(context,fd,buff,scend,0);
@@ -705,7 +707,10 @@ process:
 		beep();
 		*out = '\0';
 	}
-	draw(ep,FINAL);
+	if (!ep->ehist)
+		draw(ep,FINAL);
+	else
+		ep->ehist = 0;
 	tty_cooked(ERRIO);
 	if(ed->e_nlist)
 		ed->e_nlist = 0;
@@ -1259,8 +1264,12 @@ static void xcommands(Emacs_t *ep,int count)
 					drawbuff[eol+1] = '\0';
 				}
 			}
+			ep->ehist = 1;
 			if(ed_fulledit(ep->ed)==-1)
+			{
+				ep->ehist = 0;
 				beep();
+			}
 			else
 			{
 #if SHOPT_MULTIBYTE

--- a/src/cmd/ksh93/edit/emacs.c
+++ b/src/cmd/ksh93/edit/emacs.c
@@ -707,6 +707,7 @@ process:
 		beep();
 		*out = '\0';
 	}
+	/* ep->ehist: do not print the literal hist command after ^X^E. */
 	if (!ep->ehist)
 		draw(ep,FINAL);
 	else
@@ -1264,6 +1265,7 @@ static void xcommands(Emacs_t *ep,int count)
 					drawbuff[eol+1] = '\0';
 				}
 			}
+			/* Do not print the literal hist command. */
 			ep->ehist = 1;
 			if(ed_fulledit(ep->ed)==-1)
 			{

--- a/src/cmd/ksh93/sh.1
+++ b/src/cmd/ksh93/sh.1
@@ -5301,6 +5301,13 @@ characters undoes this change.
 .BI ^Y
 Restore last item removed from line. (Yank item back to the line.)
 .TP 10
+.BI ^X^E
+Return the command
+.BI "hist \-e ${\s-1VISUAL\s+1:\-${\s-1EDITOR\s+1:\-vi}}"
+in the input buffer to call a full editor \(em
+.BI vi
+by default \(em on the current command line.
+.TP 10
 .BI ^L
 Line feed and print current line.
 .TP 10
@@ -6057,7 +6064,9 @@ Undo all the text modifying commands performed on the line.
 [\f2count\fP]\f3v\fP
 Returns the command
 .BI "hist \-e ${\s-1VISUAL\s+1:\-${\s-1EDITOR\s+1:\-vi}}" " count"
-in the input buffer.
+in the input buffer to call a full editor \(em
+.BI vi
+by default \(em on a history entry.
 If
 .I count\^
 is omitted, then the current line is used.


### PR DESCRIPTION
Issue #563.

The function `ed_fulledit` operates by writing the appropriate `hist` command to the input buffer. In emacs mode, this results in the full `hist` command being printed to the command line and remaining there. This behavior does not occur in other shells, and can safely be considered a bug. The output can be suppressed, however, by not using `draw` with the option `FINAL` after `^X^E`:

* `emacs.c`: Add a variable `ehist` to `_emacs_` and initialize to 0; it is set to 1 by the `^X^E` command, suppressing the use of `draw(ep,FINAL)` in `ed_emacsread`. This prevents the altered input buffer from being displayed onscreen.