### PR TITLE
src/cmd/ksh93/tests/substring.sh: Add a test to catch bug-833

### DIFF
--- a/src/cmd/ksh93/sh/macro.c
+++ b/src/cmd/ksh93/sh/macro.c
@@ -1905,6 +1905,38 @@ retry2:
 			if(c=='/' || c=='#' || c== '%')
 			{
 				flag = (type || c=='/')?(STR_GROUP|STR_MAXIMAL):STR_GROUP;
+				/* phi: bug-833 *******************************/
+				/* type='%' && c='%' means we got %%
+				 * The following code with variation around
+				 * sunstring() and strngrpmatch() is broken
+				 * since its inception.
+				 * When the pattern that follow %% is a
+				 * non-pattern, i.e a pure string then
+				 * %% is the same as %.
+				 * To avoid upseting this code, I implement this
+				 * ugly kludge here that reset the STR_MAXIMAL
+				 * bit in the case of non-pattern %%
+				 */
+				if(type=='%' && c=='%')
+				{
+					char *p=pattern;
+					while(*p)
+					{
+						if( *p=='*' ||
+						    *p=='?' ||
+						    *p=='[' ||
+						    *p=='(')
+						{ break;
+						}
+						p++;
+					}
+					if(!*p)
+						flag=~STR_MAXIMAL;
+				  if(!*p)
+					flag=~STR_MAXIMAL;
+				}
+				/* phi: bug-833 ******************************/
+
 				if(c!='/')
 					flag |= STR_LEFT;
 				index = nmatch = 0;

--- a/src/cmd/ksh93/tests/substring.sh
+++ b/src/cmd/ksh93/tests/substring.sh
@@ -54,6 +54,13 @@ fi
 if	[[ ${string1%%*zzz*} != "$string1" ]]
 then	err_exit "string1%%*zzz*"
 fi
+string2=aaaa
+if	[[ ${string2%%aaa} != "a" ]]
+then	err_exit "string2%%aaa"
+fi
+if	[[ ${string2%aaa} != "a" ]]
+then	err_exit "string2%aaa"
+fi
 if	[[ ${string1#*zzz*} != "$string1" ]]
 then	err_exit "string1#*zzz*"
 fi


### PR DESCRIPTION
src/cmd/ksh93/sh/macro.c: Search for phi: bug-833
In string substitution from the end i.e ${string%%pattern} when pattern is not a pattern but a simple string the original code is apparently broken, the succession of calls from varsub() to strngrpmatch() make no sense.

This fix is a band-aid, trying not to upset to original code much, it simply detect that pattern is a pure string (non-pattern) and in that case fall back to the % replacement instead of %% which are identical.