### PR TITLE
Fix buffer overflow when using tab completion on multibyte filenames

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,9 @@ Uppercase BUG_* IDs are shell bug IDs as used by the Modernish shell library.
   expansions of name references to be incorrectly treated as invariant so they
   yielded the wrong values. Fix backported from from ksh 93v- 2013-02-13.
 
+- Fixed a buffer overflow that could occur when using tab completion
+  with multibyte filenames.
+
 2024-01-21:
 
 - [v1.1] New feature added: SRANDOM is a secure random number generator.

--- a/src/cmd/ksh93/include/lexstates.h
+++ b/src/cmd/ksh93/include/lexstates.h
@@ -115,14 +115,14 @@
 #   define mbwide()	(0)
 #   define LEN		1
 #   define SETLEN(x)	(x)
-#   define isaname(c)	((c) < 0 ? 0 : sh_lexstates[ST_NAME][c] == 0)
-#   define isaletter(c)	((c) < 0 ? 0 : (sh_lexstates[ST_DOL][c] == S_ALP && (c) != '.'))
+#   define isaname(c)	(((c) < 0 || (c) > 255) ? 0 : sh_lexstates[ST_NAME][c] == 0)
+#   define isaletter(c)	(((c) < 0 || (c) > 255) ? 0 : (sh_lexstates[ST_DOL][c] == S_ALP && (c) != '.'))
 #endif
 #define STATE(s,c)	(s[mbwide() ? ((c = fcmbget(&LEN)), LEN > 1 ? 'a' : c) : (c = fcget())])
-#define isadigit(c)	((c) < 0 ? 0 : sh_lexstates[ST_DOL][c] == S_DIG)
+#define isadigit(c)	(((c) < 0 || (c) > 255) ? 0 : sh_lexstates[ST_DOL][c] == S_DIG)
 #define isastchar(c)	((c) == '@' || (c) == '*')
-#define isexp(c)	((c) < 0 ? 0 : (sh_lexstates[ST_MACRO][c] == S_PAT || (c) == '$' || (c) == '`'))
-#define ismeta(c)	((c) < 0 ? 0 : sh_lexstates[ST_NAME][c] == S_BREAK)
+#define isexp(c)	(((c) < 0 || (c) > 255) ? 0 : (sh_lexstates[ST_MACRO][c] == S_PAT || (c) == '$' || (c) == '`'))
+#define ismeta(c)	(((c) < 0 || (c) > 255) ? 0 : sh_lexstates[ST_NAME][c] == S_BREAK)
 
 extern char *sh_lexstates[ST_NONE];
 extern const char *sh_lexrstates[ST_NONE];


### PR DESCRIPTION
Under ASan a buffer overflow in tab completion causes an intermittent crash when using command completion on certain multibyte filenames. This can cause a test in pty.sh to fail. A reproducer has been provided below:
```
$ touch /tmp/ダーツ
$ ls /tmp/ダー<Press Tab once or twice>
==135434==ERROR: AddressSanitizer: global-buffer-overflow on address 0x5555558fe87c at pc 0x55555574751b bp 0x7fffffffb100 sp 0x7fffffffb0f0
READ of size 1 at 0x5555558fe87c thread T0
    #0 0x55555574751a in find_begin /home/johno/GitRepos/KornShell/ksh/src/cmd/ksh93/edit/completion.c:229
    #1 0x55555574801c in ed_expand /home/johno/GitRepos/KornShell/ksh/src/cmd/ksh93/edit/completion.c:323
    #2 0x5555556e12df in escape /home/johno/GitRepos/KornShell/ksh/src/cmd/ksh93/edit/emacs.c:979
    #3 0x5555556dd834 in ed_emacsread /home/johno/GitRepos/KornShell/ksh/src/cmd/ksh93/edit/emacs.c:628
--- cut ---
```
This crash can also manifest in the pty tests, as seen below (it's the third test failure):
```
test pty(C.UTF-8) begins at 2024-01-22+11:40:14
	pty.sh[1027]: FAIL: suspend a blocked write to a FIFO: line 1040: expected "^\^C.*: testfifo: cannot create \[.*\]\r\n$", got "^C"
	pty.sh[1027]: FAIL: suspend a blocked write to a FIFO: line 1041: read timeout
	pty.sh[1188]: FAIL: vi completion from wide produces corrupt characters: line 1195: expected "^:test-1: cd vitest/aあb/\r\n$", got ":test-1: cd vitest/a=================================================================\r\n"
test pty(C.UTF-8) failed at 2024-01-22+11:41:17 with exit code 3 [ 60 tests 3 errors ]
```
(As a side note, the other test failures and the lockup that occur are caused by ksh using signal(2) rather than POSIX's sigaction(2). That will be fixed in a separate commit.)

In the `find_begin` function the crash occurs at the `ismeta` macro, which attempts to access the `ST_NAME` lexstate using a value of `c == 12540` (outside of the valid range):
https://github.com/ksh93/ksh/blob/9ad96a453f0a31f2d9f6197143ec0bcc70beda75/src/cmd/ksh93/edit/completion.c#L226-L231
https://github.com/ksh93/ksh/blob/9ad96a453f0a31f2d9f6197143ec0bcc70beda75/src/cmd/ksh93/include/lexstates.h#L125
https://github.com/ksh93/ksh/blob/9ad96a453f0a31f2d9f6197143ec0bcc70beda75/src/cmd/ksh93/data/lexstates.c#L105-L109

src/cmd/ksh93/include/lexstates.h:
- Modify the macros to reject excessive values for `c` (re: 2f7faf6c).