### PR TITLE
While the regcomp.c is a bit obscure to me I try this as a fix.

### DIFF
--- a/src/cmd/ksh93/tests/bracket.sh
+++ b/src/cmd/ksh93/tests/bracket.sh
@@ -623,4 +623,12 @@ test b = b c -a "" 2>/dev/null
 [[ -v p ]] && set --noposix && unset p
 
 # ======
+# Test added for bug-833
+[[ aaaaa =~ a$      ]] || err_exit 'aaaaa =~ a$ not working' 
+[[ aaaaa =~ aa$     ]] || err_exit 'aaaaa =~ aa$ not working'
+[[ aaaaa =~ aaa$    ]] || err_exit 'aaaaa =~ aaa$ not working'
+[[ aaaaa =~ aaaa$   ]] || err_exit 'aaaaa =~ aaaa$ not working'
+[[ aaaaa =~ aaaaa$  ]] || err_exit 'aaaaa =~ aaaaa$ not working'
+[[ aaaaa =~ aaaaaa$ ]] && err_exit 'aaaaa =~ aaaaaa$ not working' 
+# ======
 exit $((Errors<125?Errors:125))

--- a/src/cmd/ksh93/tests/substring.sh
+++ b/src/cmd/ksh93/tests/substring.sh
@@ -766,4 +766,26 @@ got=$(x=abcdefg; set +x; eval 'echo ${x:(10-9)+1:((1&&1)|2)}' 2>&1)
 	"(expected status 0 and $(printf %q "$exp"), got status $e and $(printf %q "$got"))"
 
 # ======
+# Test added for bug-833
+string2=aaaaa
+if	[[ ${string2%%a} != "aaaa" ]]
+then	err_exit "string2%%a"
+fi
+if	[[ ${string2%%aa} != "aaa" ]]
+then	err_exit "string2%%a"
+fi
+if	[[ ${string2%%aaa} != "aa" ]]
+then	err_exit "string2%%a"
+fi
+if	[[ ${string2%%aaaa} != "a" ]]
+then	err_exit "string2%%a"
+fi
+if	[[ ${string2%%aaaaa} != "" ]]
+then	err_exit "string2%%a"
+fi
+if	[[ ${string2%%aaaaaa} != "aaaaa" ]]
+then	err_exit "string2%%a"
+fi
+
+# ======
 exit $((Errors<125?Errors:125))

--- a/src/lib/libast/regex/regcomp.c
+++ b/src/lib/libast/regex/regcomp.c
@@ -3021,7 +3021,14 @@ special(Cenv_t* env, regex_t* p)
 	DEBUG_INIT();
 	if (e = p->env->rex)
 	{
-		if ((x = env->stats.x) && x->re.string.size < 3)
+	 	 /* phi: bug-833
+		  * orig: if ((x = env->stats.x) && x->re.string.size < 3
+		  * I don't see any reasons to limit this to string <3
+		  * I remove it here.
+		  * For the next one, t->re.trie.min, I can't figure out a test
+		  * case, leave it this way...
+		  */
+		if ((x = env->stats.x) /* && x->re.string.size < 3 */)
 			x = 0;
 		if ((t = env->stats.y) && t->re.trie.min < 3)
 			t = 0;


### PR DESCRIPTION
While the regcomp.c is a bit obscure to me I try this as a fix.

src/cmd/ksh93/tests/bracket.sh
src/cmd/ksh93/tests/substring.sh
  - Added test to catch faulty regex.

src/lib/libast/regex/regcomp.c
  - Search phi: bug-833 Suppressed the x->re.string.size < 3 test which looks bogus.