### PR TITLE
bug-733 : fix src/lib/libast/tm/tmxdate.c

### DIFF
--- a/src/cmd/ksh93/tests/printf.sh
+++ b/src/cmd/ksh93/tests/printf.sh
@@ -285,6 +285,15 @@ T '2020-2-3 12:34:56 next fri'		'2020-02-14 12:34:56'
 T '2020-2-3T12:34:56Z'			'2020-02-03 12:34:56'
 T '2020-2-3 12:34:56Z'			'2020-02-03 12:34:56'
 
+C='ORDINAL access'
+format='%F'
+T '1th tuesday in 2016-3' '2016-03-01'
+T '2th tuesday in 2016-3' '2016-03-08'
+T '3th tuesday in 2016-3' '2016-03-15'
+T '4th tuesday in 2016-3' '2016-03-22'
+T '5th tuesday in 2016-3' '2016-03-29'
+
+
 # The following tests for times relative to the current time require GNU 'date' to compare our results to.
 if	! gd=$(	set -o noglob
 		IFS=:

--- a/src/lib/libast/tm/tmxdate.c
+++ b/src/lib/libast/tm/tmxdate.c
@@ -805,7 +805,7 @@ tmxdate(const char* s, char** e, Time_t now)
 					break;
 				goto save;
 			}
-			else if (f == -1 && isalpha(*t) && tmlex(t, &t, tm_info.format + TM_ORDINAL, TM_ORDINALS - TM_ORDINAL, NULL, 0) >= 0)
+			else if ( ((f == -1) || (f == 1)) && isalpha(*t) && tmlex(t, &t, tm_info.format + TM_ORDINAL, TM_ORDINALS - TM_ORDINAL, NULL, 0) >= 0)
 			{
 				message((-1, "AHA#%d n=%d", __LINE__, n));
  ordinal:


### PR DESCRIPTION
While normalising the 'f' variable usage into tmxdate() the TM_ORDINAL case was overlooked.