### PR TITLE
Fix undefined symbol build error (re: e9278fa)

### DIFF
--- a/bin/package
+++ b/bin/package
@@ -2056,100 +2056,112 @@ case $x in
 		case $abi in
 		'')	abi="'d=$INSTALLROOT v='" ;;
 		esac
+
+		# allow loading dynamic libraries from $INSTALLROOT/dyn/lib
+		# by setting library path variables for various systems;
+		# instead of bothering to detect the system, just set them all
+
 		p=0
-		eval "
-			for a in $abi
-			do	eval \$a
-				eval \"
-					case \\\$LD_LIBRARY\${v}_PATH: in
-					\\\$d/dyn/lib:*)
-						;;
-					*)	x=\\\$LD_LIBRARY\${v}_PATH
-						case \\\$x in
-						''|:*)	;;
-						*)	x=:\\\$x ;;
+		case $action in
+		make)	# ... but not while building; otherwise, if $SHELL is a dynamically
+			# linked ksh binary, it may link against our preinstalled libraries
+			;;
+		*)	eval "
+				for a in $abi
+				do	eval \$a
+					eval \"
+						case \\\$LD_LIBRARY\${v}_PATH: in
+						\\\$d/dyn/lib:*)
+							;;
+						*)	x=\\\$LD_LIBRARY\${v}_PATH
+							case \\\$x in
+							''|:*)	;;
+							*)	x=:\\\$x ;;
+							esac
+							LD_LIBRARY\${v}_PATH=\$d/dyn/lib\\\$x
+							export LD_LIBRARY\${v}_PATH
+							p=1
+							;;
 						esac
-						LD_LIBRARY\${v}_PATH=\$d/dyn/lib\\\$x
-						export LD_LIBRARY\${v}_PATH
-						p=1
+					\"
+				done
+			"
+
+			case $LD_LIBRARY_PATH in
+			'')	;;
+			*)	for d in $lib
+				do	case $HOSTTYPE in
+					*64)	if	test -d ${d}64
+						then	d=${d}64
+						fi
 						;;
 					esac
-				\"
-			done
-		"
-		case $LD_LIBRARY_PATH in
-		'')	;;
-		*)	for d in $lib
-			do	case $HOSTTYPE in
-				*64)	if	test -d ${d}64
-					then	d=${d}64
-					fi
-					;;
-				esac
-				case :$LD_LIBRARY_PATH: in
-				*:$d:*)	;;
-				*)	if	test -d $d
-					then	LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$d
-						p=1
-					fi
-					;;
-				esac
-			done
-			;;
-		esac
-		case $p in
-		1)	$show LD_LIBRARY_PATH=$LD_LIBRARY_PATH
-			$show export LD_LIBRARY_PATH
-			export LD_LIBRARY_PATH
-			;;
-		esac
-		case $LIBPATH: in
-		$INSTALLROOT/dyn/bin:$INSTALLROOT/dyn/lib:*)
-			;;
-		*)	case $LIBPATH in
-			'')	LIBPATH=/usr/lib:/lib ;;
+					case :$LD_LIBRARY_PATH: in
+					*:$d:*)	;;
+					*)	if	test -d $d
+						then	LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$d
+							p=1
+						fi
+						;;
+					esac
+				done
+				;;
 			esac
-			LIBPATH=$INSTALLROOT/dyn/bin:$INSTALLROOT/dyn/lib:$LIBPATH
-			$show LIBPATH=$LIBPATH
-			$show export LIBPATH
-			export LIBPATH
-			;;
-		esac
-		case $SHLIB_PATH: in
-		$INSTALLROOT/dyn/lib:*)
-			;;
-		*)	SHLIB_PATH=$INSTALLROOT/dyn/lib${SHLIB_PATH:+:$SHLIB_PATH}
-			$show SHLIB_PATH=$SHLIB_PATH
-			$show export SHLIB_PATH
-			export SHLIB_PATH
-			;;
-		esac
-		case $DYLD_LIBRARY_PATH: in
-		$INSTALLROOT/dyn/lib:*)
-			;;
-		*)	DYLD_LIBRARY_PATH=$INSTALLROOT/dyn/lib${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}
-			$show DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH
-			$show export DYLD_LIBRARY_PATH
-			export DYLD_LIBRARY_PATH
-			;;
-		esac
-		case $_RLD_ROOT in
-		$INSTALLROOT/arch*)	;;
-		':')	_RLD_ROOT=$INSTALLROOT/arch:/ ;;
-		/|*:/)	_RLD_ROOT=$INSTALLROOT/arch:$_RLD_ROOT ;;
-		*)	_RLD_ROOT=$INSTALLROOT/arch:$_RLD_ROOT:/ ;;
-		esac
-		$show _RLD_ROOT=$_RLD_ROOT
-		$show export _RLD_ROOT
-		export _RLD_ROOT
-		# Haiku
-		case $LIBRARY_PATH: in
-		$INSTALLROOT/dyn/lib:*)
-			;;
-		*)	LIBRARY_PATH=$INSTALLROOT/dyn/lib${LIBRARY_PATH:+:$LIBRARY_PATH}
-			$show LIBRARY_PATH=$LIBRARY_PATH
-			$show export LIBRARY_PATH
-			export LIBRARY_PATH
+			case $p in
+			1)	$show LD_LIBRARY_PATH=$LD_LIBRARY_PATH
+				$show export LD_LIBRARY_PATH
+				export LD_LIBRARY_PATH
+				;;
+			esac
+			case $LIBPATH: in
+			$INSTALLROOT/dyn/bin:$INSTALLROOT/dyn/lib:*)
+				;;
+			*)	case $LIBPATH in
+				'')	LIBPATH=/usr/lib:/lib ;;
+				esac
+				LIBPATH=$INSTALLROOT/dyn/bin:$INSTALLROOT/dyn/lib:$LIBPATH
+				$show LIBPATH=$LIBPATH
+				$show export LIBPATH
+				export LIBPATH
+				;;
+			esac
+			case $SHLIB_PATH: in
+			$INSTALLROOT/dyn/lib:*)
+				;;
+			*)	SHLIB_PATH=$INSTALLROOT/dyn/lib${SHLIB_PATH:+:$SHLIB_PATH}
+				$show SHLIB_PATH=$SHLIB_PATH
+				$show export SHLIB_PATH
+				export SHLIB_PATH
+				;;
+			esac
+			case $DYLD_LIBRARY_PATH: in
+			$INSTALLROOT/dyn/lib:*)
+				;;
+			*)	DYLD_LIBRARY_PATH=$INSTALLROOT/dyn/lib${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}
+				$show DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH
+				$show export DYLD_LIBRARY_PATH
+				export DYLD_LIBRARY_PATH
+				;;
+			esac
+			case $_RLD_ROOT in
+			$INSTALLROOT/arch*)	;;
+			':')	_RLD_ROOT=$INSTALLROOT/arch:/ ;;
+			/|*:/)	_RLD_ROOT=$INSTALLROOT/arch:$_RLD_ROOT ;;
+			*)	_RLD_ROOT=$INSTALLROOT/arch:$_RLD_ROOT:/ ;;
+			esac
+			$show _RLD_ROOT=$_RLD_ROOT
+			$show export _RLD_ROOT
+			export _RLD_ROOT
+			# Haiku
+			case $LIBRARY_PATH: in
+			$INSTALLROOT/dyn/lib:*)
+				;;
+			*)	LIBRARY_PATH=$INSTALLROOT/dyn/lib${LIBRARY_PATH:+:$LIBRARY_PATH}
+				$show LIBRARY_PATH=$LIBRARY_PATH
+				$show export LIBRARY_PATH
+				export LIBRARY_PATH
+				;;
+			esac
 			;;
 		esac
 

