### PR TITLE
Fix long multibyte characters paste issue via ssh

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -31,6 +31,7 @@ ksh 93u+m general copyright notice
 #       hyousatsu <118750527+hyousatsu@users.noreply.github.com>       #
 #                      Trey Valenta <t@trey.net>                       #
 #  Sterling Jensen <5555776+sterlingjensen@users.noreply.github.com>   #
+#            SHIMIZU Akifumi <shimizu.akifumi@fujitsu.com>             #
 #                   Marc Wilson <posguy99@gmail.com>                   #
 #                Govind Kamat <govind_kamat@yahoo.com>                 #
 #                     Cy Schubert <cy@FreeBSD.org>                     #

--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,12 @@ This documents significant changes in the dev branch of ksh 93u+m.
 For full details, see the git log at: https://github.com/ksh93/ksh
 Uppercase BUG_* IDs are shell bug IDs as used by the Modernish shell library.
 
+2025-04-05:
+
+- Fixed a bug where pasting over 80 bytes of multibyte characters into the
+  command line over ssh resulted in corrupted input. This problem was caused
+  by multibyte characters being split when the typeahead buffer is full.
+
 2025-03-30:
 
 - Fixed: 'stty -echo' failed to turn off echoing of terminal input in

--- a/NEWS
+++ b/NEWS
@@ -2,7 +2,7 @@ This documents significant changes in the dev branch of ksh 93u+m.
 For full details, see the git log at: https://github.com/ksh93/ksh
 Uppercase BUG_* IDs are shell bug IDs as used by the Modernish shell library.
 
-2025-04-05:
+2025-04-07:
 
 - Fixed a bug where pasting over 80 bytes of multibyte characters into the
   command line over ssh resulted in corrupted input. This problem was caused

