### PR TITLE
Fix problems in relation to Fedora's C99 instrumentation

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,11 @@ This documents significant changes in the dev branch of ksh 93u+m.
 For full details, see the git log at: https://github.com/ksh93/ksh
 Uppercase BUG_* IDs are shell bug IDs as used by the Modernish shell library.
 
+2023-06-30:
+
+- Fixed a minor bug that could cause '/opt/ast/bin/getconf PID_MAX' to
+  return the wrong value when ksh is built with strict C99.
+
 2023-06-13:
 
 - Fixed a serious regression in pathname expansion where quoted wildcard

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -18,7 +18,7 @@
 
 #define SH_RELEASE_FORK	"93u+m"		/* only change if you develop a new ksh93 fork */
 #define SH_RELEASE_SVER	"1.1.0-alpha"	/* semantic version number: https://semver.org */
-#define SH_RELEASE_DATE	"2023-06-14"	/* must be in this format for $((.sh.version)) */
+#define SH_RELEASE_DATE	"2023-06-30"	/* must be in this format for $((.sh.version)) */
 #define SH_RELEASE_CPYR	"(c) 2020-2023 Contributors to ksh " SH_RELEASE_FORK
 
 /* Scripts sometimes field-split ${.sh.version}, so don't change amount of whitespace. */

--- a/src/lib/libast/comp/conf.tab
+++ b/src/lib/libast/comp/conf.tab
@@ -390,6 +390,9 @@ PBS_MESSAGE			POSIX	SC 2 FUW
 PBS_TRACK			POSIX	SC 2 FUW
 PHYS_PAGES			SUN	SC 1 0
 PID_MAX				SVID	SC 1 LMU	30000	cc{
+	#include <fcntl.h>
+	#include <stdio.h>
+	#include <stdlib.h>
 	int main(void)
 	{
 		long	v;

--- a/src/lib/libast/features/lib
+++ b/src/lib/libast/features/lib
@@ -68,7 +68,7 @@ tst	tst_errno note{ errno can be assigned }end link{
 	int main(void) { errno = 0; error(); strerror(); return 0; }
 }end
 
-tst	lib_poll_fd_1 note{ fd is first arg to poll() }end execute{
+tst	lib_poll note{ poll() args comply with the POSIX standard }end execute{
 	#include <poll.h>
 	#include <unistd.h>
 	extern int	pipe(int*);
@@ -86,28 +86,6 @@ tst	lib_poll_fd_1 note{ fd is first arg to poll() }end execute{
 		return 0;
 	}
 }end
-
-tst	lib_poll_fd_2 note{ fd is second arg to poll() }end execute{
-	#include <poll.h>
-	#include <unistd.h>
-	extern int	pipe(int*);
-	int
-	main(void)
-	{	int		rw[2];
-		struct pollfd	fd;
-		if (pipe(rw) < 0) return 1;
-		fd.fd = rw[0];
-		fd.events = POLLIN;
-		fd.revents = 0;
-		return poll(1, &fd, 0) < 0;
-		if (poll(1, &fd, 0) < 0 || fd.revents != 0) return 1;
-		if (write(rw[1], "x", 1) != 1) return 1;
-		if (poll(1, &fd, 0) < 0 || fd.revents == 0) return 1;
-		return 0;
-	}
-}end
-
-exp	_lib_poll	_lib_poll_fd_1||_lib_poll_fd_2
 
 tst	lib_poll_notimer note{ poll with no fds ignores timeout }end execute{
 	#include <sys/types.h>

--- a/src/lib/libast/sfio/sfhdr.h
+++ b/src/lib/libast/sfio/sfhdr.h
@@ -103,21 +103,12 @@
 #if _sys_select
 #include	<sys/select.h>
 #endif
-#else
-#if _lib_poll_fd_1 || _lib_poll_fd_2
-#define _lib_poll	1
-#endif
 #endif /*_lib_select_*/
 
 #if _lib_poll
 #include	<poll.h>
-
-#if _lib_poll_fd_1
 #define SFPOLL(pfd,n,tm)	poll((pfd),(ulong)(n),(tm))
-#else
-#define SFPOLL(pfd,n,tm)	poll((ulong)(n),(pfd),(tm))
 #endif
-#endif /*_lib_poll*/
 
 #if _stream_peek
 #include	<stropts.h>


### PR DESCRIPTION
This pull request applies the necessary changes to the ksh codebase to (hopefully) fix C99 compilation when using Red Hat't instrumented GCC (cf. https://fedoraproject.org/wiki/Toolchain/PortingToModernC, though note that a patch to redhat-rpm-config is also required and must be applied separately, see https://github.com/ksh93/ksh/issues/664#issuecomment-1608870665). Seeing as my [previous attempt](https://github.com/ksh93/ksh/pull/657) did not fully fix this problem, I would like @vmihalko to confirm that this pull request + the patch to redhat-rpm-config successfully fix the build errors that occur when building ksh with C99.

List of changes in the pull request:

src/lib/libast/comp/conf.tab:
\- Add include directives to fix implicit function declarations that cause the PID_MAX test to silently fail. This compile error occurs on all platforms when compiling with strict C99, but wasn't exposed even after setting IFFEFLAGS to -d1 or -d2 (that's likely a separate bug in conf.sh that'll need fixing). As a consequence, it could cause following bug in the getconf builtin (now fixed as of this commit):
```sh
$ /opt/ast/bin/getconf PID_MAX
30000  # Wrong, should be the platform value (e.g., 4194304)
```

src/lib/libast/{features/lib,sfio/sfhdr.h}:
\- Delete the lib_poll_fd_2 feature test and associated code, which allowed ksh to used non-compliant implementations of poll(3). This feature test fails on POSIX-compliant systems with int-conversion errors, which is the expected result. However, the C99 instrumentation used by Red Hat marks the entire build as a failure because of the fact those errors exist at all, even though the build proceeds as normal. Fortunately, the operating systems supported by ksh (afaik) all have proper, POSIX-compliant versions of poll() and thus don't need this test. To work around the flawed instrumentation, the unnecessary test has been jettisoned.

Note that the changes to ksh listed above **do not** fix all the errors. The remaining implicit function errors are caused by the incomplete exception list in redhat-rpm-config, which doesn't include the necessary functions ksh tests for. That must be fixed in redhat-rpm-config, not ksh. A patch which adds the required exceptions to the Lua script can be found in the following comment:
https://github.com/ksh93/ksh/issues/664#issuecomment-1608870665

After applying the patch, the Lua script (which can be run via `/usr/lib/rpm/redhat/report-gcc-errors.sh`) will ignore the implicit function errors that are expected to occur in the feature tests, which (after fixing conf.tab and _lib_poll) should allow the build to succeed with Red Hat's instrumentation.