### PR TITLE
Avoid printing a [0] element for `.sh.match`

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,7 +8,7 @@ Uppercase BUG_* IDs are shell bug IDs as used by the Modernish shell library.
   discipline functions for ~ expansion (see 2021-03-16 below).
 
 - Fixed a bug that caused listing the .sh.match variable with ${!.sh.match} to
-  show a spurious zero element.
+  show spurious elements.
 
 2024-01-22:
 

--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,9 @@ Uppercase BUG_* IDs are shell bug IDs as used by the Modernish shell library.
 - Fixed a rare crash or rare incorrect behaviour in .sh.tilde.{get,set}
   discipline functions for ~ expansion (see 2021-03-16 below).
 
+- Fixed a bug that caused listing the .sh.match variable with ${!.sh.match} to
+  show a spurious zero element.
+
 2024-01-22:
 
 - Fixed a bug in the loop invariants optimizer (SHOPT_OPTIMIZE) that caused

--- a/src/cmd/ksh93/sh/init.c
+++ b/src/cmd/ksh93/sh/init.c
@@ -1015,7 +1015,10 @@ static char* get_match(Namval_t* np, Namfun_t *fp)
 static char *name_match(Namval_t *np, Namfun_t *fp)
 {
 	int sub = nv_aindex(SH_MATCHNOD);
-	sfprintf(sh.strbuf,".sh.match[%d]",sub);
+	if(sub==0)
+		sfprintf(sh.strbuf,".sh.match");
+	else
+		sfprintf(sh.strbuf,".sh.match[%d]",sub);
 	return sfstruse(sh.strbuf);
 }
 

--- a/src/cmd/ksh93/sh/init.c
+++ b/src/cmd/ksh93/sh/init.c
@@ -1012,18 +1012,7 @@ static char* get_match(Namval_t* np, Namfun_t *fp)
 	return mp->rval[i];
 }
 
-static char *name_match(Namval_t *np, Namfun_t *fp)
-{
-	int sub = nv_aindex(SH_MATCHNOD);
-	if(sub==0)
-		sfprintf(sh.strbuf,".sh.match");
-	else
-		sfprintf(sh.strbuf,".sh.match[%d]",sub);
-	return sfstruse(sh.strbuf);
-}
-
-static const Namdisc_t SH_MATCH_disc = { sizeof(struct match), 0, get_match,
-	0,0,0,0,name_match };
+static const Namdisc_t SH_MATCH_disc  = { sizeof(struct match), 0, get_match };
 
 static char* get_version(Namval_t* np, Namfun_t *fp)
 {

--- a/src/cmd/ksh93/tests/sh_match.sh
+++ b/src/cmd/ksh93/tests/sh_match.sh
@@ -1072,5 +1072,13 @@ fi
 [[ "[a] b [c] d" =~ ^\[[^]]+\] ]]
 [[ ${.sh.match} == '[a]' ]] || err_exit 'pattern ^\[[^]]+ broken'
 
+# Avoid printing excessive elements for .sh.match
+# https://github.com/ksh93/ksh/issues/308#issuecomment-1033259414
+# https://github.com/ksh93/ksh/pull/709
+exp='.sh.match .sh.match[1] .sh.match[2]'
+got=${ $SHELL -c 'print ${!.sh.match} ${!.sh.match[1]} ${!.sh.match[2]}' }
+[[ $exp == "$got" ]] || err_exit "'print \${!.sh.match}' should not print excessive elements" \
+	"(expected ${ printf %q "$exp" }, got ${ printf %q "$got" })"
+
 # ======
 exit $((Errors<125?Errors:125))

--- a/src/cmd/ksh93/tests/variables.sh
+++ b/src/cmd/ksh93/tests/variables.sh
@@ -1651,4 +1651,11 @@ unset i got bound
 SRANDOM=0
 
 # ======
+# Avoid printing a [0] element for .sh.match
+exp='.sh.match'
+got=${ $SHELL -c 'print ${!.sh.match}' }
+[[ $exp == "$got" ]] || err_exit "'print \${!.sh.match}' should not print a [0] subscript" \
+	"(expected ${ printf %q "$exp" }, got ${ printf %q "$got" })"
+
+# ======
 exit $((Errors<125?Errors:125))

--- a/src/cmd/ksh93/tests/variables.sh
+++ b/src/cmd/ksh93/tests/variables.sh
@@ -1654,7 +1654,7 @@ SRANDOM=0
 # Avoid printing a [0] element for .sh.match
 exp='.sh.match'
 got=${ $SHELL -c 'print ${!.sh.match}' }
-[[ $exp == "$got" ]] || err_exit "'print \${!.sh.match}' should not print a [0] subscript" \
+[[ $exp == "$got" ]] || err_exit "'print \${!.sh.match}' should not print a [0] element" \
 	"(expected ${ printf %q "$exp" }, got ${ printf %q "$got" })"
 
 # ======

--- a/src/cmd/ksh93/tests/variables.sh
+++ b/src/cmd/ksh93/tests/variables.sh
@@ -1651,11 +1651,4 @@ unset i got bound
 SRANDOM=0
 
 # ======
-# Avoid printing a [0] element for .sh.match
-exp='.sh.match'
-got=${ $SHELL -c 'print ${!.sh.match}' }
-[[ $exp == "$got" ]] || err_exit "'print \${!.sh.match}' should not print a [0] element" \
-	"(expected ${ printf %q "$exp" }, got ${ printf %q "$got" })"
-
-# ======
 exit $((Errors<125?Errors:125))


### PR DESCRIPTION
This long overdue bugfix prevents `name_match()` in init.c from printing a spurious zero element when using `${!.sh.match}`. I haven't been able to break this bugfix during testing and it's one of the last remaining issues with `.sh.match`, so it's about time this is submitted as a pull request.

(See https://github.com/ksh93/ksh/issues/308#issuecomment-1033259414 and the related comments in the thread.)