### PR TITLE
Fix annoying silent crash in builtins.sh under ASan

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -174,6 +174,9 @@ Uppercase BUG_* IDs are shell bug IDs as used by the Modernish shell library.
 - [v1.1] The emacs ^Y command now accepts a numeric parameter. For example,
   ESC 10 ^Y will now "yank" (paste) the latest deleted text 10 times.
 
+- Fixed a crash that could occur in some scenarios when /opt/ast/bin
+  builtins handled invalid options in virtual subshells.
+
 2024-12-25:
 
 - The dirname path-bound built-in now accepts multiple operands.

--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,9 @@ Uppercase BUG_* IDs are shell bug IDs as used by the Modernish shell library.
 
 2025-05-27:
 
+- Fixed a crash that could occur in some scenarios when /opt/ast/bin
+  builtins handled invalid options in virtual subshells.
+
 - Fixed a bug in printf where \u0025 was taken as a % operator in a
   formatter argument. For example, printf '\u0025\n' now correctly prints a
   % followed by a newline instead of producing an error.
@@ -196,9 +199,6 @@ Uppercase BUG_* IDs are shell bug IDs as used by the Modernish shell library.
 
 - [v1.1] The emacs ^Y command now accepts a numeric parameter. For example,
   ESC 10 ^Y will now "yank" (paste) the latest deleted text 10 times.
-
-- Fixed a crash that could occur in some scenarios when /opt/ast/bin
-  builtins handled invalid options in virtual subshells.
 
 2024-12-25:
 

--- a/src/cmd/ksh93/sh/init.c
+++ b/src/cmd/ksh93/sh/init.c
@@ -244,7 +244,11 @@ void *sh_realloc(void *ptr, size_t size)
 	void *cp;
 	cp = realloc(ptr, size);
 	if(!cp)
+	{
+		if(ptr)
+			free(ptr);
 		nomemory(size);
+	}
 	return cp;
 }
 

