### PR TITLE
edit/{vi,emacs}.c: Allow tab output from stdin in read builtin.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,11 @@ This documents significant changes in the dev branch of ksh 93u+m.
 For full details, see the git log at: https://github.com/ksh93/ksh
 Uppercase BUG_* IDs are shell bug IDs as used by the Modernish shell library.
 
+2023-09-09:
+
+- Fixed incorrect rejection of the tab key while reading input using the `read`
+  built-in command. Bugs introduced on 2021-02-26 (emacs) and 2022-08-24 (vi).
+
 2023-06-13:
 
 - Fixed a serious regression in pathname expansion where quoted wildcard

--- a/src/cmd/ksh93/edit/emacs.c
+++ b/src/cmd/ksh93/edit/emacs.c
@@ -372,8 +372,11 @@ int ed_emacsread(void *context, int fd,char *buff,int scend, int reedit)
 				}
 				ep->ed->e_tabcount = 0;
 			}
-			beep();
-			continue;
+			if(sh.nextprompt)
+			{
+				beep();
+				continue;
+			}
 		do_default_processing:
 		default:
 

--- a/src/cmd/ksh93/edit/vi.c
+++ b/src/cmd/ksh93/edit/vi.c
@@ -1253,15 +1253,14 @@ static void getline(Vi_t* vp,int mode)
 
 		case '\t':		/** command completion **/
 		{
+			if(!sh_isoption(SH_VI) || !sh.nextprompt)
+				goto fallback;
 			if(blankline(vp))
 			{
 				ed_ringbell();
 				break;
 			}
-			if(sh_isoption(SH_VI) &&
-				mode != SEARCH &&
-				last_virt >= 0 &&
-				sh.nextprompt)
+			if(mode != SEARCH && last_virt >= 0)
 			{
 				if(virtual[cur_virt]=='\\')
 				{

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -18,7 +18,7 @@
 
 #define SH_RELEASE_FORK	"93u+m"		/* only change if you develop a new ksh93 fork */
 #define SH_RELEASE_SVER	"1.1.0-alpha"	/* semantic version number: https://semver.org */
-#define SH_RELEASE_DATE	"2023-06-14"	/* must be in this format for $((.sh.version)) */
+#define SH_RELEASE_DATE	"2023-09-09"	/* must be in this format for $((.sh.version)) */
 #define SH_RELEASE_CPYR	"(c) 2020-2023 Contributors to ksh " SH_RELEASE_FORK
 
 /* Scripts sometimes field-split ${.sh.version}, so don't change amount of whitespace. */


### PR DESCRIPTION
See #676.

RE: b6c8bb7, a7d6394, d9865ce

This PR addresses three related line editor bugs:

* When using `read` in `emacs` mode, tab invariably rings the bell.
* When using `read` n `vi` mode, tab rings the bell in the first two positions, and at all times when the line is blank.
* If the `vi` line editor has been built and all line editors have been turned off, tab rings the bell in the first two positions and at all times when the line is blank.

Tab completion in the `read` builtin was disabled in 2002 (`ksh93n-`); `sh.nextprompt` tracks whether the builtin is in use. In `ksh93u+m`, tab completion was eventually turned off both at the start of the line (b6c8bb7, d9865ce) and in blank lines (a7d6394) in order to prevent corrupt output and other problems. These changes introduced the current bell-ringing behavior. Tab output in `read` (and when running under no line editor if the shell was built with `SHOPT_VSH`) can be restored with two light tweaks to completion handling: 

* `emacs.c`: When checking for tab completion, only beep when `read` is not in use (i.e., when `sh.nextprompt` is non-zero).
* `vi.c`: Skip all tab completion handling when in `read` and if `vi` mode is turned off.