### PR TITLE
Fix $RANDOM crash under ASan (re: 9a3e86b)

### DIFF
--- a/src/cmd/ksh93/sh/init.c
+++ b/src/cmd/ksh93/sh/init.c
@@ -1834,7 +1834,7 @@ static void stat_init(void)
  */
 static Init_t *nv_init(void)
 {
-	double d=0;
+	Sfdouble_t d=0;
 	Init_t *ip = sh_newof(0,Init_t,1,0);
 	sh.nvfun.last = (char*)&sh;
 	sh.nvfun.nofree = 1;


### PR DESCRIPTION
After updating to 9a3e86b, the following crash occurs during init when starting up ksh with ASan:
```
==61757==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7ffff44090e0 at pc 0x55555560080b bp 0x7fffffffbbf0 sp 0x7fffffffbbe0 READ of size 16 at 0x7ffff44090e0 thread T0
    #0 0x55555560080a in put_rand /home/johno/GitRepos/KornShell/ksh/src/cmd/ksh93/sh/init.c:688
    #1 0x5555555b5747 in nv_putv /home/johno/GitRepos/KornShell/ksh/src/cmd/ksh93/sh/nvdisc.c:144
    #2 0x555555668b17 in nv_putval /home/johno/GitRepos/KornShell/ksh/src/cmd/ksh93/sh/name.c:1641
    #3 0x55555560bac7 in nv_init /home/johno/GitRepos/KornShell/ksh/src/cmd/ksh93/sh/init.c:1914
    #4 0x555555605ff9 in sh_init /home/johno/GitRepos/KornShell/ksh/src/cmd/ksh93/sh/init.c:1365
--- cut ---
Address 0x7ffff44090e0 is located in stack of thread T0 at offset 32 in frame
    #0 0x55555560a6d9 in nv_init /home/johno/GitRepos/KornShell/ksh/src/cmd/ksh93/sh/init.c:1836
  This frame has 1 object(s):
    [32, 40) 'd' (line 1837) <== Memory access at offset 32 partially overflows this variable
```

src/cmd/ksh93/sh/init.c:
- `nv_init()`: The `d` variable used for `SECONDS` and `RANDOM` must also be an `Sfdouble_t` to avoid misalignment and buffer overflows.