### PR TITLE
Winch the command line once it crosses the edge of the window.

### DIFF
--- a/src/cmd/ksh93/edit/emacs.c
+++ b/src/cmd/ksh93/edit/emacs.c
@@ -1693,7 +1693,7 @@ static void draw(Emacs_t *ep,Draw_t option)
 	
 	/* Update screen overflow indicator if need be */
 	
-	if (longline != ep->overflow && !ep->ed->e_winched)
+	if (longline != ep->overflow && ep->ed->e_winched)
 	{
 		setcursor(ep,w_size,longline);
 		ep->overflow = longline;

--- a/src/cmd/ksh93/edit/emacs.c
+++ b/src/cmd/ksh93/edit/emacs.c
@@ -1678,22 +1678,24 @@ static void draw(Emacs_t *ep,Draw_t option)
 	
 	********************/
 	
-	if (nscend >= &nscreen[ep->offset+w_size])
+	if (nscend >= &nscreen[ep->offset+w_size] && ep->ed->e_winched)
 	{
 		if (ep->offset > 0)
 			longline = BOTH;
 		else
 			longline = UPPER;
 	}
-	else
+	else if (ep->ed->e_winched)
 	{
 		if (ep->offset > 0)
 			longline = LOWER;
 	}
+	else
+		dowinch(ep);
 	
 	/* Update screen overflow indicator if need be */
 	
-	if (longline != ep->overflow && ep->ed->e_winched)
+	if (longline != ep->overflow)
 	{
 		setcursor(ep,w_size,longline);
 		ep->overflow = longline;

--- a/src/cmd/ksh93/edit/vi.c
+++ b/src/cmd/ksh93/edit/vi.c
@@ -1860,6 +1860,8 @@ static void refresh(Vi_t* vp, int mode)
 		else
 			vp->long_char = '*';
 	}
+	else if ( last_phys >= w_size )
+		dowinch(vp);
 	else
 		vp->long_char = ' ';
 

--- a/src/cmd/ksh93/include/edit.h
+++ b/src/cmd/ksh93/include/edit.h
@@ -81,6 +81,8 @@ typedef struct edit
 	int	e_lookahead;	/* index in look-ahead buffer */
 	int	e_fcol;		/* first column */
 	int	e_wsize;	/* width of display window */
+	int	e_edge;		/* edge of the screen */
+	char	e_winched;	/* line has already been adjusted for cursor position */
 #if SHOPT_MULTIBYTE
 	int	e_savedwidth;	/* saved width of a character */
 #endif /* SHOPT_MULTIBYTE */

--- a/src/cmd/ksh93/tests/pty.sh
+++ b/src/cmd/ksh93/tests/pty.sh
@@ -650,10 +650,19 @@ w set -o emacs
 p :test-2:
 w \cRset\\\\\\\\\cH\cH\cH\cH\cH
 r ^:test-2: set -o emacs$
+!
+
+((SHOPT_ESH)) && tst $LINENO <<"!"
+L emacs interrupt character
+
+d 40
+p :test-1:
+w set -o emacs
 
 # \ should escape the interrupt character (usually Ctrl+C)
+p :test-2:
 w true \\\cC
-r true \^C
+r ^:test-2: true \^C
 !
 
 ((SHOPT_VSH)) && touch vi_completion_A_file vi_completion_B_file && tst $LINENO <<"!"


### PR DESCRIPTION
Similar (or identical) bugs can be found in `pdksh`, `mksh`, `oksh`, `loksh` and `ksh2020`.

When the start of the last line of the prompt is separated from the left edge of the window, a number of buggy effects can occur once the cursor has crossed the right edge. This happens because the "physical" line's start invariably coincides with the start of the prompt's last line. Although this situation can occur any time the previous command ends without a new line, it is most readily reproduced by using unterminated `printf`:

    $ printf hey

From here, whether by history navigation, paste, typing, etc., push the end of the command line beyond the right edge of the window, plus the number of characters separating the last line of the prompt from the left edge. One or more of the following effects appear in multiline editing mode:

* Extra characters (unreachable and undeletable) are appended to the end of the command line.
* When navigating to the start of the line (e.g. `0` in `vi` mode), the cursor appears in the middle of the prompt.
* When navigating beyond the right edge, the second line of output is skipped and the remainder of the command line is revealed one character at a time on line three.

When multiline editing is turned off, the scroll point moves to the second line, offset by the number of characters between the left edge and the last line of the prompt (this seems to happen in all versions of `ksh` with line editing capabilities).

In multiline mode, using the "winch" procedure in `ed_read` of `edit.c` as soon as the end of the line crosses the edge of the screen (plus the offset) is sufficient to solve the problem. Additional winching is necessary without multiline; here, any time the cursor could cross the edge (history navigation, paste, version display, etc.), winch the line. Additionally, winch at the scroll point. Otherwise, the erroneous scroll point remains onscreen beneath the actual command line.

Changed files:

* `{emacs,vi}.c`: Add a `dowinch` function that prompts `ed_read` to execute the winch procedure when multiline is turned off; all commands that can add to the command line without typing call it.
* `edit.h`: Add variables for the right edge of the screen and to indicate that edge-of-screen winching has already been done.
* `edit.c`: Use the new variable `e_edge` to save the value of `e_winsz` from before checking for multiline capability; in `ed_read`, winch the line the first time that EOL exceeds the right edge of the window, plus offset.
* `pty.sh`: Split off the `^C` escape test.