### PR TITLE
add CI test for Cygwin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,11 +40,17 @@ jobs:
   Cygwin:
     name: Cygwin
     runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { platform: x86_64, hosttype: cygwin.i386-64 }
+          - { platform: x86,    hosttype: cygwin.i386    }
     env:
       CHERE_INVOKING: 1
       CYGWIN_NOWINPATH: 1
       CC: gcc
-      HOSTTYPE: cygwin.i386-64
+      HOSTTYPE: ${{ matrix.hosttype }}
     defaults:
       run:
         shell: bash -leo pipefail -o igncr {0}
@@ -54,7 +60,8 @@ jobs:
     - name: Install Cygwin
       uses: cygwin/cygwin-install-action@master
       with:
-        packages: gcc-core gcc-g++ git libiconv-devel ncurses
+        platform: ${{ matrix.platform }}
+        packages: gcc-core git libiconv-devel ncurses
     - name: Git reset
       run: |
         git config --global --add safe.directory "$(pwd)" && git reset --hard

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [push, workflow_dispatch]
 
 jobs:
 
@@ -36,3 +36,52 @@ jobs:
         bin/package make -j5 &&
         : default regression tests with SHOPT_SCRIPTONLY enabled &&
         script -q -e -c "bin/shtests"
+
+  Cygwin:
+    name: Cygwin
+    runs-on: windows-latest
+    env:
+      CHERE_INVOKING: 1
+      CYGWIN_NOWINPATH: 1
+      CC: gcc
+      HOSTTYPE: cygwin.i386-64
+    defaults:
+      run:
+        shell: bash -leo pipefail -o igncr {0}
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@main
+    - name: Install Cygwin
+      uses: cygwin/cygwin-install-action@master
+      with:
+        packages: gcc-core gcc-g++ git libiconv-devel ncurses
+    - name: Git reset
+      run: |
+        git config --global --add safe.directory "$(pwd)" && git reset --hard
+    - name: Build
+      run: bin/package make -j2 HOSTTYPE=$HOSTTYPE
+    - name: Regression tests
+      run: |
+        PS4="$PS4[ci.yml] "
+        set -o xtrace
+        export TZ=UTC
+        ulimit -n 1024
+        : default regression tests &&
+        : hangs: script -q -e -c "bin/package test HOSTTYPE=$HOSTTYPE" &&
+        script -q -e -c "bin/shtests HOSTTYPE=$HOSTTYPE" &&
+        : regression tests with OS-provided multibyte locales &&
+        LANG=en_US.utf8 script -q -e -c "bin/shtests --locale --nocompile HOSTTYPE=$HOSTTYPE" &&
+        : disable most SHOPTs, rebuild ksh &&
+        sed --regexp-extended --in-place=.orig \
+          '/^SHOPT (AUDIT|BGX|BRACEPAT|DEVFD|DYNAMIC|EDPREDICT|ESH|FIXEDARRAY|HISTEXPAND|MULTIBYTE|NAMESPACE|OPTIMIZE|SPAWN|STATS|SUID_EXEC|VSH)=/ s/=1?/=0/' \
+          src/cmd/ksh93/SHOPT.sh &&
+        bin/package make -j2 HOSTTYPE=$HOSTTYPE &&
+        : default regression tests with SHOPTs disabled &&
+        script -q -e -c "bin/shtests HOSTTYPE=$HOSTTYPE" &&
+        : enable SHOPT_SCRIPTONLY, rebuild ksh &&
+        sed --regexp-extended --in-place=.orig \
+          '/^SHOPT SCRIPTONLY=/ s/=0?/=1/' \
+          src/cmd/ksh93/SHOPT.sh &&
+        bin/package make -j2 HOSTTYPE=$HOSTTYPE &&
+        : default regression tests with SHOPT_SCRIPTONLY enabled &&
+        script -q -e -c "bin/shtests HOSTTYPE=$HOSTTYPE"

--- a/src/lib/libast/path/pathnative.c
+++ b/src/lib/libast/path/pathnative.c
@@ -30,25 +30,12 @@
 #include <ast.h>
 
 #if __CYGWIN__
-
-extern void	cygwin_conv_to_win32_path(const char*, char*);
+#include <sys/cygwin.h>
 
 size_t
 pathnative(const char* path, char* buf, size_t siz)
 {
-	size_t		n;
-
-	if (!buf || siz < PATH_MAX)
-	{
-		char	tmp[PATH_MAX];
-
-		cygwin_conv_to_win32_path(path, tmp);
-		if ((n = strlen(tmp)) < siz && buf)
-			memcpy(buf, tmp, n + 1);
-		return n;
-	}
-	cygwin_conv_to_win32_path(path, buf);
-	return strlen(buf);
+	return cygwin_conv_path(CCP_POSIX_TO_WIN_A | CCP_ABSOLUTE, path, buf, siz);
 }
 
 #elif __INTERIX

--- a/src/lib/libast/path/pathposix.c
+++ b/src/lib/libast/path/pathposix.c
@@ -32,24 +32,12 @@
 
 #if __CYGWIN__
 
-extern void	cygwin_conv_to_posix_path(const char*, char*);
+#include <sys/cygwin.h>
 
 size_t
 pathposix(const char* path, char* buf, size_t siz)
 {
-	size_t		n;
-
-	if (!buf || siz < PATH_MAX)
-	{
-		char	tmp[PATH_MAX];
-
-		cygwin_conv_to_posix_path(path, tmp);
-		if ((n = strlen(tmp)) < siz && buf)
-			memcpy(buf, tmp, n + 1);
-		return n;
-	}
-	cygwin_conv_to_posix_path(path, buf);
-	return strlen(buf);
+	return cygwin_conv_path(CCP_WIN_A_TO_POSIX | CCP_ABSOLUTE, path, buf, siz);
 }
 
 #elif __INTERIX


### PR DESCRIPTION
* fix pathnative and pathposix for Cygwin (so it builds).  I don't know why this doesn't fail in 1.0.10, something else must have been fixed
* seems bin/package can't tell the difference between cygwin.i386 and cygwin.i386-64
* bin/package make -j5 hangs
* bin/package test hangs in mamake regression tests
* number of shtests fail

Hopefully this can be a start to figure out the issues
@xeiavicaflashrepository @gisburn