### PR TITLE
Fix issue-673

### DIFF
--- a/src/cmd/ksh93/sh/path.c
+++ b/src/cmd/ksh93/sh/path.c
@@ -806,8 +806,16 @@ Pathcomp_t *path_absolute(const char *name, Pathcomp_t *pp, int flag)
 					np->nvenv = dll;
 					goto found;
 				}
+
+#if 0
+				// We getting here with dll=0 of addr=0
+				// meaning there is no way we found anything.
+				// By not going to found we avid to return a
+				// wrong oldpp, yet we free fp as we should
+                                // then we exit the while loop and continue.
 				if(*stkptr(sh.stk,PATH_OFFSET)=='/' && nv_search(stkptr(sh.stk,PATH_OFFSET),sh.bltin_tree,0))
 					goto found;
+#endif
 				if(fp)
 					free(fp);
 				stkseek(sh.stk,n);


### PR DESCRIPTION
File: `src/cmd/ksh93/sh/path.c::path_absolute()`
When compiled with `SHOPT_DYNAMIC=1` and when `/opt/ast/bin` is inserted into `PATH` then enter the code path commented as
`/* Load builtins from dynamic libraries */`
When reaching the `/opt/ast/bin` that is a virtual directory (not exist on the system) then the code wrongly declare `/opt/ast/bin/BuiltInLikeCat` as 'found' and as such do a goto found.

Since there is nothing to found, the code setup `*pp` in a way that next call will fail while we should fail right away.

Simply commenting out the line
````
				if(*stkptr(sh.stk,PATH_OFFSET)=='/' && nv_search(stkptr(sh.stk,PATH_OFFSET),sh.bltin_tree,0))
					goto found;
````
Seems to cure enough.