### PR TITLE
libast/tm: Check for date-appropriate time zones (printf %T)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -10,6 +10,9 @@ Uppercase BUG_* IDs are shell bug IDs as used by the Modernish shell library.
 - Fixed a minor bug that could cause '/opt/ast/bin/getconf PID_MAX' to
   return the wrong value when ksh is built with strict C99.
 
+- Fixed a bug in printf %T: when using dates and times in the past, time
+  zones for the present were incorrectly used, ignoring historical changes.
+
 2023-06-13:
 
 - Fixed a serious regression in pathname expansion where quoted wildcard

--- a/src/cmd/ksh93/tests/printf.sh
+++ b/src/cmd/ksh93/tests/printf.sh
@@ -213,12 +213,12 @@ function do_test # 1:LINENO 2:printf-STRING 3:match-string
 format='%Y-%m-%d %H:%M:%S %z'
 export TZ=Europe/Istanbul
 
-C='Historical changes: time' # https://github.com/ksh93/ksh/issues/669
+C='Historical changes (bad time)' # https://github.com/ksh93/ksh/issues/669
 T '#236961303'				'1977-07-05 17:35:03 +0300'
 
 format='%Y-%m-%d %H:%M:%S %Z'
 
-C='Historical changes: zone name'
+C='Historical changes (bad zone name)'
 T '#0'					'1970-01-01 02:00:00 EET'
 
 format='%Y-%m-%d'

--- a/src/cmd/ksh93/tests/printf.sh
+++ b/src/cmd/ksh93/tests/printf.sh
@@ -210,16 +210,14 @@ function do_test # 1:LINENO 2:printf-STRING 3:match-string
 }
 
 # The first tests require a time zone with one or more historical changes.
-format='%Y-%m-%d %H:%M:%S %z'
-export TZ=Europe/Istanbul
+format='%Y-%m-%d %H:%M:%S'
+export TZ=Europe/Riga
 
 C='Historical changes (bad time)' # https://github.com/ksh93/ksh/issues/669
-T '#236961303'				'1977-07-05 17:35:03 +0300'
+T '#236961303'				'1977-07-05 17:35:03'
 
-format='%Y-%m-%d %H:%M:%S %Z'
-
-C='Historical changes (bad zone name)'
-T '#0'					'1970-01-01 02:00:00 EET'
+export TZ=Europe/London
+T '#0'					'1970-01-01 01:00:00'
 
 format='%Y-%m-%d'
 export TZ=UTC

--- a/src/cmd/ksh93/tests/printf.sh
+++ b/src/cmd/ksh93/tests/printf.sh
@@ -209,12 +209,17 @@ function do_test # 1:LINENO 2:printf-STRING 3:match-string
 		"expected $(printf %q "$3"), got $(printf %q "$got")"
 }
 
-# The first test requires a time zone with one or more historical changes.
-format='%Y-%m-%d %H:%M:%S %Z'
+# The first tests require a time zone with one or more historical changes.
+format='%Y-%m-%d %H:%M:%S %z'
 export TZ=Europe/Istanbul
 
-C='Historical changes' # https://github.com/ksh93/ksh/issues/669
-T '#236961303'				'1977-07-05 17:35:03 EEST'
+C='Historical changes: time' # https://github.com/ksh93/ksh/issues/669
+T '#236961303'				'1977-07-05 17:35:03 +0300'
+
+format='%Y-%m-%d %H:%M:%S %Z'
+
+C='Historical changes: zone name'
+T '#0'					'1970-01-01 02:00:00 EET'
 
 format='%Y-%m-%d'
 export TZ=UTC

--- a/src/cmd/ksh93/tests/printf.sh
+++ b/src/cmd/ksh93/tests/printf.sh
@@ -202,8 +202,6 @@ unset x f
 # Tests for printf %T with relative date spec and 'exact' keyword
 # https://github.com/ksh93/ksh/issues/182
 
-export TZ=UTC
-
 # Check printf against a string
 function do_test # 1:LINENO 2:printf-STRING 3:match-string
 {	printf -v got "%($format)T" "$2"
@@ -211,7 +209,15 @@ function do_test # 1:LINENO 2:printf-STRING 3:match-string
 		"expected $(printf %q "$3"), got $(printf %q "$got")"
 }
 
