### PR TITLE
Fix bug-852 : Build failure. ast_std.h and state.c out of sync

### DIFF
--- a/src/lib/libast/misc/state.c
+++ b/src/lib/libast/misc/state.c
@@ -25,13 +25,15 @@
 _Ast_info_t	_ast_info =
 {
 	"libast",	/* ID */
-	{ 0 },
-	0,0,0,0,0,
-	strcmp,		/* collate */
+	{ 0, 0, 0, 0 },
 	0,0,
+	strcmp,		/* collate */
 	1,		/* mb_cur_max */
-	0,0,0,0,0,0,0,
-	AST_VERSION	/* version */
+	0,
+	0,0,0,0,0,
+	0,
+	AST_VERSION,	/* version */
+	0,
 };
 
 extern _Ast_info_t	_ast_info;


### PR DESCRIPTION
Since ast_std.h::_Ast_info_t has been updated, then static initializer in state.c must be updated too.