### PR TITLE
Support loading kshcode from memory to support embedding

### DIFF
--- a/src/cmd/ksh93/include/defs.h
+++ b/src/cmd/ksh93/include/defs.h
@@ -175,7 +175,7 @@ extern char		*sh_getcwd(void);
 
 #if SHOPT_SCRIPTONLY
 #define is_option(s,x)	((x)==SH_INTERACTIVE || (x)==SH_HISTORY ? 0 : ((s)->v[((x)&WMASK)/WBITS] & (1L << ((x) % WBITS))) )
-#define on_option(s,x)	( (x)==SH_INTERACTIVE || (x)==SH_HISTORY ? errormsg(SH_DICT,ERROR_exit(1),e_scriptonly) : ((s)->v[((x)&WMASK)/WBITS] |= (1L << ((x) % WBITS))) )
+#define on_option(s,x)	((x)==SH_INTERACTIVE || (x)==SH_HISTORY ? 0 : ((s)->v[((x)&WMASK)/WBITS] |= (1L << ((x) % WBITS))) )
 #define off_option(s,x)	((x)==SH_INTERACTIVE || (x)==SH_HISTORY ? 0 : ((s)->v[((x)&WMASK)/WBITS] &= ~(1L << ((x) % WBITS))) )
 #else
 #define is_option(s,x)	((s)->v[((x)&WMASK)/WBITS] & (1L << ((x) % WBITS)))

--- a/src/cmd/ksh93/sh/main.c
+++ b/src/cmd/ksh93/sh/main.c
@@ -234,7 +234,7 @@ int sh_mainex(int ac, char *av[], Shinit_f userinit,char *code,long codelen)
                 else if(code && codelen) {  /* read kshcode from memory */
                        sh.comdiv=code;
                        if (codelen == 1) codelen=strlen(code);
-		       iop = sfnew(NULL,sh.comdiv,codelen,0,SF_STRING|SF_READ);
+		       iop = sfnew(NULL,sh.comdiv,codelen,0,SFIO_STRING|SFIO_READ);
                        code=NULL;
                 }
 		else

--- a/src/cmd/ksh93/sh/main.c
+++ b/src/cmd/ksh93/sh/main.c
@@ -107,7 +107,7 @@ static int sh_source(Sfio_t *iop, const char *file)
 #define REMOTE(m)	!(m)
 #endif
 
-int sh_main(int ac, char *av[], Shinit_f userinit)
+int sh_mainex(int ac, char *av[], Shinit_f userinit,char *code,long codelen)
 {
 	char		*name;
 	int		fdin;
@@ -231,6 +231,12 @@ int sh_main(int ac, char *av[], Shinit_f userinit)
 		shell_c:
 			iop = sfnew(NULL,sh.comdiv,strlen(sh.comdiv),0,SFIO_STRING|SFIO_READ);
 		}
+                else if(code && codelen) {  /* read kshcode from memory */
+                       sh.comdiv=code;
+                       if (codelen == 1) codelen=strlen(code);
+		       iop = sfnew(NULL,sh.comdiv,codelen,0,SF_STRING|SF_READ);
+                       code=NULL;
+                }
 		else
 		{
 			name = error_info.id;
@@ -365,6 +371,26 @@ int sh_main(int ac, char *av[], Shinit_f userinit)
 	/* Start main execution loop. */
 	exfile(iop,fdin);
 	sh_done(0);
+}
+
+int sh_main(int ac, char *av[], Shinit_f userinit)
+{
+        return sh_mainex(ac, av, userinit, NULL , 0);
+}
+
+int sh_maincode(int ac, char *av[], char *code)
+{
+        if (code) {
+                long len;
+                char *ptr;
+                len=strlen(code);
+                ptr=(char *)sh_malloc(len+8);
+                if (ptr) {
+                        strcpy(ptr,code);
+                        return sh_mainex(ac, av, NULL,ptr,len);
+                }
+        }
+        return 0;
 }
 
 /*


### PR DESCRIPTION
Extended sh_main to sh_mainex by adding extra parameters in function to support loading ksh code from a memory location.
added functions sh_main and sh_maincode to support original and memory kshcode to use sh_mainex.

removed error message when SHOPT SCRIPTONLY=1 because it breaks embedded usage.