+# The first test requires a time zone with one or more historical changes.
+format='%Y-%m-%d %H:%M:%S %Z'
+export TZ=Europe/Istanbul
+
+C='Historical changes' # https://github.com/ksh93/ksh/issues/669
+T '#236961303'				'1977-07-05 17:35:03 EEST'
+
 format='%Y-%m-%d'
+export TZ=UTC
 
 C='Calendar dates'
 T '2020-01-14'				'2020-01-14'

--- a/src/cmd/ksh93/tests/printf.sh
+++ b/src/cmd/ksh93/tests/printf.sh
@@ -12,6 +12,7 @@
 #                                                                      #
 #                      Phi <phi.debian@gmail.com>                      #
 #                  Martijn Dekker <martijn@inlv.org>                   #
+#               K. Eugene Carlson <kvngncrlsn@gmail.com>               #
 #                                                                      #
 ########################################################################
 

--- a/src/lib/libast/comp/strptime.c
+++ b/src/lib/libast/comp/strptime.c
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*               K. Eugene Carlson <kvngncrlsn@gmail.com>               *
 *                                                                      *
 ***********************************************************************/
 /*

--- a/src/lib/libast/comp/strptime.c
+++ b/src/lib/libast/comp/strptime.c
@@ -58,7 +58,7 @@ strptime(const char* s, const char* format, struct tm* ts)
 	t = tmscan(s, &e, format, &f, &t, 0);
 	if (e == (char*)s || *f)
 		return NULL;
-	tmxtm(&tm, tmxclock(&t), NULL);
+	tmxtm(&tm, tmxclock(&t), NULL, 0);
 	ts->tm_sec = tm.tm_sec;
 	ts->tm_min = tm.tm_min;
 	ts->tm_hour = tm.tm_hour;

--- a/src/lib/libast/features/api
+++ b/src/lib/libast/features/api
@@ -1,6 +1,6 @@
 iff AST_API
 
-ver ast 20220801
+ver ast 20230909
 
 api ast 20120528 regexec regnexec regrexec regsubexec
 

--- a/src/lib/libast/features/lib
+++ b/src/lib/libast/features/lib
@@ -50,6 +50,7 @@ mem	dirent.d_fileno,dirent.d_ino,dirent.d_namlen,dirent.d_off,dirent.d_reclen,di
 mem	DIR sys/types.h - dirent.h - sys/dir.h
 mem	DIR.dd_fd sys/types.h - dirent.h - sys/dir.h
 mem	inheritance.pgroup spawn.h
+mem	tm.tm_zone time.h
 
 sys	dir,filio,jioctl,localedef,ptem,resource
 sys	socket,stream,systeminfo,universe

--- a/src/lib/libast/features/tmx
+++ b/src/lib/libast/features/tmx
@@ -88,7 +88,7 @@ cat{
 	extern Time_t		tmxscan(const char*, char**, const char*, char**, Time_t, long);
 	extern int		tmxsleep(Time_t);
 	extern Time_t		tmxtime(Tm_t*, int);
-	extern Tm_t*		tmxtm(Tm_t*, Time_t, Tm_zone_t*);
+	extern Tm_t*		tmxtm(Tm_t*, Time_t, Tm_zone_t*, const char);
 
 	extern Time_t		tmxgettime(void);
 	extern int		tmxsettime(Time_t);

--- a/src/lib/libast/include/tm.h
+++ b/src/lib/libast/include/tm.h
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2023 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*               K. Eugene Carlson <kvngncrlsn@gmail.com>               *
 *                                                                      *
 ***********************************************************************/
 /*
@@ -26,7 +27,7 @@
 #ifndef _TM_H
 #define _TM_H
 
-#define TM_VERSION	20070319L
+#define TM_VERSION	20230909L
 
 #include <ast.h>
 #include <times.h>

--- a/src/lib/libast/include/tm.h
+++ b/src/lib/libast/include/tm.h
@@ -33,7 +33,7 @@
 
 #undef	daylight
 
-#define tmset(z)	tminit(z)
+#define tmset(x, y, z)	tminit(x, y, z)
 #define tmisleapyear(y)	(!((y)%4)&&(((y)%100)||!((((y)<1900)?((y)+1900):(y))%400)))
 
 #define TM_ADJUST	(1<<0)		/* local doesn't do leap secs	*/
