### PR TITLE
Fix infinite loop in emacs mode when HISTFILE is empty

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,12 @@ This documents significant changes in the dev branch of ksh 93u+m.
 For full details, see the git log at: https://github.com/ksh93/ksh
 Uppercase BUG_* IDs are shell bug IDs as used by the Modernish shell library.
 
+2024-01-14:
+
+- Fixed a regression introduced on 2022-11-01 that caused ksh to enter
+  an infinite loop after using the up arrow in emacs mode with an empty
+  history file.
+
 2024-01-11:
 
 - Fixed ancient incorrect behaviour in the 'kill' built-in: it sent SIGCONT

--- a/src/cmd/ksh93/edit/emacs.c
+++ b/src/cmd/ksh93/edit/emacs.c
@@ -648,9 +648,7 @@ update:
 			{
 				hline = hismin+1;
 				beep();
-#ifndef ESH_NFIRST
 				continue;
-#endif
 			}
 			goto common;
 


### PR DESCRIPTION
This commit fixes a regression introduced in 5eeeed06. Pressing the up arrow in emacs mode when the history file is empty or otherwise cannot be read from causes an infinite loop that repeatedly calls `beep()`.

Reproducer (using `/dev/null` as `HISTFILE` also reproduces the bug):
```sh
$ echo '' > /tmp/a
$ ENV=/dev/null HISTFILE=/tmp/a ksh -o emacs
$ # <Press Up Arrow>
```

The loop happens because when blanks lines in the history file are skipped at L700, `ed_ungetchar` loops back to L635, beeps at L650, and since ksh is compiled with `ESH_NFIRST` enabled by default a `goto` at L655 jumps back to the code the initial `ed_ungetchar` is located. Since the variable `c` is still ^P, this loop continues into perpetuity. (Also of note is that if the history is not empty, but the first command is a blank space, ksh will loop once that space is reached while using the up arrow.)
https://github.com/ksh93/ksh/blob/2014448ab3d540e1119b8fdccaec9d275cb686d9/src/cmd/ksh93/edit/emacs.c#L696-L701
https://github.com/ksh93/ksh/blob/2014448ab3d540e1119b8fdccaec9d275cb686d9/src/cmd/ksh93/edit/emacs.c#L635-L637
https://github.com/ksh93/ksh/blob/2014448ab3d540e1119b8fdccaec9d275cb686d9/src/cmd/ksh93/edit/emacs.c#L646-L655

src/cmd/ksh93/edit/emacs.c:
- Rather than use a `goto` that loops repeatedly, remove the `ifndef` that prevented use of the `continue` statement. Once the beep occurs we evidently can't go back any further in the command history, so bail out. (I've also tested the `ESH_NFIRST` feature and AFAICT it works identically after the fix.)