--- a/src/cmd/ksh93/edit/edit.c
+++ b/src/cmd/ksh93/edit/edit.c
@@ -736,7 +736,7 @@ static int putstack(Edit_t *ep,char string[], int nbyte, int type)
 {
 	int c;
 #if SHOPT_MULTIBYTE
-	char *endp, *p=string, *prevp;
+	char *endp, *p=string;
 	int size, offset = ep->e_lookahead + nbyte;
 	*(endp = &p[nbyte]) = 0;
 	endp = &p[nbyte];
@@ -760,7 +760,7 @@ static int putstack(Edit_t *ep,char string[], int nbyte, int type)
 		}
 		else
 		{
-			prevp = p;
+			char *prevp = p;
 		again:
 			if((c=mbchar(p)) >=0)
 			{

--- a/src/cmd/ksh93/edit/edit.c
+++ b/src/cmd/ksh93/edit/edit.c
@@ -769,10 +769,8 @@ static int putstack(Edit_t *ep,char string[], int nbyte, int type)
 			}
 			else if((endp-p) < mbmax())
 			{
-#ifdef EILSEQ
 				if(errno == EILSEQ)
 					errno = 0;
-#endif
 				if ((c=ed_read(ep,ep->e_fd,endp, 1,0)) == 1)
 				{
 					p = prevp;
@@ -781,10 +779,8 @@ static int putstack(Edit_t *ep,char string[], int nbyte, int type)
 				}
 				return c;
 			}
-#ifdef EILSEQ
 			else if(errno == EILSEQ)
 				errno = 0;
-#endif
 			else
 			{
 				ed_ringbell();
@@ -834,7 +830,10 @@ static int putstack(Edit_t *ep,char string[], int nbyte, int type)
 int ed_getchar(Edit_t *ep,int mode)
 {
 	int n = 0, c;
-	char readin[LOOKAHEAD+6];
+	static char *readin;
+	static int old_mbmax;
+	if(old_mbmax < mbmax())
+		readin = sh_realloc(readin, LOOKAHEAD + (old_mbmax = mbmax()));
 	if(!ep->e_lookahead)
 	{
 		ed_flush(ep);

--- a/src/cmd/ksh93/edit/edit.c
+++ b/src/cmd/ksh93/edit/edit.c
@@ -15,6 +15,7 @@
 *            Johnothan King <johnothanking@protonmail.com>             *
 *               Anuradha Weeraman <anuradha@debian.org>                *
 *               K. Eugene Carlson <kvngncrlsn@gmail.com>               *
+*            SHIMIZU Akifumi <shimizu.akifumi@fujitsu.com>             *
 *                                                                      *
 ***********************************************************************/
 /*

--- a/src/cmd/ksh93/edit/edit.c
+++ b/src/cmd/ksh93/edit/edit.c
@@ -735,7 +735,7 @@ static int putstack(Edit_t *ep,char string[], int nbyte, int type)
 {
 	int c;
 #if SHOPT_MULTIBYTE
-	char *endp, *p=string;
+	char *endp, *p=string, *prevp;
 	int size, offset = ep->e_lookahead + nbyte;
 	*(endp = &p[nbyte]) = 0;
 	endp = &p[nbyte];
@@ -759,6 +759,7 @@ static int putstack(Edit_t *ep,char string[], int nbyte, int type)
 		}
 		else
 		{
+			prevp = p;
 		again:
 			if((c=mbchar(p)) >=0)
 			{
@@ -766,19 +767,24 @@ static int putstack(Edit_t *ep,char string[], int nbyte, int type)
 				if(type)
 					c = -c;
 			}
-#ifdef EILSEQ
-			else if(errno == EILSEQ)
-				errno = 0;
-#endif
 			else if((endp-p) < mbmax())
 			{
+#ifdef EILSEQ
+				if(errno == EILSEQ)
+					errno = 0;
+#endif
 				if ((c=ed_read(ep,ep->e_fd,endp, 1,0)) == 1)
 				{
+					p = prevp;
 					*++endp = 0;
 					goto again;
 				}
 				return c;
 			}
+#ifdef EILSEQ
+			else if(errno == EILSEQ)
+				errno = 0;
+#endif
 			else
 			{
 				ed_ringbell();
@@ -828,7 +834,7 @@ static int putstack(Edit_t *ep,char string[], int nbyte, int type)
 int ed_getchar(Edit_t *ep,int mode)
 {
 	int n = 0, c;
-	char readin[LOOKAHEAD+1];
+	char readin[LOOKAHEAD+6];
 	if(!ep->e_lookahead)
 	{
 		ed_flush(ep);

--- a/src/cmd/ksh93/edit/edit.c
+++ b/src/cmd/ksh93/edit/edit.c
@@ -831,10 +831,7 @@ static int putstack(Edit_t *ep,char string[], int nbyte, int type)
 int ed_getchar(Edit_t *ep,int mode)
 {
 	int n = 0, c;
-	static char *readin;
-	static int old_mbmax;
-	if(old_mbmax < mbmax())
-		readin = sh_realloc(readin, LOOKAHEAD + (old_mbmax = mbmax()));
+	char *readin = fmtbuf(LOOKAHEAD + mbmax());
 	if(!ep->e_lookahead)
 	{
 		ed_flush(ep);

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -18,7 +18,7 @@
 #include <ast_release.h>
 #include "git.h"
 
-#define SH_RELEASE_DATE	"2025-03-30"	/* must be in this format for $((.sh.version)) */
+#define SH_RELEASE_DATE	"2025-04-05"	/* must be in this format for $((.sh.version)) */
 /*
  * This comment keeps SH_RELEASE_DATE a few lines away from SH_RELEASE_SVER to avoid
  * merge conflicts when cherry-picking dev branch commits onto a release branch.

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -18,7 +18,7 @@
 #include <ast_release.h>
 #include "git.h"
 
-#define SH_RELEASE_DATE	"2025-04-05"	/* must be in this format for $((.sh.version)) */
+#define SH_RELEASE_DATE	"2025-04-07"	/* must be in this format for $((.sh.version)) */
 /*
  * This comment keeps SH_RELEASE_DATE a few lines away from SH_RELEASE_SVER to avoid
  * merge conflicts when cherry-picking dev branch commits onto a release branch.


### PR DESCRIPTION
When I paste long multibyte characters(over 80 byte) to ksh via SSH, the characters are not displayed correctly.
For example, the following input demonstrates the issue.  ja_JP.UTF-8 encoding is used.
input  : echo "長い文字列を入れるとkshで文字列が乱れる場合があるようです"
output: です"echo "長い文字列を入れるとkshで文字列が乱れる場合がある

This issue appears to be caused by the ed_read() function splitting a multibyte character sequence when reading into an 80-byte buffer.
This leads to incorrect character interpretation and display.

Therefore, we edited the code to handle the case where the buffer size is full in the middle of a multi-byte character.