@@ -156,7 +156,7 @@ extern Tm_t*		tmfix(Tm_t*);
 extern char*		tmfmt(char*, size_t, const char*, time_t*);
 extern char*		tmform(char*, const char*, time_t*);
 extern int		tmgoff(const char*, char**, int);
-extern void		tminit(Tm_zone_t*);
+extern void		tminit(Tm_zone_t*, time_t, const char);
 extern time_t		tmleap(time_t*);
 extern int		tmlex(const char*, char**, char**, int, char**, int);
 extern char**		tmlocale(void);

--- a/src/lib/libast/man/tm.3
+++ b/src/lib/libast/man/tm.3
@@ -494,7 +494,7 @@ to override the default.
 .PD
 .RE
 .TP
-.L "void tminit(Tm_zone_t* zone)"
+.L "void tminit(Tm_zone_t* zone, time_t now, const char newzone)"
 Implicitly called by the other
 .I tm
 library routines to initialize global data, including the
@@ -508,14 +508,18 @@ If
 .L "zone != 0"
 then it specifies a time zone other that the local time zone.
 .TP
-.L "void tmset(Tm_zone_t* zone);"
+.L "void tmset(Tm_zone_t* zone, time_t now, const char newzone);"
 .L tmset
 sets the reference timezone to
 .LR zone .
 .L tm_info.local
 points to the local timezone and
 .L tm_info.zone
-points to the current reference timezone.
+points to the reference timezone at a given time
+.L now
+if
+.L newzone
+is non-zero, or to the current reference timezone otherwise.
 .TP
 .L "time_t tmleap(time_t* clock)"
 Returns a

--- a/src/lib/libast/man/tmx.3
+++ b/src/lib/libast/man/tmx.3
@@ -461,7 +461,7 @@ to override the default.
 .PD
 .RE
 .TP
-.L "void tminit(Tm_zone_t* zone)"
+.L "void tminit(Tm_zone_t* zone, time_t now, const char newzone)"
 Implicitly called by the other
 .I tm
 library routines to initialize global data, including the
@@ -475,14 +475,18 @@ If
 .L "zone != 0"
 then it specifies a time zone other that the local time zone.
 .TP
-.L "void tmset(Tm_zone_t* zone);"
+.L "void tmset(Tm_zone_t* zone, time_t now, const char newzone);"
 .L tmset
 sets the reference timezone to
 .LR zone .
 .L tm_info.local
 points to the local timezone and
 .L tm_info.zone
-points to the current reference timezone.
+points to the reference timezone at a given time
+.L now
+if
+.L newzone
+is non-zero, or to the current reference timezone otherwise.
 .TP
 .L "time_t tmleap(time_t* clock)"
 Returns a

--- a/src/lib/libast/tm/tminit.c
+++ b/src/lib/libast/tm/tminit.c
@@ -15,6 +15,7 @@
 *                     Phong Vo <phongvo@gmail.com>                     *
 *                  Martijn Dekker <martijn@inlv.org>                   *
 *            Johnothan King <johnothanking@protonmail.com>             *
+*               K. Eugene Carlson <kvngncrlsn@gmail.com>               *
 *                                                                      *
 ***********************************************************************/
 /*

--- a/src/lib/libast/tm/tminit.c
+++ b/src/lib/libast/tm/tminit.c
@@ -143,7 +143,7 @@ tzwest(time_t* clock, int* isdst)
 	 */
 
 	tp = tmlocaltime(clock);
-#ifdef __USE_MISC
+#if _mem_tm_zone_tm
 	if (tp->tm_zone && !tz_abbr)
 		tz_abbr = strdup(tp->tm_zone);
 #endif

--- a/src/lib/libast/tm/tminit.c
+++ b/src/lib/libast/tm/tminit.c
@@ -143,7 +143,7 @@ tzwest(time_t* clock, int* isdst)
 	 */
 
 	tp = tmlocaltime(clock);
