### PR TITLE
Fix segfault in NetBSD and DragonFlyBSD single user mode

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,11 @@ This documents significant changes in the dev branch of ksh 93u+m.
 For full details, see the git log at: https://github.com/ksh93/ksh
 Uppercase BUG_* IDs are shell bug IDs as used by the Modernish shell library.
 
+2024-02-22:
+
+- Fixed a segmentation fault that occurred when starting ksh in single
+  user mode on NetBSD and DragonFlyBSD.
+
 2024-02-17:
 
 - Fixed a crash that could occur when using 'typeset -T' typed variables

--- a/NEWS
+++ b/NEWS
@@ -4,8 +4,8 @@ Uppercase BUG_* IDs are shell bug IDs as used by the Modernish shell library.
 
 2024-02-22:
 
-- Fixed a segmentation fault that occurred when starting ksh in single
-  user mode on NetBSD and DragonFlyBSD.
+- Fixed a crash that occurred when starting ksh with no TERM variable in the
+  environment (e.g., in single user mode on NetBSD and DragonFlyBSD).
 
 2024-02-17:
 

--- a/src/cmd/ksh93/edit/edit.c
+++ b/src/cmd/ksh93/edit/edit.c
@@ -611,7 +611,7 @@ void	ed_setup(Edit_t *ep, int fd, int reedit)
 		static char *oldterm;
 		Namval_t *np = nv_search("TERM",sh.var_tree,0);
 		char *term = NULL;
-		if(nv_isattr(np,NV_EXPORT))
+		if(np && nv_isattr(np,NV_EXPORT))
 			term = nv_getval(np);
 		if(!term)
 			term = "";

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -18,7 +18,7 @@
 
 #define SH_RELEASE_FORK	"93u+m"		/* only change if you develop a new ksh93 fork */
 #define SH_RELEASE_SVER	"1.1.0-alpha"	/* semantic version number: https://semver.org */
-#define SH_RELEASE_DATE	"2024-02-17"	/* must be in this format for $((.sh.version)) */
+#define SH_RELEASE_DATE	"2024-02-22"	/* must be in this format for $((.sh.version)) */
 #define SH_RELEASE_CPYR	"(c) 2020-2024 Contributors to ksh " SH_RELEASE_FORK
 
 /* Scripts sometimes field-split ${.sh.version}, so don't change amount of whitespace. */

--- a/src/cmd/ksh93/tests/pty.sh
+++ b/src/cmd/ksh93/tests/pty.sh
@@ -1322,5 +1322,20 @@ c \Ek
 r ^:prompt: "\$SHELL" -o vi -c 'read -s "foo\?:prompt: "'$
 !
 
+((multiline && (SHOPT_VSH || SHOPT_ESH))) && TERM=vt100 tst $LINENO <<"!"
+L crash when TERM is undefined
+# https://github.com/ksh93/ksh/issues/722
+
+d 40
+p :test-1:
+w unset TERM
+p :test-2:
+w "$SHELL"
+p :test-3:
+w print Exit status $?
+r print
+r ^Exit status 0\r\n$
+!
+
 # ======
 exit $((Errors<125?Errors:125))


### PR DESCRIPTION
This commit fixes a crash that prevented ksh from starting up in single user mode on DragonFlyBSD and NetBSD.

src/cmd/ksh93/edit/edit.c:
- Make sure the `np` node for `$TERM` is not null before checking for an export attribute.

Resolves: https://github.com/ksh93/ksh/issues/722

Note: I did try to add a regression test, but for whatever reason it fails to fail under `pty`. My attempt is below:
```diff
diff --git a/src/cmd/ksh93/tests/pty.sh b/src/cmd/ksh93/tests/pty.sh
index 86c6ace79..6a6c03ae1 100755
--- a/src/cmd/ksh93/tests/pty.sh
+++ b/src/cmd/ksh93/tests/pty.sh
@@ -1322,5 +1322,18 @@ c \Ek
 r ^:prompt: "\$SHELL" -o vi -c 'read -s "foo\?:prompt: "'$
 !
 
+((SHOPT_VSH || SHOPT_ESH)) && TERM=vt100 tst $LINENO <<"!"
+L crash when TERM is undefined
+
+d 40
+p :test-1:
+w unset TERM
+p :test-2:
+w exec "$SHELL"
+p :test-3:
+w print Did something
+u ^Did something\r\n$
+!
+
 # ======
 exit $((Errors<125?Errors:125))

```