### PR TITLE
Introduce save/restore for `SRANDOM` in virtual subshells

### DIFF
--- a/src/cmd/ksh93/include/shell.h
+++ b/src/cmd/ksh93/include/shell.h
@@ -312,6 +312,7 @@ struct Shell_s
 	int		savesig;
 	unsigned char	*sigflag;	/* pointer to signal states */
 	char		intrap;		/* set while executing a trap action */
+	uint32_t	srand_upper_bound;
 	char		forked;
 	char		binscript;
 	char		funload;

--- a/src/cmd/ksh93/sh/init.c
+++ b/src/cmd/ksh93/sh/init.c
@@ -725,7 +725,6 @@ void sh_reseed_rand(struct rand *rp)
 /*
  * The following three functions are for SRANDOM
  */
-static uint32_t srand_upper_bound;
 
 static void put_srand(Namval_t* np,const char *val,int flags,Namfun_t *fp)
 {
@@ -740,19 +739,19 @@ static void put_srand(Namval_t* np,const char *val,int flags,Namfun_t *fp)
 	if(sh_isstate(SH_INIT))
 		return;
 	if(flags&NV_INTEGER)
-		srand_upper_bound = *(Sfdouble_t*)val;
+		sh.srand_upper_bound = *(Sfdouble_t*)val;
 	else
-		srand_upper_bound = sh_arith(val);
+		sh.srand_upper_bound = sh_arith(val);
 }
 
 static Sfdouble_t nget_srand(Namval_t* np, Namfun_t *fp)
 {
-	return (Sfdouble_t)(srand_upper_bound ? arc4random_uniform(srand_upper_bound) : arc4random());
+	return (Sfdouble_t)(sh.srand_upper_bound ? arc4random_uniform(sh.srand_upper_bound) : arc4random());
 }
 
 static char* get_srand(Namval_t* np, Namfun_t *fp)
 {
-	intmax_t n = (intmax_t)(srand_upper_bound ? arc4random_uniform(srand_upper_bound) : arc4random());
+	intmax_t n = (intmax_t)(sh.srand_upper_bound ? arc4random_uniform(sh.srand_upper_bound) : arc4random());
 	return fmtbase(n, 10, 0);
 }
 

--- a/src/cmd/ksh93/tests/variables.sh
+++ b/src/cmd/ksh93/tests/variables.sh
@@ -1647,6 +1647,16 @@ while	read i
 do	((got = i>=bound)) && break
 done
 ((got)) || err_exit "SRANDOM upper bound inherited from environment"
+# SRANDOM upper bound leaks out of virtual subshells
+for i in 0 10000; do
+	(SRANDOM=$i)
+	for ((i=0; i<bound; i++))
+	do	if	let "got = SRANDOM, got >= bound"
+		then	err_exit "SRANDOM upper bound leads out of virtual subshells ($got >= $bound)"
+			break
+		fi
+	done
+done
 unset i got bound
 SRANDOM=0
 

--- a/src/cmd/ksh93/tests/variables.sh
+++ b/src/cmd/ksh93/tests/variables.sh
@@ -1652,7 +1652,7 @@ for i in 0 10000; do
 	(SRANDOM=$i)
 	for ((i=0; i<bound; i++))
 	do	if	let "got = SRANDOM, got >= bound"
-		then	err_exit "SRANDOM upper bound leads out of virtual subshells ($got >= $bound)"
+		then	err_exit "SRANDOM upper bound leaks out of virtual subshells ($got >= $bound)"
 			break
 		fi
 	done


### PR DESCRIPTION
This commit fixes a virtual subshell leak that caused the set upper bound for `SRANDOM` to leak out into the parent shell. This is fixed by saving and restoring the parent shell's upper bound for `SRANDOM` (`srand_upper_bound` has been moved to the `sh` struct for this purpose).
Reproducer:
```sh
# Reproducer script
SRANDOM=1000
print "Before subshell: $SRANDOM $SRANDOM $SRANDOM"
(
	SRANDOM=0
	print "Subshell 1 Before: $SRANDOM $SRANDOM $SRANDOM"
	(
		SRANDOM=10
		echo "Subshell 2: $SRANDOM $SRANDOM $SRANDOM"
	)
	print "Subshell 1 After: $SRANDOM $SRANDOM $SRANDOM"
)
print "After subshell: $SRANDOM $SRANDOM $SRANDOM"

# Before bugfix
Before subshell: 435 272 618
Subshell 1 Before: 1461253674 1597142489 2487128825
Subshell 2: 6 6 6
Subshell 1 After: 4 6 9
After subshell: 4 1 3

# After bugfix
Before subshell: 681 566 159
Subshell 1 Before: 3742307994 3140966143 1338501372
Subshell 2: 5 1 3
Subshell 1 After: 675002308 2320886572 3838638198
After subshell: 960 788 753
```