-#ifdef tp->tm_zone
+#ifdef __USE_MISC
 	if (tp->tm_zone && !tz_abbr)
 		tz_abbr = strdup(tp->tm_zone);
 #endif
@@ -206,6 +206,9 @@ tmlocal(time_t now)
 	char			buf[16];
 
 	static Tm_zone_t	local;
+
+	local.standard = 0;
+	local.daylight = 0;
 
 #if _tzset_environ
 	{

--- a/src/lib/libast/tm/tminit.c
+++ b/src/lib/libast/tm/tminit.c
@@ -186,7 +186,7 @@ tmopt(void* a, const void* p, int n, const char* v)
  */
 
 static void
-tmlocal(void)
+tmlocal(time_t now)
 {
 	Tm_zone_t*		zp;
 	int			n;
@@ -197,7 +197,6 @@ tmlocal(void)
 	int			isdst;
 	char*			t;
 	struct tm*		tp;
-	time_t			now;
 	char			buf[16];
 
 	static Tm_zone_t	local;
@@ -238,7 +237,6 @@ tmlocal(void)
 	 */
 
 	tm_info.zone = tm_info.local = &local;
-	time(&now);
 	n = tzwest(&now, &isdst);
 
 	/*
@@ -415,7 +413,7 @@ tmlocal(void)
  */
 
 void
-tminit(Tm_zone_t* zp)
+tminit(Tm_zone_t* zp, time_t now, const char newzone)
 {
 	static uint32_t		serial = ~(uint32_t)0;
 
@@ -428,9 +426,9 @@ tminit(Tm_zone_t* zp)
 			tm_info.local = 0;
 		}
 	}
-	if (!tm_info.local)
-		tmlocal();
-	if (!zp)
+	if (!tm_info.local || newzone)
+		tmlocal(now);
+	if (!zp || newzone)
 		zp = tm_info.local;
 	tm_info.zone = zp;
 }

--- a/src/lib/libast/tm/tminit.c
+++ b/src/lib/libast/tm/tminit.c
@@ -143,8 +143,10 @@ tzwest(time_t* clock, int* isdst)
 	 */
 
 	tp = tmlocaltime(clock);
+#ifdef tp->tm_zone
 	if (tp->tm_zone && !tz_abbr)
 		tz_abbr = strdup(tp->tm_zone);
