### PR TITLE
Fix many errors that occur on 32-bit systems under UBSan

### DIFF
--- a/src/cmd/INIT/mamake.c
+++ b/src/cmd/INIT/mamake.c
@@ -409,7 +409,7 @@ static void report(int level, char *text, char *item, Rule_t *r)
 		fprintf(stderr, "%s", text);
 		if (r && r->time && state.debug <= -2)
 #if __STDC_VERSION__ >= 199901L
-			fprintf(stderr, " %lld", (long long)r->time);
+			fprintf(stderr, " %llu", (unsigned long long)r->time);
 #else
 			fprintf(stderr, " %lu", (unsigned long)r->time);
 #endif

--- a/src/cmd/builtin/pty.c
+++ b/src/cmd/builtin/pty.c
@@ -348,7 +348,7 @@ mkpty(int* master, int* minion)
 static Proc_t*
 runcmd(char** argv, int minion, int session)
 {
-	long	ops[4];
+	int64_t	ops[4];
 
 	if (session)
 	{

--- a/src/cmd/ksh93/bltins/alarm.c
+++ b/src/cmd/ksh93/bltins/alarm.c
@@ -189,13 +189,9 @@ static void putval(Namval_t* np, const char* val, int flag, Namfun_t* fp)
 	if(val)
 	{
 		double now;
-#ifdef timeofday
 		struct timeval tmp;
 		timeofday(&tmp);
 		now = tmp.tv_sec + 1.e-6*tmp.tv_usec;
-#else
-		now = (double)time(NULL);
-#endif /* timeofday */
 		nv_putv(np,val,flag,fp);
 		d = nv_getnum(np);
 		if(*val=='+')

--- a/src/cmd/ksh93/bltins/misc.c
+++ b/src/cmd/ksh93/bltins/misc.c
@@ -520,13 +520,13 @@ int    b_jobs(int n,char *argv[],Shbltin_t *context)
  */
 static void	print_times(struct timeval utime, struct timeval stime)
 {
-	int ut_min = utime.tv_sec / 60;
-	int ut_sec = utime.tv_sec % 60;
-	int ut_ms = utime.tv_usec / 1000;
-	int st_min = stime.tv_sec / 60;
-	int st_sec = stime.tv_sec % 60;
-	int st_ms = stime.tv_usec / 1000;
-	sfprintf(sfstdout, sh_isoption(SH_POSIX) ? "%dm%d%c%03ds %dm%d%c%03ds\n" : "%dm%02d%c%03ds %dm%02d%c%03ds\n",
+	Sfulong_t ut_min = utime.tv_sec / 60;
+	Sfulong_t ut_sec = utime.tv_sec % 60;
+	Sfulong_t ut_ms = utime.tv_usec / 1000;
+	Sfulong_t st_min = stime.tv_sec / 60;
+	Sfulong_t st_sec = stime.tv_sec % 60;
+	Sfulong_t st_ms = stime.tv_usec / 1000;
+	sfprintf(sfstdout, sh_isoption(SH_POSIX) ? "%jum%ju%c%03jus %jum%ju%c%03jus\n" : "%jum%02ju%c%03jus %jum%02ju%c%03jus\n",
 		ut_min, ut_sec, sh.radixpoint, ut_ms, st_min, st_sec, sh.radixpoint, st_ms);
 }
 #if _lib_getrusage
@@ -545,23 +545,23 @@ static void	print_cpu_times(void)
 static void	print_cpu_times(void)
 {
 	struct timeval utime, stime;
-	double dtime;
+	Sfdouble_t dtime;
 	int clk_tck = sh.lim.clk_tck;
 	struct tms cpu_times;
 	times(&cpu_times);
 	/* Print the time (user & system) consumed by the shell. */
-	dtime = (double)cpu_times.tms_utime / clk_tck;
+	dtime = (Sfdouble_t)cpu_times.tms_utime / clk_tck;
 	utime.tv_sec = dtime / 60;
 	utime.tv_usec = 1000000 * (dtime - utime.tv_sec);
-	dtime = (double)cpu_times.tms_stime / clk_tck;
+	dtime = (Sfdouble_t)cpu_times.tms_stime / clk_tck;
 	stime.tv_sec = dtime / 60;
 	stime.tv_usec = 1000000 * (dtime - utime.tv_sec);
 	print_times(utime, stime);
 	/* Print the time (user & system) consumed by the child processes of the shell. */
-	dtime = (double)cpu_times.tms_cutime / clk_tck;
+	dtime = (Sfdouble_t)cpu_times.tms_cutime / clk_tck;
 	utime.tv_sec = dtime / 60;
 	utime.tv_usec = 1000000 * (dtime - utime.tv_sec);
-	dtime = (double)cpu_times.tms_cstime / clk_tck;
+	dtime = (Sfdouble_t)cpu_times.tms_cstime / clk_tck;
 	stime.tv_sec = dtime / 60;
 	stime.tv_usec = 1000000 * (dtime - utime.tv_sec);
 	print_times(utime, stime);

--- a/src/cmd/ksh93/bltins/trap.c
+++ b/src/cmd/ksh93/bltins/trap.c
@@ -327,7 +327,7 @@ int	b_suspend(int argc,char *argv[],Shbltin_t *context)
 	}
 	if(kill(sh.pid, SIGSTOP) != 0)
 	{
-		errormsg(SH_DICT, ERROR_exit(1), "could not signal main shell at PID %d", sh.pid);
+		errormsg(SH_DICT, ERROR_exit(1), "could not signal main shell at PID %jd", (Sflong_t)sh.pid);
 		UNREACHABLE();
 	}
 	return 0;

--- a/src/cmd/ksh93/edit/history.c
+++ b/src/cmd/ksh93/edit/history.c
@@ -324,7 +324,7 @@ retry:
 	if(hist_clean(fd) && hist_start>1 && hsize > HIST_MAX)
 	{
 #ifdef DEBUG
-		sfprintf(sfstderr,"%lld: hist_trim hsize=%d\n",(Sflong_t)sh.current_pid,hsize);
+		sfprintf(sfstderr,"%jd: hist_trim hsize=%d\n",(Sflong_t)sh.current_pid,hsize);
 		sfsync(sfstderr);
 #endif /* DEBUG */
 		hp = hist_trim(hp,(int)hp->histind-maxlines);
@@ -747,9 +747,9 @@ static ssize_t hist_write(Sfio_t *iop,const void *buff,size_t insize,Sfdisc_t* h
 	if(hp->auditfp)
 	{
 		time_t	t=time(NULL);
-		sfprintf(hp->auditfp, "%u;%lu;%s;%*s%c",
+		sfprintf(hp->auditfp, "%u;%ju;%s;%*s%c",
 			 sh_isoption(SH_PRIVILEGED) ? sh.euserid : sh.userid,
-			 (unsigned long)t, hp->tty, size, buff, 0);
+			 (Sfulong_t)t, hp->tty, size, buff, 0);
 		sfsync(hp->auditfp);
 	}
 #endif	/* SHOPT_AUDIT */

--- a/src/cmd/ksh93/include/defs.h
+++ b/src/cmd/ksh93/include/defs.h
@@ -169,17 +169,17 @@ extern char		*sh_getcwd(void);
 #endif
 #define sh_translate(s)	_sh_translate(ERROR_dictionary(s))
 
-#define WBITS		(sizeof(long)*8)
+#define WBITS		(sizeof(uint64_t)*8)
 #define WMASK		(0xff)
 
 #if SHOPT_SCRIPTONLY
-#define is_option(s,x)	((x)==SH_INTERACTIVE || (x)==SH_HISTORY ? 0 : ((s)->v[((x)&WMASK)/WBITS] & (1L << ((x) % WBITS))) )
-#define on_option(s,x)	( (x)==SH_INTERACTIVE || (x)==SH_HISTORY ? errormsg(SH_DICT,ERROR_exit(1),e_scriptonly) : ((s)->v[((x)&WMASK)/WBITS] |= (1L << ((x) % WBITS))) )
-#define off_option(s,x)	((x)==SH_INTERACTIVE || (x)==SH_HISTORY ? 0 : ((s)->v[((x)&WMASK)/WBITS] &= ~(1L << ((x) % WBITS))) )
+#define is_option(s,x)	((x)==SH_INTERACTIVE || (x)==SH_HISTORY ? 0 : ((s)->v[((x)&WMASK)/WBITS] & ((uint64_t)1 << ((x) % WBITS))) )
+#define on_option(s,x)	( (x)==SH_INTERACTIVE || (x)==SH_HISTORY ? errormsg(SH_DICT,ERROR_exit(1),e_scriptonly) : ((s)->v[((x)&WMASK)/WBITS] |= ((uint64_t)1 << ((x) % WBITS))) )
+#define off_option(s,x)	((x)==SH_INTERACTIVE || (x)==SH_HISTORY ? 0 : ((s)->v[((x)&WMASK)/WBITS] &= ~((uint64_t)1 << ((x) % WBITS))) )
 #else
-#define is_option(s,x)	((s)->v[((x)&WMASK)/WBITS] & (1L << ((x) % WBITS)))
-#define on_option(s,x)	((s)->v[((x)&WMASK)/WBITS] |= (1L << ((x) % WBITS)))
-#define off_option(s,x)	((s)->v[((x)&WMASK)/WBITS] &= ~(1L << ((x) % WBITS)))
+#define is_option(s,x)	((s)->v[((x)&WMASK)/WBITS] & ((uint64_t)1 << ((x) % WBITS)))
+#define on_option(s,x)	((s)->v[((x)&WMASK)/WBITS] |= ((uint64_t)1 << ((x) % WBITS)))
+#define off_option(s,x)	((s)->v[((x)&WMASK)/WBITS] &= ~((uint64_t)1 << ((x) % WBITS)))
 #endif /* SHOPT_SCRIPTONLY */
 #define sh_isoption(x)	is_option(&sh.options,x)
 #define sh_onoption(x)	on_option(&sh.options,x)

--- a/src/cmd/ksh93/include/fault.h
+++ b/src/cmd/ksh93/include/fault.h
@@ -132,7 +132,7 @@ extern void 	sh_sigdone(void);
 extern void	sh_siginit(void);
 extern void 	sh_sigtrap(int);
 extern void 	sh_sigreset(int);
-extern void 	*sh_timeradd(unsigned long,int ,void (*)(void*),void*);
+extern void 	*sh_timeradd(Sfulong_t,int ,void (*)(void*),void*);
 extern void	sh_timerdel(void*);
 
 extern const char e_alarm[];

--- a/src/cmd/ksh93/include/shell.h
+++ b/src/cmd/ksh93/include/shell.h
@@ -44,7 +44,7 @@
 /* options */
 typedef struct
 {
-	unsigned long v[4];
+	uint64_t v[4];
 }
 Shopt_t;
 
@@ -476,9 +476,9 @@ extern void		*sh_waitnotify(Shwait_f);
 extern Shscope_t	*sh_getscope(int,int);
 extern Shscope_t	*sh_setscope(Shscope_t*);
 extern void		sh_sigcheck(void);
-extern unsigned long	sh_isoption(int);
-extern unsigned long	sh_onoption(int);
-extern unsigned long	sh_offoption(int);
+extern uint64_t		sh_isoption(int);
+extern uint64_t		sh_onoption(int);
+extern uint64_t		sh_offoption(int);
 extern int		sh_exec(const Shnode_t*,int);
 
 /*

--- a/src/cmd/ksh93/sh/init.c
+++ b/src/cmd/ksh93/sh/init.c
@@ -223,7 +223,7 @@ static int		rand_shift;
  */
 static noreturn void *nomemory(size_t s)
 {
-	errormsg(SH_DICT, ERROR_SYSTEM|ERROR_PANIC, "out of memory (needed %llu bytes)", (uintmax_t)s);
+	errormsg(SH_DICT, ERROR_SYSTEM|ERROR_PANIC, "out of memory (needed %zu bytes)", s);
 	UNREACHABLE();
 }
 
@@ -552,13 +552,8 @@ static char* get_ifs(Namval_t* np, Namfun_t *fp)
 /*
  * these functions are used to get and set the SECONDS variable
  */
-#ifdef timeofday
-#   define dtime(tp) ((double)((tp)->tv_sec)+1e-6*((double)((tp)->tv_usec)))
-#   define tms	timeval
-#else
-#   define dtime(tp)	(((double)times(tp))/sh.lim.clk_tck)
-#   define timeofday(a)
-#endif
+#define dtime(tp) ((double)((tp)->tv_sec)+1e-6*((double)((tp)->tv_usec)))
+#define tms	timeval
 
 static void put_seconds(Namval_t* np,const char *val,int flags,Namfun_t *fp)
 {
@@ -1921,17 +1916,17 @@ static void env_init(void)
  */
 #define BYPASS_MACRO
 
-unsigned long sh_isoption BYPASS_MACRO (int opt)
+uint64_t sh_isoption BYPASS_MACRO (int opt)
 {
 	return sh_isoption(opt);
 }
 
-unsigned long sh_onoption BYPASS_MACRO (int opt)
+uint64_t sh_onoption BYPASS_MACRO (int opt)
 {
 	return sh_onoption(opt);
 }
 
-unsigned long sh_offoption BYPASS_MACRO (int opt)
+uint64_t sh_offoption BYPASS_MACRO (int opt)
 {
 	return sh_offoption(opt);
 }

--- a/src/cmd/ksh93/sh/io.c
+++ b/src/cmd/ksh93/sh/io.c
@@ -1089,7 +1089,7 @@ static char *io_usename(char *name, int *perm, int fno, int mode)
 		ep = sp;
 		stkseek(sh.stk,0);
 	}
-	sfprintf(sh.stk, ".<#%lld_%d{;.tmp", (Sflong_t)sh.current_pid, fno);
+	sfprintf(sh.stk, ".<#%jd_%d{;.tmp", (Sflong_t)sh.current_pid, fno);
 	tname = stkfreeze(sh.stk,1);
 	switch(mode)
 	{

--- a/src/cmd/ksh93/sh/jobs.c
+++ b/src/cmd/ksh93/sh/jobs.c
@@ -261,7 +261,7 @@ int job_reap(int sig)
 	Waitevent_f waitevent = sh.waitevent;
 	static int wcontinued = WCONTINUED;
 #ifdef DEBUG
-	if(sfprintf(sfstderr,"ksh: job line %4d: reap PID=%lld critical=%d signal=%d\n",__LINE__,(Sflong_t)sh.current_pid,job.in_critical,sig) <=0)
+	if(sfprintf(sfstderr,"ksh: job line %4d: reap PID=%jd critical=%d signal=%d\n",__LINE__,(Sflong_t)sh.current_pid,job.in_critical,sig) <=0)
 		write(2,"waitsafe\n",9);
 	sfsync(sfstderr);
 #endif /* DEBUG */
@@ -314,7 +314,7 @@ int job_reap(int sig)
 		if(!(pw=job_bypid(pid)))
 		{
 #ifdef DEBUG
-			sfprintf(sfstderr,"ksh: job line %4d: reap PID=%lld critical=%d unknown job PID=%d pw=%x\n",__LINE__,(Sflong_t)sh.current_pid,job.in_critical,pid,pw);
+			sfprintf(sfstderr,"ksh: job line %4d: reap PID=%jd critical=%d unknown job PID=%jd pw=%x\n",__LINE__,(Sflong_t)sh.current_pid,job.in_critical,(Sflong_t)pid,pw);
 #endif /* DEBUG */
 			if (WIFCONTINUED(wstat) && wcontinued)
 				continue;
@@ -420,7 +420,7 @@ int job_reap(int sig)
 				jp->exitval |= SH_EXITSIG;
 		}
 #ifdef DEBUG
-		sfprintf(sfstderr,"ksh: job line %4d: reap PID=%lld critical=%d job %d with PID %d flags=%o complete with status=%x exit=%d\n",__LINE__,(Sflong_t)sh.current_pid,job.in_critical,pw->p_job,pid,pw->p_flag,wstat,pw->p_exit);
+		sfprintf(sfstderr,"ksh: job line %4d: reap PID=%jd critical=%d job %d with PID %jd flags=%o complete with status=%x exit=%d\n",__LINE__,(Sflong_t)sh.current_pid,job.in_critical,pw->p_job,(Sflong_t)pid,pw->p_flag,wstat,pw->p_exit);
 		sfsync(sfstderr);
 #endif /* DEBUG */
 		/* only top-level process in job should have notify set */
@@ -787,7 +787,7 @@ int job_list(struct process *pw,int flag)
 		return 0;
 	if((flag&JOB_PFLAG))
 	{
-		sfprintf(outfile,"%d\n",px->p_pgrp?px->p_pgrp:px->p_pid);
+		sfprintf(outfile,"%jd\n",(Sflong_t)(px->p_pgrp?px->p_pgrp:px->p_pid));
 		return 0;
 	}
 	if((px->p_flag&P_DONE) && job.waitall && !(flag&JOB_LFLAG))
@@ -807,7 +807,7 @@ int job_list(struct process *pw,int flag)
 	{
 		n = 0;
 		if(flag&JOB_LFLAG)
-			sfprintf(outfile,"%d\t",px->p_pid);
+			sfprintf(outfile,"%jd\t",(Sflong_t)px->p_pid);
 		if(px->p_flag&P_SIGNALLED)
 			msg = job_sigmsg((int)(px->p_exit));
 		else if(px->p_flag&P_NOTIFY)
@@ -822,7 +822,7 @@ int job_list(struct process *pw,int flag)
 		msize = strlen(msg);
 		if(n)
 		{
-			sfprintf(outfile,"(%d)",(int)n);
+			sfprintf(outfile,"(%d)",n);
 			msize += (3+(n>10)+(n>100));
 		}
 		if(px->p_flag&P_COREDUMP)
@@ -1158,8 +1158,8 @@ int job_post(pid_t pid, pid_t join)
 		pw->p_fgrp = 0;
 	pw->p_pgrp = pw->p_fgrp;
 #ifdef DEBUG
-	sfprintf(sfstderr,"ksh: job line %4d: post PID=%lld critical=%d job=%d PID=%d PGID=%d savesig=%d join=%d\n",__LINE__,(Sflong_t)sh.current_pid,job.in_critical,pw->p_job,
-		pw->p_pid,pw->p_pgrp,job.savesig,join);
+	sfprintf(sfstderr,"ksh: job line %4d: post PID=%jd critical=%d job=%d PID=%jd PGID=%jd savesig=%d join=%d\n",__LINE__,(Sflong_t)sh.current_pid,job.in_critical,pw->p_job,
+		(Sflong_t)pw->p_pid,(Sflong_t)pw->p_pgrp,job.savesig,join);
 	sfsync(sfstderr);
 #endif /* DEBUG */
 	if(hp && !sh_isstate(SH_PROFILE) && !sh.realsubshell)
@@ -1242,7 +1242,7 @@ static void job_prmsg(struct process *pw)
 		if(sh_isstate(SH_INTERACTIVE))
 			sfprintf(sfstderr,"%s%s\n",msg,dump);
 		else
-			errormsg(SH_DICT,2,"%d: %s%s",pw->p_pid,msg,dump);
+			errormsg(SH_DICT,2,"%jd: %s%s",(Sflong_t)pw->p_pid,msg,dump);
 	}
 }
 
@@ -1304,9 +1304,9 @@ int	job_wait(pid_t pid)
 	}
 	pwfg = pw;
 #ifdef DEBUG
-	sfprintf(sfstderr,"ksh: job line %4d: wait PID=%lld critical=%d job=%d PID=%d\n",__LINE__,(Sflong_t)sh.current_pid,job.in_critical,jobid,pid);
+	sfprintf(sfstderr,"ksh: job line %4d: wait PID=%jd critical=%d job=%d PID=%jd\n",__LINE__,(Sflong_t)sh.current_pid,job.in_critical,jobid,(Sflong_t)pid);
 	if(pw)
-		sfprintf(sfstderr,"ksh: job line %4d: wait PID=%lld critical=%d flags=%o\n",__LINE__,(Sflong_t)sh.current_pid,job.in_critical,pw->p_flag);
+		sfprintf(sfstderr,"ksh: job line %4d: wait PID=%jd critical=%d flags=%o\n",__LINE__,(Sflong_t)sh.current_pid,job.in_critical,pw->p_flag);
 #endif /* DEBUG */
 	errno = 0;
 	if(sh.coutpipe>=0 && lastpid && sh.cpid==lastpid)
@@ -1547,7 +1547,7 @@ static struct process *job_unpost(struct process *pwtop,int notify)
 	struct process *pw;
 	/* make sure all processes are done */
 #ifdef DEBUG
-	sfprintf(sfstderr,"ksh: job line %4d: drop PID=%lld critical=%d PID=%d env=%u\n",__LINE__,(Sflong_t)sh.current_pid,job.in_critical,pwtop->p_pid,pwtop->p_env);
+	sfprintf(sfstderr,"ksh: job line %4d: drop PID=%jd critical=%d PID=%jd env=%u\n",__LINE__,(Sflong_t)sh.current_pid,job.in_critical,(Sflong_t)pwtop->p_pid,pwtop->p_env);
 	sfsync(sfstderr);
 #endif /* DEBUG */
 	pwtop = pw = job_byjid(pwtop->p_job);
@@ -1593,7 +1593,7 @@ static struct process *job_unpost(struct process *pwtop,int notify)
 	}
 	pwtop->p_pid = 0;
 #ifdef DEBUG
-	sfprintf(sfstderr,"ksh: job line %4d: free PID=%lld critical=%d job=%d\n",__LINE__,(Sflong_t)sh.current_pid,job.in_critical,pwtop->p_job);
+	sfprintf(sfstderr,"ksh: job line %4d: free PID=%jd critical=%d job=%d\n",__LINE__,(Sflong_t)sh.current_pid,job.in_critical,pwtop->p_job);
 	sfsync(sfstderr);
 #endif /* DEBUG */
 	job_free(pwtop->p_job);
@@ -1783,7 +1783,7 @@ void job_subrestore(void* ptr)
 void job_fork(pid_t parent)
 {
 #ifdef DEBUG
-	sfprintf(sfstderr,"ksh: job line %4d: fork PID=%lld critical=%d parent=%d\n",__LINE__,(Sflong_t)sh.current_pid,job.in_critical,parent);
+	sfprintf(sfstderr,"ksh: job line %4d: fork PID=%jd critical=%d parent=%d\n",__LINE__,(Sflong_t)sh.current_pid,job.in_critical,parent);
 #endif /* DEBUG */
 	switch (parent)
 	{

--- a/src/cmd/ksh93/sh/lex.c
+++ b/src/cmd/ksh93/sh/lex.c
@@ -234,7 +234,7 @@ int sh_lex(Lex_t *lp)
 		if(flag&ARG_QUOTED)
 			quoted = "quoted:";
 	}
-	sfprintf(sfstderr,"%lld: line %d: %o:%s%s%s%s %s\n",(Sflong_t)sh.current_pid,sh.inlineno,tok,quoted,
+	sfprintf(sfstderr,"%jd: line %d: %o:%s%s%s%s %s\n",(Sflong_t)sh.current_pid,sh.inlineno,tok,quoted,
 		macro, split, expand, fmttoken(lp,tok));
 	return tok;
 }

--- a/src/cmd/ksh93/sh/macro.c
+++ b/src/cmd/ksh93/sh/macro.c
@@ -2190,7 +2190,7 @@ static void comsubst(Mac_t *mp,Shnode_t* t, int type)
 			if((Sflong_t)num!=num)
 				sfprintf(sh.strbuf,"%.*Lg",LDBL_DIG,num);
 			else if(num)
-				sfprintf(sh.strbuf,"%lld",(Sflong_t)num);
+				sfprintf(sh.strbuf,"%jd",(Sflong_t)num);
 			else
 				sfprintf(sh.strbuf,"%Lg",num);
 			str = sfstruse(sh.strbuf);

--- a/src/cmd/ksh93/sh/main.c
+++ b/src/cmd/ksh93/sh/main.c
@@ -517,7 +517,7 @@ static void	exfile(Sfio_t *iop,int fno)
 			{
 				buff.mode = SH_JMPERREXIT;
 #ifdef DEBUG
-				errormsg(SH_DICT,ERROR_warn(0),"%lld: mode changed to SH_JMPERREXIT",(Sflong_t)sh.current_pid);
+				errormsg(SH_DICT,ERROR_warn(0),"%jd: mode changed to SH_JMPERREXIT",(Sflong_t)sh.current_pid);
 #endif
 			}
 		}

--- a/src/cmd/ksh93/sh/parse.c
+++ b/src/cmd/ksh93/sh/parse.c
@@ -2082,12 +2082,12 @@ int kiaclose(Lex_t *lexp)
 		sfmove(kia.tmp,kia.file,SFIO_UNBOUND,-1);
 		off2 = sfseek(kia.file,0,SEEK_END);
 		if(off2==off1)
-			n= sfprintf(kia.file,"DIRECTORY\nENTITY;%lld;%d\nDIRECTORY;",(Sflong_t)kia.begin,(size_t)(off1-kia.begin));
+			n= sfprintf(kia.file,"DIRECTORY\nENTITY;%jd;%zu\nDIRECTORY;",(Sflong_t)kia.begin,(size_t)(off1-kia.begin));
 		else
-			n= sfprintf(kia.file,"DIRECTORY\nENTITY;%lld;%d\nRELATIONSHIP;%lld;%d\nDIRECTORY;",(Sflong_t)kia.begin,(size_t)(off1-kia.begin),(Sflong_t)off1,(size_t)(off2-off1));
+			n= sfprintf(kia.file,"DIRECTORY\nENTITY;%jd;%zu\nRELATIONSHIP;%jd;%zu\nDIRECTORY;",(Sflong_t)kia.begin,(size_t)(off1-kia.begin),(Sflong_t)off1,(size_t)(off2-off1));
 		if(off2 >= INT_MAX)
 			off2 = -(n+12);
-		sfprintf(kia.file,"%010.10lld;%010d\n",(Sflong_t)off2+10, n+12);
+		sfprintf(kia.file,"%010.10jd;%010d\n",(Sflong_t)off2+10, n+12);
 	}
 	return sfclose(kia.file);
 }

--- a/src/cmd/ksh93/sh/path.c
+++ b/src/cmd/ksh93/sh/path.c
@@ -1049,7 +1049,7 @@ pid_t path_spawn(const char *opath,char **argv, char **envp, Pathcomp_t *libpath
 #if _lib_readlink
 	/* save original pathname */
 	stkseek(sh.stk,PATH_OFFSET);
-	pidsize = sfprintf(sh.stk, "*%lld*", (Sflong_t)(spawn ? sh.current_pid : sh.current_ppid));
+	pidsize = sfprintf(sh.stk, "*%jd*", (Sflong_t)(spawn ? sh.current_pid : sh.current_ppid));
 	sfputr(sh.stk,opath,-1);
 	opath = stkfreeze(sh.stk,1)+PATH_OFFSET+pidsize;
 	np = path_gettrackedalias(argv[0]);

--- a/src/cmd/ksh93/sh/timers.c
+++ b/src/cmd/ksh93/sh/timers.c
@@ -26,8 +26,8 @@
 
 typedef struct _timer
 {
-	double		wakeup;
-	double		incr;
+	Sfdouble_t	wakeup;
+	Sfdouble_t	incr;
 	struct _timer	*next;
 	void 		(*action)(void*);
 	void		*handle;
@@ -41,29 +41,24 @@ typedef struct _timer
 static Timer_t *tptop, *tpmin, *tpfree;
 static char time_state;
 
-static double getnow(void)
+static Sfdouble_t getnow(void)
 {
-	double now;
-#ifdef timeofday
+	Sfdouble_t now;
 	struct timeval tp;
 	timeofday(&tp);
 	now = tp.tv_sec + 1.e-6*tp.tv_usec;
-
-#else
-	now = (double)time(NULL);
-#endif /* timeofday */
 	return now+.001;
 }
 
 /*
  * set an alarm for <t> seconds
  */
-static double setalarm(double t)
+static Sfdouble_t setalarm(Sfdouble_t t)
 {
 #if defined(_lib_setitimer) && defined(ITIMER_REAL)
 	struct itimerval tnew, told;
 	tnew.it_value.tv_sec = t;
-	tnew.it_value.tv_usec = 1.e6*(t- (double)tnew.it_value.tv_sec);
+	tnew.it_value.tv_usec = 1.e6*(t- (Sfdouble_t)tnew.it_value.tv_sec);
 	if(t && tnew.it_value.tv_sec==0 && tnew.it_value.tv_usec<1000)
 		tnew.it_value.tv_usec = 1000;
 	tnew.it_interval.tv_sec = 0;
@@ -78,7 +73,7 @@ static double setalarm(double t)
 	unsigned seconds = (unsigned)t;
 	if(t && seconds<1)
 		seconds=1;
-	t = (double)alarm(seconds);
+	t = (Sfdouble_t)alarm(seconds);
 #endif
 	return t;
 }
@@ -87,8 +82,8 @@ static double setalarm(double t)
 static void sigalrm(int sig)
 {
 	Timer_t *tp, *tplast, *tpold, *tpnext;
-	double now;
-	static double left;
+	Sfdouble_t now;
+	static Sfdouble_t left;
 	NOT_USED(sig);
 	left = 0;
 	if(time_state&SIGALRM_CALL)
@@ -178,12 +173,12 @@ static void oldalrm(void *handle)
 	(*fn)(SIGALRM);
 }
 
-void *sh_timeradd(unsigned long msec,int flags,void (*action)(void*),void *handle)
+void *sh_timeradd(Sfulong_t msec,int flags,void (*action)(void*),void *handle)
 {
 	Timer_t *tp;
-	double t;
+	Sfdouble_t t;
 	Handler_t fn;
-	t = ((double)msec)/1000.;
+	t = ((Sfdouble_t)msec)/1000.;
 	if(t<=0 || !action)
 		return NULL;
 	if(tp=tpfree)
@@ -205,7 +200,7 @@ void *sh_timeradd(unsigned long msec,int flags,void (*action)(void*),void *handl
 		{
 			Handler_t *hp = (Handler_t*)sh_malloc(sizeof(Handler_t));
 			*hp = fn;
-			sh_timeradd((long)(1000*t), 0, oldalrm, hp);
+			sh_timeradd((Sflong_t)(1000*t), 0, oldalrm, hp);
 		}
 		tp = tptop;
 	}
@@ -237,7 +232,7 @@ void	sh_timerdel(void *handle)
 		if(tpmin)
 		{
 			tpmin = 0;
-			setalarm((double)0);
+			setalarm((Sfdouble_t)0);
 		}
 		signal(SIGALRM,(sh.sigflag[SIGALRM]&SH_SIGFAULT)?sh_fault:SIG_DFL);
 	}

--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -115,12 +115,11 @@ static void get_cpu_times(struct timeval *tv_usr, struct timeval *tv_sys)
 	timeradd(&usage_self.ru_stime, &usage_child.ru_stime, tv_sys);
 }
 #else
-#ifdef timeofday
 static void get_cpu_times(struct timeval *tv_usr, struct timeval *tv_sys)
 {
 	struct tms cpu_times;
 	struct timeval tv1, tv2;
-	double dtime;
+	Sfdouble_t dtime;
 
 	if(times(&cpu_times) == (clock_t)-1)
 	{
@@ -128,90 +127,61 @@ static void get_cpu_times(struct timeval *tv_usr, struct timeval *tv_sys)
 		UNREACHABLE();
 	}
 
-	dtime = (double)cpu_times.tms_utime / sh.lim.clk_tck;
+	dtime = (Sfdouble_t)cpu_times.tms_utime / sh.lim.clk_tck;
 	tv1.tv_sec = dtime / 60;
 	tv1.tv_usec = 1000000 * (dtime - tv1.tv_sec);
-	dtime = (double)cpu_times.tms_cutime / sh.lim.clk_tck;
+	dtime = (Sfdouble_t)cpu_times.tms_cutime / sh.lim.clk_tck;
 	tv2.tv_sec = dtime / 60;
 	tv2.tv_usec = 1000000 * (dtime - tv2.tv_sec);
 	timeradd(&tv1, &tv2, tv_usr);
 
-	dtime = (double)cpu_times.tms_stime / sh.lim.clk_tck;
+	dtime = (Sfdouble_t)cpu_times.tms_stime / sh.lim.clk_tck;
 	tv1.tv_sec = dtime / 60;
 	tv1.tv_usec = 1000000 * (dtime - tv1.tv_sec);
-	dtime = (double)cpu_times.tms_cstime / sh.lim.clk_tck;
+	dtime = (Sfdouble_t)cpu_times.tms_cstime / sh.lim.clk_tck;
 	tv2.tv_sec = dtime / 60;
 	tv2.tv_usec = 1000000 * (dtime - tv2.tv_sec);
 	timeradd(&tv1, &tv2, tv_sys);
 }
-#endif /* timeofday */
 #endif /* _lib_getrusage */
 
-#ifdef timeofday
-static inline double timeval_to_double(struct timeval tv)
+static inline Sfdouble_t timeval_to_double(struct timeval tv)
 {
-	return (double)tv.tv_sec + ((double)tv.tv_usec / 1000000.0);
+	return (Sfdouble_t)tv.tv_sec + ((Sfdouble_t)tv.tv_usec / 1000000.0);
 }
-#endif
 
 /*
  * print time <t> in h:m:s format with precision <p>
  */
-#ifdef timeofday
 static void l_time(Sfio_t *outfile, struct timeval *tv, int precision)
 {
-	int hr = tv->tv_sec / (60 * 60);
-	int min = (tv->tv_sec / 60) % 60;
-	int sec = tv->tv_sec % 60;
-	int frac = tv->tv_usec;
+	Sfulong_t hr = tv->tv_sec / (60 * 60);
+	Sfulong_t min = (tv->tv_sec / 60) % 60;
+	Sfulong_t sec = tv->tv_sec % 60;
+	Sfulong_t frac = tv->tv_usec;
 
 	/* scale fraction from micro to milli, centi, or deci second according to precision */
 	int n;
 	for(n = 3 + (3 - precision); n > 0; --n)
 		frac /= 10;
-#else
-/* fallback */
-static void l_time(Sfio_t *outfile,clock_t t,int precision)
-{
-	int min, sec, frac;
-	int hr;
-	if(precision)
-	{
-		frac = t%sh.lim.clk_tck;
-		frac = (frac*(int)pow(10,precision))/sh.lim.clk_tck;
-	}
-	t /= sh.lim.clk_tck;
-	sec = t%60;
-	t /= 60;
-	min = t%60;
-	hr = t/60;
-#endif
 	if(hr)
-		sfprintf(outfile,"%dh",hr);
+		sfprintf(outfile,"%juh",hr);
 	if(precision)
-		sfprintf(outfile, sh_isoption(SH_POSIX) ? "%dm%d%c%0*ds" : "%dm%02d%c%0*ds", min, sec, sh.radixpoint, precision, frac);
+		sfprintf(outfile, sh_isoption(SH_POSIX) ? "%jum%ju%c%0*jus" : "%jum%02ju%c%0*jus", min, sec, sh.radixpoint, precision, frac);
 	else
-		sfprintf(outfile, sh_isoption(SH_POSIX) ? "%dm%ds" : "%dm%02ds", min, sec);
+		sfprintf(outfile, sh_isoption(SH_POSIX) ? "%jum%jus" : "%jum%02jus", min, sec);
 }
 
 #define TM_REAL_IDX 0
 #define TM_USR_IDX 1
 #define TM_SYS_IDX 2
 
-#ifdef timeofday
 static void p_time(Sfio_t *out, const char *format, struct timeval tm[3])
-#else
-static void p_time(Sfio_t *out, const char *format, clock_t *tm)
-#endif
 {
 	int		c,n,offset = stktell(sh.stk);
 	const char	*first;
-#ifdef timeofday
 	struct timeval	tv_cpu_sum;
 	struct timeval	*tvp;
-#else
-	double d;
-#endif
 	for(first=format; *format; format++)
 	{
 		unsigned char l_modifier = 0;
@@ -241,10 +211,9 @@ static void p_time(Sfio_t *out, const char *format, clock_t *tm)
 		}
 		if(c=='P')
 		{
-#ifdef timeofday
 			struct timeval tv_real = tm[TM_REAL_IDX];
 			struct timeval tv_cpu;
-			double d;
+			Sfdouble_t d;
 			timeradd(&tm[TM_USR_IDX], &tm[TM_SYS_IDX], &tv_cpu);
 			d = timeval_to_double(tv_real);
 			if(d)
@@ -252,19 +221,12 @@ static void p_time(Sfio_t *out, const char *format, clock_t *tm)
 			sfprintf(sh.stk, "%.*f", precision, d);
 			first = format + 1;
 			continue;
-#else
-			if(d=tm[0])
-				d = 100.*(((double)(tm[1]+tm[2]))/d);
-			precision = 2;
-			goto skip;
-#endif
 		}
 		if(c=='l')
 		{
 			l_modifier = 1;
 			c = *++format;
 		}
-#ifdef timeofday
 		if(c=='R')
 			tvp = &tm[TM_REAL_IDX];
 		else if(c=='U')
@@ -288,43 +250,15 @@ static void p_time(Sfio_t *out, const char *format, clock_t *tm)
 		else
 		{
 			/* scale fraction from micro to milli, centi, or deci second according to precision */
-			long sec = tvp->tv_sec;
-			int n, frac = tvp->tv_usec;
+			Sfulong_t sec = tvp->tv_sec;
+			Sfulong_t n, frac = tvp->tv_usec;
 			for(n = 3 + (3 - precision); n > 0; --n)
 				frac /= 10;
 			if(precision)
-				sfprintf(sh.stk, "%ld%c%0*d", sec, sh.radixpoint, precision, frac);
+				sfprintf(sh.stk, "%ju%c%0*ju", sec, sh.radixpoint, precision, frac);
 			else
-				sfprintf(sh.stk, "%ld", sec);
+				sfprintf(sh.stk, "%ju", sec);
 		}
-#else
-		if(c=='R')
-			n = 0;
-		else if(c=='U')
-			n = 1;
-		else if(c=='S')
-			n = 2;
-		else if(c=='C')
-			n = 3;
-		else
-		{
-			stkseek(sh.stk,offset);
-			errormsg(SH_DICT,ERROR_exit(0),e_badtformat,c);
-			return;
-		}
-		if(n==3)
-		{
-			/* sum of U + S */
-			d = (double)((tm[1]+tm[2])/sh.lim.clk_tck);
-		}
-		else
-			d = (double)tm[n]/sh.lim.clk_tck;
-	skip:
-		if(l_modifier)
-			l_time(sh.stk, n==3 ? tm[1] + tm[2] : tm[n], precision);
-		else
-			sfprintf(sh.stk,"%.*f", precision, d);
-#endif
 		first = format+1;
 	}
 	if(format>first)
@@ -2302,12 +2236,7 @@ int sh_exec(const Shnode_t *t, int flags)
 		    {
 			const char *format = e_timeformat;
 			struct timeval ta, tb;
-#ifdef timeofday
 			struct timeval before_usr, before_sys, after_usr, after_sys, tm[3];
-#else
-			struct tms before,after;
-			clock_t at, bt, tm[3];
-#endif
 			if(type!=TTIME)
 			{
 				sh_exec(t->par.partre, flags & ARG_OPTIMIZE);
@@ -2317,18 +2246,9 @@ int sh_exec(const Shnode_t *t, int flags)
 			if(t->par.partre)
 			{
 				int timer_on = sh_isstate(SH_TIMING);
-#ifdef timeofday
 				/* must be run after forking a subshell */
 				timeofday(&tb);
 				get_cpu_times(&before_usr, &before_sys);
-#else
-				bt = times(&before);
-				if(bt == (clock_t)-1)
-				{
-					errormsg(SH_DICT, ERROR_exit(1), "times(3) failed: %s", strerror(errno));
-					UNREACHABLE();
-				}
-#endif
 				sh_onstate(SH_TIMING);
 				sh_exec(t->par.partre,sh_isstate(SH_ERREXIT)|(flags & ARG_OPTIMIZE));
 				if(!timer_on)
@@ -2336,31 +2256,14 @@ int sh_exec(const Shnode_t *t, int flags)
 			}
 			else
 			{
-#ifdef timeofday
 				before_usr.tv_sec = before_usr.tv_usec = 0;
 				before_sys.tv_sec = before_sys.tv_usec = 0;
-#else
-				bt = 0;
-				before.tms_utime = before.tms_cutime = 0;
-				before.tms_stime = before.tms_cstime = 0;
-#endif
 			}
-#ifndef timeofday
-			at = times(&after) - bt;
-			if(at == (clock_t)-1)
-			{
-				errormsg(SH_DICT, ERROR_exit(1), "times(3) failed: %s", strerror(errno));
-				UNREACHABLE();
-			}
-			tm[0] = at;
-#else
 			get_cpu_times(&after_usr, &after_sys);
 			timeofday(&ta);
 			timersub(&ta, &tb, &tm[TM_REAL_IDX]); /* calculate elapsed real-time */
 			timersub(&after_usr, &before_usr, &tm[TM_USR_IDX]);
 			timersub(&after_sys, &before_sys, &tm[TM_SYS_IDX]);
-#endif
-
 			if(t->par.partre)
 			{
 				Namval_t *np;
@@ -2369,12 +2272,6 @@ int sh_exec(const Shnode_t *t, int flags)
 			}
 			else
 				format = strchr(format+1,'\n')+1;
-#ifndef timeofday
-			tm[1] = after.tms_utime - before.tms_utime;
-			tm[1] += after.tms_cutime - before.tms_cutime;
-			tm[2] = after.tms_stime - before.tms_stime;
-			tm[2] += after.tms_cstime - before.tms_cstime;
-#endif
 			if(format && *format)
 				p_time(sfstderr,sh_translate(format),tm);
 			break;

--- a/src/cmd/ksh93/shell.3
+++ b/src/cmd/ksh93/shell.3
@@ -32,9 +32,9 @@ Shell_t	*sh_getinterp(void);
 
 Namval_t	*sh_addbuiltin(const char *\fIname\fP, Sh_bltin_f \fIfn\fP, void *\fIarg\fP);
 
-unsigned int	sh_isoption(int \fIoption\fP);
-unsigned int	sh_onoption(int \fIoption\fP);
-unsigned int	sh_offoption(int \fIoption\fP);
+uint64_t	sh_isoption(int \fIoption\fP);
+uint64_t	sh_onoption(int \fIoption\fP);
+uint64_t	sh_offoption(int \fIoption\fP);
 
 void		*sh_parse(Sfio_t *\fIsp\fP, int \fIflags\fP);
 int 		sh_trap(const char *\fIstring\fP, int \fImode\fP);

--- a/src/lib/libast/features/standards
+++ b/src/lib/libast/features/standards
@@ -154,9 +154,11 @@ elif tst note{ GNU (glibc), Cygwin, or Android }end compile{
 		 * (see feature_test_macros(7)), but on GNU we also need to define _FILE_OFFSET_BITS to get large
 		 * file support. We also need to define 'basename' to stop string.h from declaring a GNU-specific
 		 * version of basename(3) which on Cygwin has a declaration that conflicts with AST basename(3).
+		 * Additionally, 64-bit time_t is required to avoid integer overflows in e.g. the 'time' keyword.
 		 */
 		#define _GNU_SOURCE	1
 		#define _FILE_OFFSET_BITS 64
+		#define _TIME_BITS 64
 		#define basename	basename
 		#include <limits.h>
 		#include <unistd.h>
@@ -182,6 +184,9 @@ elif tst note{ GNU (glibc), Cygwin, or Android }end compile{
 		#endif
 		#ifndef _FILE_OFFSET_BITS
 		#define _FILE_OFFSET_BITS 64
+		#endif
+		#ifndef _TIME_BITS
+		#define _TIME_BITS 64
 		#endif
 		#define basename	basename	/* avoid string.h defining this in conflict with AST basename(3) */
 	}

--- a/src/lib/libast/features/time
+++ b/src/lib/libast/features/time
@@ -1,6 +1,7 @@
 lib	getrusage,nanosleep,usleep,_strftime
 typ	clock_t = uint32_t
-typ	time_t = uint32_t
+typ	time_t = uint64_t
+typ	suseconds_t = uint64_t
 
 if sys resource {
 	#include <sys/resource.h>
@@ -38,7 +39,7 @@ if ! mem timeval.tv_sec sys/time.h {
 	struct timeval
 	{
 		time_t	tv_sec;
-		time_t	tv_usec;
+		suseconds_t	tv_usec;
 	};
 }
 endif

--- a/src/lib/libast/features/time
+++ b/src/lib/libast/features/time
@@ -1,7 +1,7 @@
 lib	getrusage,nanosleep,usleep,_strftime
 typ	clock_t = uint32_t
-typ	time_t = uint64_t
-typ	suseconds_t = uint64_t
+typ	time_t = int64_t
+typ	suseconds_t = int32_t
 
 if sys resource {
 	#include <sys/resource.h>

--- a/src/lib/libast/features/tv
+++ b/src/lib/libast/features/tv
@@ -15,7 +15,7 @@ cat{
 
 	typedef struct Tv_s
 	{
-		uint32_t	tv_sec;
+		time_t		tv_sec;
 		uint32_t	tv_nsec;
 	} Tv_t;
 }end

--- a/src/lib/libast/features/tvlib
+++ b/src/lib/libast/features/tvlib
@@ -17,7 +17,7 @@ if ! mem timeval.tv_sec sys/time.h {
 	struct timeval
 	{
 		time_t	tv_sec;
-		time_t	tv_usec;
+		suseconds_t	tv_usec;
 	};
 }
 endif

--- a/src/lib/libast/include/ast_std.h
+++ b/src/lib/libast/include/ast_std.h
@@ -171,12 +171,12 @@ extern char*		strerror(int);
 #define AST_LC_LANG		255
 
 #define AST_LC_internal		1
-#define AST_LC_test		(1L<<26)
-#define AST_LC_setenv		(1L<<27)
-#define AST_LC_find		(1L<<28)
-#define AST_LC_debug		(1L<<29)
-#define AST_LC_setlocale	(1L<<30)
-#define AST_LC_translate	(1L<<31)
+#define AST_LC_test		(1 << 25)
+#define AST_LC_setenv		(1 << 26)
+#define AST_LC_find		(1 << 27)
+#define AST_LC_debug		(1 << 28)
+#define AST_LC_setlocale	(1 << 29)
+#define AST_LC_translate	(1 << 30)
 
 #ifndef LC_ALL
 #define LC_ALL			(-AST_LC_ALL)

--- a/src/lib/libast/include/proc.h
+++ b/src/lib/libast/include/proc.h
@@ -64,8 +64,8 @@
 
 #define PROC_fd_ctty	0xc
 
-#define PROC_op1(o,a)	(((long)(o)<<(2*PROC_ARG_BIT))|((long)(a)&((PROC_ARG_NULL<<PROC_ARG_BIT)|PROC_ARG_NULL)))
-#define PROC_op2(o,a,b)	(((long)(o)<<(2*PROC_ARG_BIT))|(((long)(b)&PROC_ARG_NULL)<<PROC_ARG_BIT)|((long)(a)&PROC_ARG_NULL))
+#define PROC_op1(o,a)	(((int64_t)(o)<<(2*PROC_ARG_BIT))|((int64_t)(a)&((PROC_ARG_NULL<<PROC_ARG_BIT)|PROC_ARG_NULL)))
+#define PROC_op2(o,a,b)	(((int64_t)(o)<<(2*PROC_ARG_BIT))|(((int64_t)(b)&PROC_ARG_NULL)<<PROC_ARG_BIT)|((int64_t)(a)&PROC_ARG_NULL))
 
 #define PROC_FD_CLOSE(p,f)	PROC_op2(PROC_fd_dup|(f),p,PROC_ARG_NULL)
 #define PROC_FD_CTTY(f)		PROC_op1(PROC_fd_ctty,f)
@@ -75,8 +75,8 @@
 #define PROC_SYS_PGRP(g)	PROC_op1(PROC_sys_pgrp,g)
 #define PROC_SYS_UMASK(m)	PROC_op1(PROC_sys_umask,m,0)
 
-#define PROC_OP(x)	(((x)>>(2*PROC_ARG_BIT))&((1<<PROC_OP_BIT)-1))
-#define PROC_ARG(x,n)	((n)?(((x)>>(((n)-1)*PROC_ARG_BIT))&PROC_ARG_NULL):(((x)&~((1<<(2*PROC_ARG_BIT))-1))==~((1<<(2*PROC_ARG_BIT))-1))?(-1):((x)&~((1<<(2*PROC_ARG_BIT))-1)))
+#define PROC_OP(x)	(((int64_t)(x)>>(2*PROC_ARG_BIT))&((1<<PROC_OP_BIT)-1))
+#define PROC_ARG(x,n)	((n)?(((int64_t)(x)>>(((n)-1)*PROC_ARG_BIT))&PROC_ARG_NULL):(((int64_t)(x)&~((1<<(2*PROC_ARG_BIT))-1))==~((1<<(2*PROC_ARG_BIT))-1))?(-1):((int64_t)(x)&~((1<<(2*PROC_ARG_BIT))-1)))
 
 typedef struct
 {
@@ -93,7 +93,7 @@ _PROC_PRIVATE_
 
 extern int	procclose(Proc_t*);
 extern int	procfree(Proc_t*);
-extern Proc_t*	procopen(const char*, char**, char**, long*, int);
+extern Proc_t*	procopen(const char*, char**, char**, int64_t*, int);
 extern int	procrun(const char*, char**, int);
 
 #endif

--- a/src/lib/libast/man/proc.3
+++ b/src/lib/libast/man/proc.3
@@ -43,7 +43,7 @@ proc \- process control routines (deprecated)
 .EX
 #include <proc.h>
 
-Proc_t* procopen(const char* \fIcommand\fP, char** \fIargv\fP, char** \fIenvv\fP, long* \fIopv\fP, long \fIflags\fP);
+Proc_t* procopen(const char* \fIcommand\fP, char** \fIargv\fP, char** \fIenvv\fP, int64_t* \fIopv\fP, int \fIflags\fP);
 int procfree(Proc_t* \fIproc\fP);
 int procclose(Proc_t* \fIproc\fP);
 int procrun(const char* \fIcommand\fP, char** \fIargv\fP);

--- a/src/lib/libast/misc/procopen.c
+++ b/src/lib/libast/misc/procopen.c
@@ -390,7 +390,7 @@ restore(Proc_t* proc)
  */
 
 Proc_t*
-procopen(const char* cmd, char** argv, char** envv, long* modv, int flags)
+procopen(const char* cmd, char** argv, char** envv, int64_t* modv, int flags)
 {
 	Proc_t*		proc = 0;
 	int		procfd = -1;
@@ -399,7 +399,7 @@ procopen(const char* cmd, char** argv, char** envv, long* modv, int flags)
 	int		i;
 	int		forked = 0;
 	int		signalled = 0;
-	long		n;
+	int64_t		n;
 	char		path[PATH_MAX];
 	char		env[PATH_MAX + 2];
 	int		pio[2];

--- a/src/lib/libast/misc/systrace.c
+++ b/src/lib/libast/misc/systrace.c
@@ -34,7 +34,7 @@ systrace(const char* id)
 	char*		s;
 	char		buf[PATH_MAX];
 	char*		av[7];
-	long		ov[2];
+	int64_t		ov[2];
 
 	static char*	trace[] = { "trace", "truss", "strace", "traces" };
 

--- a/src/lib/libast/port/astconf.c
+++ b/src/lib/libast/port/astconf.c
@@ -1302,7 +1302,7 @@ nativeconf(Proc_t** pp, const char* operand)
 {
 	Sfio_t*		sp;
 	char*		cmd[3];
-	long		ops[2];
+	int64_t		ops[2];
 
 #if DEBUG_astconf
 	error(-6, "astconf defer %s %s", _pth_getconf, operand);

--- a/src/lib/libast/sfio/sftable.c
+++ b/src/lib/libast/sfio/sftable.c
@@ -265,7 +265,9 @@ static Fmtpos_t* sffmtpos(Sfio_t* f,const char* form,va_list args,Sffmt_t* ft,in
 					size = sizeof(ptrdiff_t);
 				else if(flags&SFFMT_ZFLAG)
 					size = sizeof(size_t);
-				else if(flags&(SFFMT_LLONG|SFFMT_JFLAG) )
+				else if(flags&SFFMT_LLONG)
+					size = sizeof(long long);
+				else if(flags&SFFMT_JFLAG)
 					size = sizeof(Sflong_t);
 				else if(flags&SFFMT_IFLAG)
 				{	if(size <= 0 ||

--- a/src/lib/libast/sfio/sfvprintf.c
+++ b/src/lib/libast/sfio/sfvprintf.c
@@ -482,7 +482,9 @@ loop_fmt :
 					size = sizeof(ptrdiff_t);
 				else if(flags&SFFMT_ZFLAG)
 					size = sizeof(size_t);
-				else if(flags&(SFFMT_LLONG|SFFMT_JFLAG) )
+				else if(flags&SFFMT_LLONG)
+					size = sizeof(long long);
+				else if(flags&SFFMT_JFLAG)
 					size = sizeof(Sflong_t);
 				else if(flags&SFFMT_IFLAG)
 				{	if(size <= 0 ||

--- a/src/lib/libast/sfio/sfvscanf.c
+++ b/src/lib/libast/sfio/sfvscanf.c
@@ -594,7 +594,9 @@ loop_fmt:
 					size = sizeof(ptrdiff_t);
 				else if(flags&SFFMT_ZFLAG)
 					size = sizeof(size_t);
-				else if(flags&(SFFMT_LLONG|SFFMT_JFLAG) )
+				else if(flags&SFFMT_LLONG)
+					size = sizeof(long long);
+				else if(flags&SFFMT_JFLAG)
 					size = sizeof(Sflong_t);
 				else if(flags&SFFMT_IFLAG)
 				{	if(size <= 0 ||

--- a/src/lib/libast/tm/tvsleep.c
+++ b/src/lib/libast/tm/tvsleep.c
@@ -116,7 +116,7 @@ tvsleep(const Tv_t* tv, Tv_t* rv)
 
 #else
 
-	uint32_t	s = tv->tv_sec;
+	time_t		s = tv->tv_sec;
 	uint32_t	n = tv->tv_nsec;
 	unsigned int	t;
 

--- a/src/lib/libcmd/pids.c
+++ b/src/lib/libcmd/pids.c
@@ -57,7 +57,7 @@ key(void* handle, Sffmt_t* fp, const char* arg, char** ps, Sflong_t* pn)
 {
 	char*	s;
 	int	fd;
-	long	tid;
+	pid_t	tid;
 
 	if (!(s = fp->t_str) || streq(s, "pid"))
 		*pn = getpid();


### PR DESCRIPTION
This commit fixes fixes a large number of runtime errors that occur when ksh is compiled with `-fsanitize=undefined` on Linux 32-bit using GCC.

Noted changes:
- Switched out `long` and `double` for `Sflong_t` and `Sfdouble_t` in many places to fix runtime errors under UBSan. (In certain places `(u)int64_t` was used to specify exactly 64-bits rather than `intmax_t`.) The following errors should no longer occur:
```
src/cmd/ksh93/sh/macro.c:2489:9: runtime error: left shift of 1 by 31 places cannot be represented in type 'long int'
src/cmd/ksh93/sh/args.c:252:4: runtime error: left shift of 1 by 31 places cannot be represented in type 'long int'
src/cmd/ksh93/sh/args.c:272:4: runtime error: left shift of 1 by 31 places cannot be represented in type 'long int'
src/cmd/builtin/pty.c:355:12: runtime error: left shift of 12 by 28 places cannot be represented in type 'long int'
src/cmd/ksh93/sh/args.c:175:60: runtime error: left shift of 1 by 31 places cannot be represented in type 'long int'
src/cmd/ksh93/sh/xec.c:2359:4: runtime error: signed integer overflow: 1734423994 - -1213168416 cannot be represented in type 'long int'
src/cmd/builtin/pty.c:355:12: runtime error: left shift of 12 by 28 places cannot be represented in type 'long int'
src/cmd/ksh93/sh/args.c:607:10: runtime error: left shift of 1 by 31 places cannot be represented in type 'long int'
src/cmd/ksh93/sh/args.c:622:38: runtime error: left shift of 1 by 31 places cannot be represented in type 'long int'
```

- For mamake, use `unsigned long long` to avoid requiring `<stdint.h>`.

- Remove `!timeofday` code. All modern systems have `gettimeofday`, which makes this code unused and an unnecessary maintenance burden.

- Define `_TIME_BITS=64` to fix integer overflows in the `time` keyword and likely elsewhere (ksh assumes `time_t` is 64-bits).

- Moved the `AST_LC_*` bitflags into the 32-bit range.

- Don't assume `long long` and `intmax_t` are the same. While `intmax_t` is in practice the same as `long long`, this is not guaranteed by the C standard (it's permitted for these types to differ). For correctness, only use `%jd` and `%ju` with `Sflong_t` (aka `intmax_t`), and enforce this distinction in SFIO's handling of `%ll` and `%j`. (The extra if statements are optimized away on platforms where the types are identical.)

- Use `suseconds_t` for `tv->usec` and enforce 64-bit `time_t` in the libast feature tests.

- Casted more PIDs to `Sflong_t` when using PIDs with format specifiers.

- Use the `%zu` format specifier with `size_t` vars rather than unnecessary casts.