--- a/src/cmd/INIT/mamake.c
+++ b/src/cmd/INIT/mamake.c
@@ -1294,6 +1294,13 @@ static int execute(char *s)
 	if (pid == 0)
 	{	/* child */
 		report(-5, s, "exec", 0);
+		/*
+		 * $SHELL or /bin/sh may be an old version of ksh that cannot use
+		 * a freshly built copy of libast due to ABI changes. To ensure
+		 * the build doesn't prematurely fail with an undefined symbol error
+		 * LD_LIBRARY_PATH is unset before the shell is invoked.
+		 */
+		unsetenv("LD_LIBRARY_PATH");
 		execl(state.shell, "sh", "-c", s, (char*)0);
 		if (errno == ENOENT)
 			exit(127);

--- a/src/cmd/INIT/mamake.c
+++ b/src/cmd/INIT/mamake.c
@@ -1294,13 +1294,6 @@ static int execute(char *s)
 	if (pid == 0)
 	{	/* child */
 		report(-5, s, "exec", 0);
-		/*
-		 * $SHELL or /bin/sh may be an old version of ksh that cannot use
-		 * a freshly built copy of libast due to ABI changes. To ensure
-		 * the build doesn't prematurely fail with an undefined symbol error
-		 * LD_LIBRARY_PATH is unset before the shell is invoked.
-		 */
-		unsetenv("LD_LIBRARY_PATH");
 		execl(state.shell, "sh", "-c", s, (char*)0);
 		if (errno == ENOENT)
 			exit(127);


### PR DESCRIPTION
Commit e9278fa exposed a build error that can occur when mamake attempts to use ksh as the shell for invoking exec scripts:
```
# src/lib/libast/Mamfile: 4796-4801: make ${INSTALLROOT}/dyn/lib/libast.so
+ LDFLAGS='  -Wl,-no-as-needed'
+ export LDFLAGS
+ sed 1d ast.req
+ dylink -m ast -v 6.0 -p lib -s .so state.o opendir.o --redacted object file list--
[dylink] + cc -Wl,-no-as-needed -o /home/johno/GitRepos/KornShell/ksh/arch/linux.i386-64/dyn/lib/libast.so.6.0 --redacted--
# src/lib/libast/Mamfile: 4809-4811: make ${INSTALLROOT}/lib/mam
sh: symbol lookup error: /usr/lib/libcmd.so.2: undefined symbol: _ast_getpgrp
mamake [lib/libast]: *** exit code 127 making /home/johno/GitRepos/KornShell/ksh/arch/linux.i386-64/lib/mam
mamake: *** exit code 1 making lib/libast
mamake: *** exit code 1 making all
package: make failed at Sun Jul 21 16:16:04 PDT 2024 in /home/johno/GitRepos/KornShell/ksh/arch/linux.i386-64
```
This error is caused by mamake using the system's installed ksh binary, which is dynamically linked to its own libast.so.
`bin/package` exports `LD_LIBRARY_PATH` and mamake inherits it, which causes ksh to try to use the freshly built libast.so produced by dylink.
https://github.com/ksh93/ksh/blob/6f4ba06b8c8a5b8a8408be6b9c37882c80972eec/bin/package#L2072-L2074
The new libast.so is binary incompatible with the system's libcmd.so and by extension `/bin/ksh`, so the build fails with an undefined symbol error.

src/cmd/INIT/mamake.c:
\- After forking a child process for the exec script, unset `LD_LIBRARY_PATH` before invoking the shell, as there is no guarantee the shell isn't an older release of ksh incompatible with a freshly built libast.so.