+#endif
 	if (n = tp->tm_yday - n)
 	{
 		if (n > 1)

--- a/src/lib/libast/tm/tmtype.c
+++ b/src/lib/libast/tm/tmtype.c
@@ -41,7 +41,7 @@ tmtype(const char* s, char** e)
 	Tm_zone_t*	zp;
 	char*		t;
 
-	tmset(tm_info.zone);
+	tmset(tm_info.zone, time(NULL), 0);
 	zp = tm_info.local;
 	do
 	{

--- a/src/lib/libast/tm/tmtype.c
+++ b/src/lib/libast/tm/tmtype.c
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*               K. Eugene Carlson <kvngncrlsn@gmail.com>               *
 *                                                                      *
 ***********************************************************************/
 /*

--- a/src/lib/libast/tm/tmxdate.c
+++ b/src/lib/libast/tm/tmxdate.c
@@ -16,6 +16,7 @@
 *                  Martijn Dekker <martijn@inlv.org>                   *
 *            Johnothan King <johnothanking@protonmail.com>             *
 *                      Phi <phi.debian@gmail.com>                      *
+*               K. Eugene Carlson <kvngncrlsn@gmail.com>               *
 *                                                                      *
 ***********************************************************************/
 /*

--- a/src/lib/libast/tm/tmxdate.c
+++ b/src/lib/libast/tm/tmxdate.c
@@ -204,7 +204,7 @@ tmxdate(const char* s, char** e, Time_t now)
 	 * use now for defaults
 	 */
 
-	tm = tmxtm(&ts, now, NULL);
+	tm = tmxtm(&ts, now, NULL, 1);
 	tm_info.date = tm->tm_zone;
 	day = -1;
 	dir = 0;
@@ -631,7 +631,7 @@ tmxdate(const char* s, char** e, Time_t now)
 				if (flags & (MONTH|MDAY|WDAY))
 				{
 					fix = tmxtime(tm, zone);
-					tm = tmxtm(tm, fix, tm->tm_zone);
+					tm = tmxtm(tm, fix, tm->tm_zone, 0);
 					i = tm->tm_mon + 1;
 					j = tm->tm_mday;
 					k = tm->tm_wday;
@@ -649,7 +649,7 @@ tmxdate(const char* s, char** e, Time_t now)
 							tt = tmxtime(tm, zone);
 							if (tt < fix)
 								goto done;
-							tm = tmxtm(tm, tt, tm->tm_zone);
+							tm = tmxtm(tm, tt, tm->tm_zone, 0);
 							i = tm->tm_mon + 1;
 							j = tm->tm_mday;
 							k = tm->tm_wday;
@@ -670,7 +670,7 @@ tmxdate(const char* s, char** e, Time_t now)
 							{
 								tm->tm_mon = i - 1;
 								tm->tm_mday = j;
-								tm = tmxtm(tm, tmxtime(tm, zone), tm->tm_zone);
+								tm = tmxtm(tm, tmxtime(tm, zone), tm->tm_zone, 0);
 								i = tm->tm_mon + 1;
 								j = tm->tm_mday;
 								k = tm->tm_wday;
@@ -1450,7 +1450,7 @@ tmxdate(const char* s, char** e, Time_t now)
 								set |= HOUR;
 							goto clear_hour;
 						case TM_PARTS+4:
-							tm = tmxtm(tm, tmxtime(tm, zone), tm->tm_zone);
+							tm = tmxtm(tm, tmxtime(tm, zone), tm->tm_zone, 0);
 							tm->tm_hour += m * 7 * 24;
 							set |= DAY;
 							goto clear_hour;
@@ -1483,7 +1483,7 @@ tmxdate(const char* s, char** e, Time_t now)
 						}
 						if (m >= 0 && (state & ORDINAL))
 							tm->tm_mday = 1;
-						tm = tmxtm(tm, tmxtime(tm, zone), tm->tm_zone);
+						tm = tmxtm(tm, tmxtime(tm, zone), tm->tm_zone, 0);
 						day = j -= TM_DAY;
 						if (!dir)
 							dir = m;
@@ -1753,7 +1753,7 @@ tmxdate(const char* s, char** e, Time_t now)
 			tm->tm_mday = 1;
 		else if (m < 0)
 			m++;
-		tm = tmxtm(tm, tmxtime(tm, zone), tm->tm_zone);
+		tm = tmxtm(tm, tmxtime(tm, zone), tm->tm_zone, 0);
 		j = day - tm->tm_wday;
 		if (j < 0)
 			j += 7;

--- a/src/lib/libast/tm/tmxfmt.c
+++ b/src/lib/libast/tm/tmxfmt.c
@@ -121,7 +121,7 @@ tmxfmt(char* buf, size_t len, const char* format, Time_t t)
 	char		fmt[32];
 
 	tmlocale();
-	tm = tmxtm(&ts, t, NULL);
+	tm = tmxtm(&ts, t, NULL, 0);
 	if (!format || !*format)
 		format = tm_info.deformat;
 	oformat = format;
@@ -444,7 +444,7 @@ tmxfmt(char* buf, size_t len, const char* format, Time_t t)
 									{
 										flags |= n;
 										tm_info.flags |= n;
-										tm = tmxtm(tm, t, (flags & TM_UTC) ? &tm_data.zone[2] : tm->tm_zone);
+										tm = tmxtm(tm, t, (flags & TM_UTC) ? &tm_data.zone[2] : tm->tm_zone, 0);
 										if (!i)
 											tm_info.flags &= ~n;
 									}
@@ -453,7 +453,7 @@ tmxfmt(char* buf, size_t len, const char* format, Time_t t)
 								{
 									flags &= ~n;
 									tm_info.flags &= ~n;
-									tm = tmxtm(tm, t, (flags & TM_UTC) ? &tm_data.zone[2] : tm->tm_zone);
+									tm = tmxtm(tm, t, (flags & TM_UTC) ? &tm_data.zone[2] : tm->tm_zone, 0);
 									if (!i)
 										tm_info.flags |= n;
 								}
@@ -590,7 +590,7 @@ tmxfmt(char* buf, size_t len, const char* format, Time_t t)
 			if (arg)
 			{
 				if ((zp = tmzone(arg, &f, 0, 0)) && !*f && tm->tm_zone != zp)
-					tm = tmxtm(tm, tmxtime(tm, tm->tm_zone->west + (tm->tm_isdst ? tm->tm_zone->dst : 0)), zp);
+					tm = tmxtm(tm, tmxtime(tm, tm->tm_zone->west + (tm->tm_isdst ? tm->tm_zone->dst : 0)), zp, 0);
 				continue;
 			}
 			if ((ep - cp) >= 16)
@@ -601,7 +601,7 @@ tmxfmt(char* buf, size_t len, const char* format, Time_t t)
 			{
 				if ((zp = tmzone(arg, &f, 0, 0)) && !*f && tm->tm_zone != zp)
 				{
-					tm = tmxtm(tm, tmxtime(tm, tm->tm_zone->west + (tm->tm_isdst ? tm->tm_zone->dst : 0)), zp);
+					tm = tmxtm(tm, tmxtime(tm, tm->tm_zone->west + (tm->tm_isdst ? tm->tm_zone->dst : 0)), zp, 0);
 					if (zp->west || zp->dst)
 						flags &= ~TM_UTC;
 				}
@@ -676,7 +676,7 @@ tmxfmt(char* buf, size_t len, const char* format, Time_t t)
 				{
 					flags |= n;
 					tm_info.flags |= n;
-					tm = tmxtm(tm, t, (flags & TM_UTC) ? &tm_data.zone[2] : tm->tm_zone);
+					tm = tmxtm(tm, t, (flags & TM_UTC) ? &tm_data.zone[2] : tm->tm_zone, 0);
 					if (!i)
 						tm_info.flags &= ~n;
 				}
@@ -685,7 +685,7 @@ tmxfmt(char* buf, size_t len, const char* format, Time_t t)
 			{
 				flags &= ~n;
 				tm_info.flags &= ~n;
-				tm = tmxtm(tm, t, (flags & TM_UTC) ? &tm_data.zone[2] : tm->tm_zone);
+				tm = tmxtm(tm, t, (flags & TM_UTC) ? &tm_data.zone[2] : tm->tm_zone, 0);
 				if (!i)
 					tm_info.flags |= n;
 			}

--- a/src/lib/libast/tm/tmxfmt.c
+++ b/src/lib/libast/tm/tmxfmt.c
@@ -15,6 +15,7 @@
 *                     Phong Vo <phongvo@gmail.com>                     *
 *                  Martijn Dekker <martijn@inlv.org>                   *
 *            Johnothan King <johnothanking@protonmail.com>             *
+*               K. Eugene Carlson <kvngncrlsn@gmail.com>               *
 *                                                                      *
 ***********************************************************************/
 /*

--- a/src/lib/libast/tm/tmxleap.c
+++ b/src/lib/libast/tm/tmxleap.c
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*               K. Eugene Carlson <kvngncrlsn@gmail.com>               *
 *                                                                      *
 ***********************************************************************/
 /*

--- a/src/lib/libast/tm/tmxleap.c
+++ b/src/lib/libast/tm/tmxleap.c
@@ -36,7 +36,7 @@ tmxleap(Time_t t)
 	Tm_leap_t*	lp;
 	uint32_t		sec;
 
-	tmset(tm_info.zone);
+	tmset(tm_info.zone, time(NULL), 0);
 	if (tm_info.flags & TM_ADJUST)
 	{
 		sec = tmxsec(t);

--- a/src/lib/libast/tm/tmxmake.c
+++ b/src/lib/libast/tm/tmxmake.c
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*               K. Eugene Carlson <kvngncrlsn@gmail.com>               *
 *                                                                      *
 ***********************************************************************/
 /*

--- a/src/lib/libast/tm/tmxmake.c
+++ b/src/lib/libast/tm/tmxmake.c
@@ -33,7 +33,7 @@
  */
 
 Tm_t*
-tmxtm(Tm_t* tm, Time_t t, Tm_zone_t* zone)
+tmxtm(Tm_t* tm, Time_t t, Tm_zone_t* zone, const char newzone)
 {
 	struct tm*		tp;
 	Tm_leap_t*		lp;
@@ -48,7 +48,7 @@ tmxtm(Tm_t* tm, Time_t t, Tm_zone_t* zone)
 	uint32_t		i;
 #endif
 
-	tmset(tm_info.zone);
+	tmset(tm_info.zone, tmxsec(t), newzone);
 	leapsec = 0;
 	if ((tm_info.flags & (TM_ADJUST|TM_LEAP)) == (TM_ADJUST|TM_LEAP) && (n = tmxsec(t)))
 	{
@@ -132,5 +132,5 @@ tmxmake(Time_t t)
 {
 	static Tm_t		ts;
 
-	return tmxtm(&ts, t, NULL);
+	return tmxtm(&ts, t, NULL, 0);
 }

--- a/src/lib/libast/tm/tmxscan.c
+++ b/src/lib/libast/tm/tmxscan.c
@@ -133,13 +133,13 @@ gen(Tm_t* tm, Set_t* set)
 	if (set->yday >= 0)
 	{
 		z = 1;
-		tm = tmxtm(tm, t, tm->tm_zone);
+		tm = tmxtm(tm, t, tm->tm_zone, 0);
 		tm->tm_mday += set->yday - tm->tm_yday;
 	}
 	else if (set->wday >= 0)
 	{
 		z = 1;
-		tm = tmxtm(tm, t, tm->tm_zone);
+		tm = tmxtm(tm, t, tm->tm_zone, 0);
 		if ((n = set->wday - tm->tm_wday) < 0)
 			n += 7;
 		tm->tm_mday += n;
@@ -151,7 +151,7 @@ gen(Tm_t* tm, Set_t* set)
 		if (!z)
 		{
 			z = 1;
-			tm = tmxtm(tm, t, tm->tm_zone);
+			tm = tmxtm(tm, t, tm->tm_zone, 0);
 		}
 		tm->tm_nsec = set->nsec;
 	}
@@ -188,7 +188,7 @@ scan(const char* s, char** e, const char* format, char** f, Time_t t, long flags
 	b = s;
  again:
 	CLEAR(set);
-	tm = tmxtm(&ts, t, NULL);
+	tm = tmxtm(&ts, t, NULL, 0);
 	pedantic = (flags & TM_PEDANTIC) != 0;
 	for (;;)
 	{
@@ -323,7 +323,7 @@ scan(const char* s, char** e, const char* format, char** f, Time_t t, long flags
 				x = strtoul(s, &u, 0);
 				if (s == u)
 					goto next;
-				tm = tmxtm(tm, tmxsns(x, 0), tm->tm_zone);
+				tm = tmxtm(tm, tmxsns(x, 0), tm->tm_zone, 0);
 				s = u;
 				CLEAR(set);
 				continue;

--- a/src/lib/libast/tm/tmxscan.c
+++ b/src/lib/libast/tm/tmxscan.c
@@ -15,6 +15,7 @@
 *                     Phong Vo <phongvo@gmail.com>                     *
 *                  Martijn Dekker <martijn@inlv.org>                   *
 *            Johnothan King <johnothanking@protonmail.com>             *
+*               K. Eugene Carlson <kvngncrlsn@gmail.com>               *
 *                                                                      *
 ***********************************************************************/
 /*

--- a/src/lib/libast/tm/tmxtime.c
+++ b/src/lib/libast/tm/tmxtime.c
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*               K. Eugene Carlson <kvngncrlsn@gmail.com>               *
 *                                                                      *
 ***********************************************************************/
 /*

--- a/src/lib/libast/tm/tmxtime.c
+++ b/src/lib/libast/tm/tmxtime.c
@@ -54,7 +54,7 @@ tmxtime(Tm_t* tm, int west)
 	ts = *tm;
 	to = tm;
 	tm = &ts;
-	tmset(tm_info.zone);
+	tmset(tm_info.zone, time(NULL), 0);
 	tmfix(tm);
 	y = tm->tm_year;
 	if (y < 69 || y > (TMX_MAXYEAR - 1900))

--- a/src/lib/libast/tm/tmzone.c
+++ b/src/lib/libast/tm/tmzone.c
@@ -54,7 +54,7 @@ tmzone(const char* name, char** end, const char* type, int* dst)
 	static Tm_zone_t	fixed;
 	static char		off[16];
 
-	tmset(tm_info.zone);
+	tmset(tm_info.zone, time(NULL), 0);
 	if ((name[0] == '+' || name[0] == '-') && (fixed.west = tmgoff(name, &e, TM_LOCALZONE)) != TM_LOCALZONE && (!*e || isspace(*e)))
 	{
 		p = fixed.standard = fixed.daylight = off;

--- a/src/lib/libast/tm/tmzone.c
+++ b/src/lib/libast/tm/tmzone.c
@@ -15,6 +15,7 @@
 *                     Phong Vo <phongvo@gmail.com>                     *
 *                  Martijn Dekker <martijn@inlv.org>                   *
 *            Johnothan King <johnothanking@protonmail.com>             *
+*               K. Eugene Carlson <kvngncrlsn@gmail.com>               *
 *                                                                      *
 ***********************************************************************/
 /*


### PR DESCRIPTION
See #669.

In a longstanding oversight predating `ksh93u+m`, the `tminit` (called by `tmset`) and `tmlocal` functions in `libast/tm/tminit.c` determine time zone characteristics for the present only. This results in anachronistic time zones being used for certain combinations of dates and time zones with historical changes. The issue is exposed by variations on `printf "%T"`, compared here with the output of GNU `date` on Slackware64 -current:

    $ TZ=Europe/Riga printf "%(%F %T %Z %z)T\n" "#236961303"   
    1977-07-05 16:35:03 EET +0200
    $ TZ=Europe/Riga date --date="@236961303" "+%Y-%m-%d %H:%M:%S %Z %z"
    1977-07-05 17:35:03 MSK +0300

Moscow Time was used in Riga without a DST offset as of 1977, whereas today Riga has EEST in summer and EET otherwise. Hence, if time calculations are performed with EET/EEST for a date in summer 1977, the results will be in EET +0200 as no DST adjustment existed at that time, and the result will be an hour behind where it should be (MSK +0300). Hence, the first part of the fix is to tweak `tminit.c` to allow for determining a contemporaneous time zone abbreviation. This essentially solves the issue on Linux-glibc, macOS and the BSDs.

An additional change is needed to accommodate Linux-musl and operating systems with exotic time zone handling, such as Haiku: if available, extract and use the appropriate time zone abbreviation (`tm->tm_zone`) after calling `localtime(3)` in `tzwest` of `tminit.c`.

* Linux-musl: In contrast to Linux-glibc and the BSD operating systems, calling `localtime` sets the members of `tzname` based on the present time, meaning that incorrect abbreviation names (from `%Z`) will appear in the results.
* Haiku: This operating system has non-standard time zone handling. Attempting time calculations with almost any zone name other than the one stored by e.g. `localtime` generally causes a failure to apply time offsets from UTC. As an aside, the changes in this PR fix a Haiku regression test failure in `builtins.sh`.

The following changes are included:

* `tminit.c`: `tminit` and `tmlocal` accept a target time as a parameter; allow time zone calculation to be forced if it has already been done. When calling `localtime(3)`, set the zone abbreviation as the `tm` member `tm_zone` if it is available.
* `tmxmake.c`: `tmxtm` accepts a parameter that determines whether time zone calculation is forced when calling `tmset`.
* `tmxdate.c`: When setting the "default" time zone in the initial `tmxtm` call, specify that time zone recalculation should be forced in the subsequent `tmset` call.
* `libast/tm/*`: Adjust all `tmset` and `tmxtm` calls to reflect parameter changes.
* `libast/features/tmx`, `libast/include/tm.h`: Update specifications of `tmxtm`, `tminit` and `tmset`.
* `libast/man/tm*.3`: Update the documentation accordingly.
* `printf.sh`: Add regression tests.
* `libast/features/lib`: Check for `tm_zone` availability.