--- a/src/lib/libast/port/astconf.c
+++ b/src/lib/libast/port/astconf.c
@@ -467,16 +467,19 @@ synthesize(Feature_t* fp, const char* path, const char* value, Error_f conferror
 		fp->value = 0;
 	if (n == 1 && (*value == '0' || *value == '-'))
 		n = 0;
-	fp->flags |= CONF_ALLOC;
 	if(!(newvalue = calloc(1, n + 1)))
 	{
+		if(fp->value && fp->value != null)
+			free(fp->value);
+		fp->value = null;
 		if (conferror)
 			(*conferror)(&state, &state, 2, "synthesize(): out of memory");
 		return NULL;
 	}
 	/* memcpy comes before free because fp->value and value might share memory */
+	fp->flags |= CONF_ALLOC;
 	memcpy(newvalue, value, n);
-	if(fp->value)
+	if(fp->value && fp->value != null)
 		free(fp->value);
 	fp->value = newvalue;
 	fp->value[n] = 0;

--- a/src/lib/libast/port/astconf.c
+++ b/src/lib/libast/port/astconf.c
@@ -467,7 +467,7 @@ synthesize(Feature_t* fp, const char* path, const char* value, Error_f conferror
 		fp->value = 0;
 	if (n == 1 && (*value == '0' || *value == '-'))
 		n = 0;
-	if(!(newvalue = calloc(1, n + 1)))
+	if(!(newvalue = malloc(n + 1)))
 	{
 		if(fp->value && fp->value != null)
 			free(fp->value);
@@ -477,13 +477,12 @@ synthesize(Feature_t* fp, const char* path, const char* value, Error_f conferror
 		return NULL;
 	}
 	/* memcpy comes before free because fp->value and value might share memory */
-	fp->flags |= CONF_ALLOC;
 	memcpy(newvalue, value, n);
+	newvalue[n] = 0;
 	if(fp->value && fp->value != null)
 		free(fp->value);
-	fp->value = newvalue;
-	fp->value[n] = 0;
-	return fp->value;
+	fp->flags |= CONF_ALLOC;
+	return fp->value = newvalue;
 }
 
 /*

--- a/src/lib/libast/port/astconf.c
+++ b/src/lib/libast/port/astconf.c
@@ -70,7 +70,7 @@
 #define CONF_GLOBAL	(CONF_USER<<3)
 
 #define DEFAULT(o)	((state.std||!dynamic[o].ast)?dynamic[o].std:dynamic[o].ast)
-#define INITIALIZE()	do{if(!state.data)synthesize(NULL,NULL,NULL);}while(0)
+#define INITIALIZE()	do{if(!state.data)synthesize(NULL,NULL,NULL,NULL);}while(0)
 #define STANDARD(v)	(streq(v,"standard")||streq(v,"strict")||streq(v,"posix")||streq(v,"xopen"))
 
 #define MAXVAL		256
@@ -300,13 +300,13 @@ buffer(char* s)
  */
 
 static char*
-synthesize(Feature_t* fp, const char* path, const char* value)
+synthesize(Feature_t* fp, const char* path, const char* value, Error_f conferror)
 {
 	char*		s;
 	char*		d;
 	char*		v;
 	char*		p;
-	int		docpy;
+	char*		newvalue;
 	int		n;
 
 #if DEBUG_astconf
@@ -327,7 +327,11 @@ synthesize(Feature_t* fp, const char* path, const char* value)
 			n += strlen(s) + 1;
 		n = roundof(n, 32);
 		if (!(state.data = newof(0, char, n, 0)))
+		{
+			if (conferror)
+				(*conferror)(&state, &state, 2, "synthesize(): out of memory");
 			return NULL;
+		}
 		state.last = state.data + n - 1;
 		strcpy(state.data, state.name);
 		state.data += state.prefix - 1;
@@ -435,7 +439,11 @@ synthesize(Feature_t* fp, const char* path, const char* value)
 		c = n + state.last - state.data + 3 * MAXVAL;
 		c = roundof(c, 32);
 		if (!(state.data = newof(state.data, char, c, 0)))
+		{
+			if (conferror)
+				(*conferror)(&state, &state, 2, "synthesize(): out of memory");
 			return NULL;
+		}
 		state.last = state.data + c - 1;
 		state.data += state.prefix;
 		d = state.data + i;
@@ -459,25 +467,18 @@ synthesize(Feature_t* fp, const char* path, const char* value)
 		fp->value = 0;
 	if (n == 1 && (*value == '0' || *value == '-'))
 		n = 0;
-	docpy = fp->value != value;
-	if (!fp->value && !(fp->value = calloc(1, n + 1)))
-	{
-		error(ERROR_SYSTEM|ERROR_PANIC,"out of memory");
-		UNREACHABLE();
-	}
-	else
-	{
-		char *tofree = fp->value;
-		if (!(fp->value = realloc(fp->value, n + 1)))
-		{
-			free(tofree);
-			error(ERROR_SYSTEM|ERROR_PANIC,"out of memory");
-			UNREACHABLE();
-		}
-	}
 	fp->flags |= CONF_ALLOC;
-	if(docpy)
-		memcpy(fp->value, value, n);
+	if(!(newvalue = calloc(1, n + 1)))
+	{
+		if (conferror)
+			(*conferror)(&state, &state, 2, "synthesize(): out of memory");
+		return NULL;
+	}
+	/* memcpy comes before free because fp->value and value might share memory */
+	memcpy(newvalue, value, n);
+	if(fp->value)
+		free(fp->value);
+	fp->value = newvalue;
 	fp->value[n] = 0;
 	return fp->value;
 }
@@ -490,7 +491,7 @@ synthesize(Feature_t* fp, const char* path, const char* value)
  */
 
 static void
-initialize(Feature_t* fp, const char* path, const char* command, const char* succeed, const char* fail)
+initialize(Feature_t* fp, const char* path, const char* command, const char* succeed, const char* fail, Error_f conferror)
 {
 	char*	p;
 	int	ok = 1;
@@ -601,7 +602,7 @@ initialize(Feature_t* fp, const char* path, const char* command, const char* suc
 #if DEBUG_astconf
 	error(-6, "state.std=%d %s [%s] std=%s ast=%s value=%s ok=%d", state.std, fp->name, ok ? succeed : fail, fp->std, fp->ast, fp->value, ok);
 #endif
-	synthesize(fp, path, ok ? succeed : fail);
+	synthesize(fp, path, ok ? succeed : fail, conferror);
 }
 
 /*
@@ -615,9 +616,6 @@ format(Feature_t* fp, const char* path, const char* value, unsigned int flags, E
 	int			n;
 	static struct utsname	uts;
 
-#ifndef UNIV_MAX
-	NOT_USED(conferror);
-#endif
 #if DEBUG_astconf
 	error(-6, "astconf format name=%s path=%s value=%s flags=%04x fp=%p%s", fp->name, path, value, flags, fp, state.synthesizing ? " SYNTHESIZING" : "");
 #else
@@ -646,8 +644,8 @@ format(Feature_t* fp, const char* path, const char* value, unsigned int flags, E
 #endif
 		if (state.synthesizing && value == (char*)fp->std)
 			fp->value = (char*)value;
-		else if (!synthesize(fp, path, value))
-			initialize(fp, path, NULL, fp->std, fp->value);
+		else if (!synthesize(fp, path, value, conferror))
+			initialize(fp, path, NULL, fp->std, fp->value, conferror);
 #if DEBUG_astconf
 		error(-6, "state.std=%d %s [%s] std=%s ast=%s value=%s", state.std, fp->name, value, fp->std, fp->ast, fp->value);
 #endif
@@ -673,8 +671,8 @@ format(Feature_t* fp, const char* path, const char* value, unsigned int flags, E
 	case OP_path_resolve:
 		if (state.synthesizing && value == (char*)fp->std)
 			fp->value = (char*)value;
-		else if (!synthesize(fp, path, value))
-			initialize(fp, path, NULL, "logical", DEFAULT(OP_path_resolve));
+		else if (!synthesize(fp, path, value, conferror))
+			initialize(fp, path, NULL, "logical", DEFAULT(OP_path_resolve), conferror);
 		break;
 
 	case OP_universe:
@@ -716,7 +714,11 @@ format(Feature_t* fp, const char* path, const char* value, unsigned int flags, E
 					fp->value = 0;
 				n = strlen(value);
 				if (!(fp->value = newof(fp->value, char, n, 1)))
+				{
+					if (conferror)
+						(*conferror)(&state, &state, 2, "%s: out of memory", value);
 					fp->value = null;
+				}
 				else
 				{
 					fp->flags |= CONF_ALLOC;
@@ -725,10 +727,10 @@ format(Feature_t* fp, const char* path, const char* value, unsigned int flags, E
 				}
 			}
 			else
-				synthesize(fp, path, value);
+				synthesize(fp, path, value, conferror);
 		}
 		else
-			initialize(fp, path, "echo", DEFAULT(OP_universe), "ucb");
+			initialize(fp, path, "echo", DEFAULT(OP_universe), "ucb", conferror);
 #endif
 #endif
 		break;
@@ -737,7 +739,7 @@ format(Feature_t* fp, const char* path, const char* value, unsigned int flags, E
 		if (state.synthesizing && value == (char*)fp->std)
 			fp->value = (char*)value;
 		else
-			synthesize(fp, path, value);
+			synthesize(fp, path, value, conferror);
 		break;
 
 	}


### PR DESCRIPTION
Under ASan the builtins.sh script silently exits with exit status 1 and no backtrace. After isolating the bug into a simplified script, I managed to reproduce it with an actual stacktrace. Reproducer:
```sh
#!/bin/ksh
set -o xtrace  # Shows how far the script goes before crashing
               # (which is inconsistent and system-dependent
               # AFAICT; the ALL_LIBCMD shopt can influence it).
bltin='/opt/ast/bin/basename
/opt/ast/bin/cat
/opt/ast/bin/cp
/opt/ast/bin/cut
/opt/ast/bin/dirname
/opt/ast/bin/getconf
/opt/ast/bin/ln
/opt/ast/bin/mktemp
/opt/ast/bin/mv'  # Feel free to expand this with other commands
                  # from libcmd if you with.
for i in ${bltin}
do ({ PATH=/opt/ast/bin; "${bltin##*/}" --this-option-does-not-exist; } 2>&1)
done
```
Stacktrace obtained after much effort:
```
=================================================================
==116622==ERROR: AddressSanitizer: heap-use-after-free on address 0x502000000e50 at pc 0x72ad1bb52b7f bp 0x7ffc8b5a0cd0 sp 0x7ffc8b5a0478 READ of size 3 at 0x502000000e50 thread T0
    #0 0x72ad1bb52b7e in memcpy /usr/src/debug/gcc/gcc/libsanitizer/sanitizer_common/sanitizer_common_interceptors_memintrinsics.inc:115
    #1 0x5bb0a922f3de in synthesize /home/johno/GitRepos/KornShell/ksh/src/lib/libast/port/astconf.c:466
    #2 0x5bb0a92305cd in initialize /home/johno/GitRepos/KornShell/ksh/src/lib/libast/port/astconf.c:591
    #3 0x5bb0a9230fac in format /home/johno/GitRepos/KornShell/ksh/src/lib/libast/port/astconf.c:632
    #4 0x5bb0a923ba4b in astgetconf /home/johno/GitRepos/KornShell/ksh/src/lib/libast/port/astconf.c:1382
    #5 0x5bb0a923d5c5 in astconf /home/johno/GitRepos/KornShell/ksh/src/lib/libast/port/astconf.c:1472
    #6 0x5bb0a924e07b in initconformance /home/johno/GitRepos/KornShell/ksh/src/lib/libast/misc/conformance.c:50
    #7 0x5bb0a924eff2 in conformance /home/johno/GitRepos/KornShell/ksh/src/lib/libast/misc/conformance.c:122
    #8 0x5bb0a9288b8e in b_cp /home/johno/GitRepos/KornShell/ksh/src/lib/libcmd/cp.c:706
    <CUT>
```

src/lib/libast/port/astconf.c:
- If `fp->value` and `value` pointed to the same allocated memory before `realloc`, avoid `memcpy` as `value` now points to freed memory.
- Produce an obvious panic if memory allocation fails.

src/cmd/ksh93/sh/init.c:
- For correctness, prevent memory leaks by freeing memory in `sh_realloc` upon failure.