### PR TITLE
Fix non-functional `globcasedetect` option on Linux (re: 725eef35)

### DIFF
--- a/src/lib/libast/features/tty
+++ b/src/lib/libast/features/tty
@@ -10,6 +10,7 @@ lib	tcgetpgrp unistd.h fail{
 	echo "$0: POSIX tcgetpgrp(3) is required" >&2
 	exit 1
 }end
+hdr	sys/ioctl
 sys	ioctl
 mac	_POSIX_VDISABLE termios.h
 mem	termios.c_line termios.h
@@ -37,7 +38,7 @@ cat{
 #endif /* TCSADFLUSH */
 #undef TIOCGETC
 
-#if _sys_ioctl
+#if _hdr_sys_ioctl
 #   include <sys/ioctl.h>
 #endif
 

--- a/src/lib/libast/path/pathicase.c
+++ b/src/lib/libast/path/pathicase.c
@@ -23,14 +23,14 @@
 #if _hdr_linux_msdos_fs
 #include <linux/msdos_fs.h>
 #endif
-#if _sys_ioctl
+#if _hdr_sys_ioctl
 #include <sys/ioctl.h>
 #endif
 
-#if _sys_ioctl && _hdr_linux_fs && defined(FS_IOC_GETFLAGS) && defined(FS_CASEFOLD_FL)
+#if _hdr_sys_ioctl && _hdr_linux_fs && defined(FS_IOC_GETFLAGS) && defined(FS_CASEFOLD_FL)
 #define _linux_casefold	1
 #endif
-#if _sys_ioctl && _hdr_linux_msdos_fs && defined(FAT_IOCTL_GET_ATTRIBUTES)
+#if _hdr_sys_ioctl && _hdr_linux_msdos_fs && defined(FAT_IOCTL_GET_ATTRIBUTES)
 #define _linux_fatfs	1
 #endif
 


### PR DESCRIPTION
The referenced commit removed the probe that detects the `sys/ioctl.h` header (`_hdr_sys_ioctl`) under the false assumption `_sys_ioctl` would be a sufficient replacement. In reality this change causes `iffe` to fail to detect `sys/ioctl.h` on Linux, which breaks the `globcasedetect` option and underlying `pathicase` function. Reproducer using the 'EFI' folder on a UEFI boot partition:
```sh
$ set -o globcasedetect
$ ls /boot/ef*
ls: cannot access '/boot/ef*': No such file or directory
```

- Restored the `_hdr_sys_ioctl` probe to fix compatibility with ext4 casefold and FAT32.