### PR TITLE
Fix ksh lockup after `arch-chroot`

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,11 @@ This documents significant changes in the dev branch of ksh 93u+m.
 For full details, see the git log at: https://github.com/ksh93/ksh
 Uppercase BUG_* IDs are shell bug IDs as used by the Modernish shell library.
 
+2024-02-06:
+
+- Fixed a regression introduced on 2023-03-04 that caused ksh to lock up
+  after using the Arch Linux arch-chroot script.
+
 2024-02-03:
 
 - Fixed: the arithmetic representation of negative integers with a base other

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -18,7 +18,7 @@
 
 #define SH_RELEASE_FORK	"93u+m"		/* only change if you develop a new ksh93 fork */
 #define SH_RELEASE_SVER	"1.1.0-alpha"	/* semantic version number: https://semver.org */
-#define SH_RELEASE_DATE	"2024-02-03"	/* must be in this format for $((.sh.version)) */
+#define SH_RELEASE_DATE	"2024-02-06"	/* must be in this format for $((.sh.version)) */
 #define SH_RELEASE_CPYR	"(c) 2020-2024 Contributors to ksh " SH_RELEASE_FORK
 
 /* Scripts sometimes field-split ${.sh.version}, so don't change amount of whitespace. */

--- a/src/cmd/ksh93/sh/jobs.c
+++ b/src/cmd/ksh93/sh/jobs.c
@@ -550,7 +550,6 @@ void job_init(int lflag)
 		/* This should have already been done by rlogin */
                 int fd;
                 char *ttynam;
-                setpgid(0,sh.pid);
 		if(job.mypgid<0 || !(ttynam=ttyname(JOBTTY)))
 			return;
 		while(close(JOBTTY)<0 && errno==EINTR)


### PR DESCRIPTION
In commit da74ed6f code that was hidden behind `'#ifndef SIGTSTP'` was accidentally left in jobs.c, which causes ksh to lockup after the Arch Linux `arch-chroot` script starts ksh. Reproducer below (though note that I was using a Debian system to chroot into the Arch install):
```
# mount /dev/nvme0n1p3 /mnt
# mount /dev/nvme0n1p1 /mnt/boot
# /mnt/usr/bin/arch-chroot /mnt /bin/ksh
<Lockup occurs>
```

src/cmd/ksh93/sh/jobs.c:
- Remove leftover code that sets the process group ID in such a way that `arch-chroot` fails to launch a functional ksh prompt (though for some reason regular `chroot` isn't affected). This `setpgid` call was only ever meant to be used on non-POSIX systems that lack `SIGTSTP`.