### PR TITLE
jobs: change p_job variable type from short to int

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,11 @@ This documents significant changes in the dev branch of ksh 93u+m.
 For full details, see the git log at: https://github.com/ksh93/ksh
 Uppercase BUG_* IDs are shell bug IDs as used by the Modernish shell library.
 
+2024-07-13:
+
+- The shell is now capable of handling more than 32767 simultaneous
+  background jobs, subject to system limitations.
+
 2024-07-02:
 
 - Support for UNC paths (//server/dir) is now enabled by default on Cygwin.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ outputs the name of this subdirectory.
 Dynamically linked binaries, if supported for your system, are stored in
 `dyn/bin` and `dyn/lib` subdirectories of your architecture directory.
 If built, they are built in addition to the statically linked versions.
-Export `AST_NO_DYLIB` to deactivate building dyanmically linked versions.
+Export `AST_NO_DYLIB` to deactivate building dynamically linked versions.
 
 If you have trouble or want to tune the binaries, you may pass additional
 compiler and linker flags. It is usually best to export these as environment

--- a/src/cmd/INIT/mamake.c
+++ b/src/cmd/INIT/mamake.c
@@ -2458,9 +2458,7 @@ int main(int argc, char **argv)
 		case 'K':
 			continue;
 		case 'V':
-			(void)write(1, id + 10, strlen(id) - 12);
-			putchar('\n');
-			exit(0);
+			return !(write(1, id + 10, strlen(id) - 12) > 0 && putchar('\n') == '\n');
 		case 'f':
 			append(state.opt, " -f ");
 			append(state.opt, opt_info.arg);
@@ -2575,9 +2573,7 @@ int main(int argc, char **argv)
 				setval(state.vars, "-strip-symbols", "1");
 				continue;
 			case 'V':
-				(void)write(1, id + 10, strlen(id) - 12);
-				putchar('\n');
-				exit(0);
+				return !(write(1, id + 10, strlen(id) - 12) > 0 && putchar('\n') == '\n');
 			case 'f':
 			case 'r':
 			case 'C':

--- a/src/cmd/ksh93/README
+++ b/src/cmd/ksh93/README
@@ -119,7 +119,7 @@ The options have the following defaults and meanings:
     NOECHOE      off Disable the '-e' option to the 'echo' command,
                      unless SHOPT_ECHOPRINT is enabled.
 
-    OPTIMIZE     on  Optimize loop invariants for with for and while loops.
+    OPTIMIZE     on  Optimize loop invariants in 'for' and 'while' loops.
 
     PRINTF_LEGACY    The printf built-in accepts a format operand that starts
                      with '-' without the standard preceding '--' options

--- a/src/cmd/ksh93/data/builtins.c
+++ b/src/cmd/ksh93/data/builtins.c
@@ -321,8 +321,7 @@ const char sh_set[] =
  * --posix is an AST optget(3) default option, so for ksh to use it, it must be listed
  * explicitly (and handled by sh_argopts() in sh/args.c) to stop optget(3) overriding it.
  */
-"[05:posix?Enable the \bposix\b option. When given at invocation time, "
-	"disables importing variable type attributes from the environment.]"
+"[05:posix?Enable the \bposix\b option.]"
 "[p?Privileged mode. Disabling \b-p\b sets the effective user ID to the "
 	"real user ID, and the effective group ID to the real group ID. "
 	"Enabling \b-p\b restores the effective user and group IDs to their "

--- a/src/cmd/ksh93/include/jobs.h
+++ b/src/cmd/ksh93/include/jobs.h
@@ -51,7 +51,7 @@ struct process
 	pid_t		p_pid;		/* process ID */
 	pid_t		p_pgrp;		/* process group */
 	pid_t		p_fgrp;		/* process group when stopped */
-	short		p_job;		/* job number of process */
+	int		p_job;		/* job number of process */
 	unsigned short	p_exit;		/* exit value or signal number */
 	unsigned short	p_exitmin;	/* minimum exit value for xargs */
 	unsigned short	p_flag;		/* flags - see below */

--- a/src/cmd/ksh93/include/jobs.h
+++ b/src/cmd/ksh93/include/jobs.h
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1982-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2023 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  Martijn Dekker <martijn@inlv.org>                   *
 *            Johnothan King <johnothanking@protonmail.com>             *
 *               Anuradha Weeraman <anuradha@debian.org>                *
+*               Vincent Mihalkovic <vmihalko@redhat.com>               *
 *                                                                      *
 ***********************************************************************/
 #ifndef JOB_NFLAG

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -18,7 +18,7 @@
 
 #define SH_RELEASE_FORK	"93u+m"		/* only change if you develop a new ksh93 fork */
 #define SH_RELEASE_SVER	"1.1.0-alpha"	/* semantic version number: https://semver.org */
-#define SH_RELEASE_DATE	"2024-07-02"	/* must be in this format for $((.sh.version)) */
+#define SH_RELEASE_DATE	"2024-07-13"	/* must be in this format for $((.sh.version)) */
 #define SH_RELEASE_CPYR	"(c) 2020-2024 Contributors to ksh " SH_RELEASE_FORK
 
 /* Scripts sometimes field-split ${.sh.version}, so don't change amount of whitespace. */

--- a/src/cmd/ksh93/sh/jobs.c
+++ b/src/cmd/ksh93/sh/jobs.c
@@ -13,6 +13,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                  Martijn Dekker <martijn@inlv.org>                   *
 *            Johnothan King <johnothanking@protonmail.com>             *
+*               Vincent Mihalkovic <vmihalko@redhat.com>               *
 *                                                                      *
 ***********************************************************************/
 /*

--- a/src/cmd/ksh93/sh/jobs.c
+++ b/src/cmd/ksh93/sh/jobs.c
@@ -437,7 +437,7 @@ int job_reap(int sig)
 			pw->p_flag &= ~P_NOTIFY;
 		if(job.jobcontrol && pid==pw->p_fgrp && pid==tcgetpgrp(JOBTTY))
 		{
-			px = job_byjid((int)pw->p_job);
+			px = job_byjid(pw->p_job);
 			for(; px && (px->p_flag&P_DONE); px=px->p_nxtproc);
 			if(!px)
 				tcsetpgrp(JOBTTY,job.mypid);
@@ -1527,7 +1527,7 @@ int job_switch(struct process *pw,int bgflag)
 {
 	const char *msg;
 	job_lock();
-	if(!pw || !(pw=job_byjid((int)pw->p_job)))
+	if(!pw || !(pw=job_byjid(pw->p_job)))
 	{
 		job_unlock();
 		return 1;
@@ -1541,7 +1541,7 @@ int job_switch(struct process *pw,int bgflag)
 	}
 	if(bgflag=='b')
 	{
-		sfprintf(outfile,"[%d]\t",(int)pw->p_job);
+		sfprintf(outfile,"[%d]\t",pw->p_job);
 		sh.bckpid = pw->p_pid;
 		pw->p_flag |= P_BG;
 		msg = "&";
@@ -1622,7 +1622,7 @@ static struct process *job_unpost(struct process *pwtop,int notify)
 	sfprintf(sfstderr,"ksh: job line %4d: drop PID=%lld critical=%d PID=%d env=%u\n",__LINE__,(Sflong_t)sh.current_pid,job.in_critical,pwtop->p_pid,pwtop->p_env);
 	sfsync(sfstderr);
 #endif /* DEBUG */
-	pwtop = pw = job_byjid((int)pwtop->p_job);
+	pwtop = pw = job_byjid(pwtop->p_job);
 	if(!pw)
 		return NULL;
 #if SHOPT_BGX
@@ -1663,7 +1663,7 @@ static struct process *job_unpost(struct process *pwtop,int notify)
 	sfprintf(sfstderr,"ksh: job line %4d: free PID=%lld critical=%d job=%d\n",__LINE__,(Sflong_t)sh.current_pid,job.in_critical,pwtop->p_job);
 	sfsync(sfstderr);
 #endif /* DEBUG */
-	job_free((int)pwtop->p_job);
+	job_free(pwtop->p_job);
 	return NULL;
 }
 

--- a/src/cmd/ksh93/tests/arith.sh
+++ b/src/cmd/ksh93/tests/arith.sh
@@ -703,6 +703,7 @@ if [[ -o ?posix ]]
 then	(set -o posix; let x=010; [[ $x == 8 ]]) || err_exit 'let not treating 010 as octal with posix on'
 fi
 
+unset A
 float z=0
 integer aa=2 a=1
 typeset -A A


### PR DESCRIPTION
This PR addresses a problem where the number of jobs exceeds `2^15 - 1` (32767), the variable [`short p_job`](https://github.com/ksh93/ksh/blob/dev/src/cmd/ksh93/include/jobs.h) overflows and ksh hangs ([here](https://github.com/ksh93/ksh/blob/dev/src/cmd/ksh93/sh/jobs.c#L1210)).

### How to reproduce?
#### `reproducer.ksh`:
```bash
#!/bin/ksh

trap 'echo SIGINT $i' SIGINT

for (( i=0; i<=60000; i++ )); do
    sleep inf &
done

kill -SIGINT $$
```
and run `ksh -lic '. ./reproducer.ksh'` . 

This bug was found during a debugging session with @lzaoral and @msekletar - thank you!