### PR TITLE
Fix `bin/package host` mistaking 64-bit systems for 32-bit in `fakeroot`

### DIFF
--- a/bin/package
+++ b/bin/package
@@ -1545,7 +1545,7 @@ int b(void) { return 0; }
 					echo 'int main(void) { return 0; }' > $tmp.a.c
 					checkcc
 					$cc $CCFLAGS -o $tmp.a.exe $tmp.a.c </dev/null >/dev/null 2>&1
-					file $tmp.a.exe 2>/dev/null | sed "s/$tmp\.a\.exe//g"  )
+					{ file $tmp.a.exe || file --no-sandbox $tmp.a.exe; } 2>/dev/null | sed "s/$tmp\.a\.exe//g")
 				case $bits in
 				*\ 64-bit* | *\ 64\ bit* | *\ 64bit*)
 					bits=64 ;;


### PR DESCRIPTION
When `file` is run inside of an Arch Linux PKGBUILD's `package()` function (but not `build()`), it will fail:
```
PKGBUILD: line 27: 210645 Bad system call         file /bin/ksh
```
This error is caused by seccomp restricting `file`'s usage of system calls when inside of a fakeroot environment:
```
$ rm -rf ./arch
$ fakeroot
# file /bin/ksh
Bad system call
# bin/package host
linux.i386
# uname -m
x86_64
```
Since `file` fails to run, `bin/package` fails to get information from it (the test executable compiles successfully, but `file` errors out).
https://github.com/ksh93/ksh/blob/9926e2b99b8f2648eb6dacd80e9c0c1472ecb9fb/bin/package#L1541-L1553
This bug is currently the reason the [ksh93-git PKGBUILD](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=ksh93-git#n44) does not use `bin/package install`, since bin/package will first create 'arch/linux.i386-64' during `build()`, then create and attempt to use a spurious 'arch/linux.i386' folder during `package()`.

bin/package:
\- If the first use of `file` fails, try again with `--no-sandbox` to disable seccomp restrictions.