### PR TITLE
Fix use of strdup on a NULL pointer

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,11 @@ This documents significant changes in the dev branch of ksh 93u+m.
 For full details, see the git log at: https://github.com/ksh93/ksh
 Uppercase BUG_* IDs are shell bug IDs as used by the Modernish shell library.
 
+2024-02-08:
+
+- Fixed an init-time crash that may occur if standard error is on a terminal,
+  but the path to its tty device can't be found (e.g., in a chroot situation).
+
 2024-02-06:
 
 - Fixed a regression introduced on 2023-03-04 that caused ksh to lock up

--- a/src/cmd/ksh93/edit/history.c
+++ b/src/cmd/ksh93/edit/history.c
@@ -15,6 +15,7 @@
 *            Johnothan King <johnothanking@protonmail.com>             *
 *         hyenias <58673227+hyenias@users.noreply.github.com>          *
 *                Govind Kamat <govind_kamat@yahoo.com>                 *
+*               Vincent Mihalkovic <vmihalko@redhat.com>               *
 *                                                                      *
 ***********************************************************************/
 /*

--- a/src/cmd/ksh93/edit/history.c
+++ b/src/cmd/ksh93/edit/history.c
@@ -353,7 +353,8 @@ retry:
 			if(fd>=0)
 			{
 				fcntl(fd,F_SETFD,FD_CLOEXEC);
-				hp->tty = sh_strdup(isatty(2)?ttyname(2):"notty");
+                                const char* tty = ttyname(2);
+				hp->tty = sh_strdup(tty?tty:"notty");
 				hp->auditfp = sfnew(NULL,NULL,-1,fd,SF_WRITE);
 			}
 		}

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -18,7 +18,7 @@
 
 #define SH_RELEASE_FORK	"93u+m"		/* only change if you develop a new ksh93 fork */
 #define SH_RELEASE_SVER	"1.1.0-alpha"	/* semantic version number: https://semver.org */
-#define SH_RELEASE_DATE	"2024-02-06"	/* must be in this format for $((.sh.version)) */
+#define SH_RELEASE_DATE	"2024-02-08"	/* must be in this format for $((.sh.version)) */
 #define SH_RELEASE_CPYR	"(c) 2020-2024 Contributors to ksh " SH_RELEASE_FORK
 
 /* Scripts sometimes field-split ${.sh.version}, so don't change amount of whitespace. */


### PR DESCRIPTION
### Description
This is a follow up to the https://github.com/ksh93/ksh/commit/9a9da2c299a0adcd36b4efd1b1c0ee2883beba7b commit.

On Linux, [ttyname(3)](https://man7.org/linux/man-pages/man3/ttyname.3.html) may fail if:
* EBADF  Bad file descriptor.
* ENODEV fd refers to a slave pseudoterminal device but the corresponding pathname could not be found (see NOTES).
* ENOTTY fd does not refer to a terminal device.

### Reproducer
Thank you @lzaoral for debugging this issue and creating this **reproducer**:
```bash
$ tty   # check that the shell is connected to a pseudoterminal
/dev/pts/4
$ mkdir /var/tmp/chroottest
$ dnf --releasever=39 --installroot=/var/tmp/chroottest install ksh
$ echo "/dev/udp/127.0.0.1/514;0;104" | sudo tee /var/tmp/chroottest/etc/ksh_audit
$ sudo chroot /var/tmp/chroottest /bin/ksh -lic 'exit 0'
zsh: segmentation fault  sudo chroot /var/tmp/chroottest /bin/ksh -lic 'exit 0'
```

### Solution
Calling isatty() before ttyname prevents the first (EBADF) and third (ENOTTY) cases above. To catch the second (ENODEV) case, let's call ttyname(2) directly, check for NULL and remove the redundant isatty() call.

src/cmd/ksh93/edit/history.c:
- Make strdup duplicate 'notty' instead of NULL to prevent crashes.