### PR TITLE
Felefold fixes

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,4 @@
-This documents significant changes in the dev branch of ksh 93u+m.
+﻿This documents significant changes in the dev branch of ksh 93u+m.
 For full details, see the git log at: https://github.com/ksh93/ksh
 Uppercase BUG_* IDs are shell bug IDs as used by the Modernish shell library.
 
@@ -64,7 +64,7 @@ Uppercase BUG_* IDs are shell bug IDs as used by the Modernish shell library.
   Unlike in bash, the pattern may match any number of characters.
 
 - The SHOPT_DYNAMIC compile-time option (the ability to load builtins from
-  dynamically linked libaries such as libcmd) is now automatically disabled
+  dynamically linked libraries such as libcmd) is now automatically disabled
   for the version of ksh that is linked against the static libast/libcmd/
   libshell libraries, as it cannot work correctly on those. On the version of
   ksh linked against the dynamic version of these libraries (on supported
@@ -112,7 +112,7 @@ Uppercase BUG_* IDs are shell bug IDs as used by the Modernish shell library.
 2025-03-24:
 
 - Fixed a crash that occurred in specific circumstances when processing a
-  here-documnet within a command subtitution within another here-document.
+  here-document within a command substitution within another here-document.
 
 2025-03-21:
 
@@ -206,14 +206,14 @@ Uppercase BUG_* IDs are shell bug IDs as used by the Modernish shell library.
 2024-12-21:
 
 - Fixed a bug in the emacs/gmacs line editor where a command repeat count
-  (e.g., ESC 3) sticks and is re-used for the next command after an ESC
+  (e.g., ESC 3) sticks and is reused for the next command after an ESC
   command. For example, ESC 3 ESC _ recalls the third word from the last
   command in the history. The bug is that the next command, such as ^B to
   move back, is then repeated three times. Bug introduced on 2020-09-17.
 
 2024-12-18:
 
-- Persuant to POSIX.1-2024, exec(1) will no longer cause the shell to exit
+- Pursuant to POSIX.1-2024, exec(1) will no longer cause the shell to exit
   when it fails to replace an interactive shell with the given command.
 
 2024-12-08:
@@ -387,7 +387,7 @@ Uppercase BUG_* IDs are shell bug IDs as used by the Modernish shell library.
 2024-07-16:
 
 - The history expansion character ('!' by default) is now not processed when
-  immediately following '${'. This makes it psosible to use expansion syntax
+  immediately following '${'. This makes it possible to use expansion syntax
   like ${!varname} and ${!prefix@} on the interactive command line with the
   histexpand option on; these no longer trigger an "event not found" error.
 
@@ -440,7 +440,7 @@ Uppercase BUG_* IDs are shell bug IDs as used by the Modernish shell library.
   specifications. For example,
 	printf '%(%F)T\n' '4th tuesday in march 2016'
   wrongly printed '2016-04-09' and now again correctly prints '2016-03-22'.
-  This regression was introduded with the printf fixes on 2023-05-18.
+  This regression was introduced with the printf fixes on 2023-05-18.
 
 2024-03-24:
 
@@ -462,7 +462,7 @@ Uppercase BUG_* IDs are shell bug IDs as used by the Modernish shell library.
 - Android with Termux is now a supported environment for ksh 93u+m. Testing
   was done on Android 14.0 with Termux 0.118.0. Please report any breakage.
   Build dependencies (Termux packages): clang, binutils, getconf. Runtime
-  depenencies: ncurses-utils (for --multiline), getconf (fallback for the
+  dependencies: ncurses-utils (for --multiline), getconf (fallback for the
   /opt/ast/bin/getconf builtin).
 
 2024-03-12:
@@ -504,7 +504,7 @@ Uppercase BUG_* IDs are shell bug IDs as used by the Modernish shell library.
   commands) would run a path-bound built-in if /opt/ast/bin is in PATH.
 
 - Fixed a corner case bug: a ${ shared-state command substitution;} failed to
-  capture the standard output of a command that replces the shell via 'exec'.
+  capture the standard output of a command that replaces the shell via 'exec'.
 
 2024-02-29:
 
@@ -578,7 +578,7 @@ Uppercase BUG_* IDs are shell bug IDs as used by the Modernish shell library.
 - Fixed: the arithmetic representation of negative integers with a base other
   than 10 is no longer incorrectly treated as unsigned long. For example,
 	typeset -i16 n=-12; echo $n
-  now correctly outputs '-16#c' and no longer ouputs '16#fffffffffffffff4'.
+  now correctly outputs '-16#c' and no longer outputs '16#fffffffffffffff4'.
 
 2024-01-27:
 

--- a/src/cmd/INIT/iffe.sh
+++ b/src/cmd/INIT/iffe.sh
@@ -33,7 +33,7 @@ esac
 set -o noglob
 
 command=iffe
-version=2025-05-01
+version=2025-05-16
 
 # DEFPATH should be inherited from package(1)
 case $DEFPATH in

--- a/src/cmd/INIT/iffe.sh
+++ b/src/cmd/INIT/iffe.sh
@@ -2545,7 +2545,7 @@ int x;
 					*)	q="a library" ;;
 					esac
 					case $e in
-					0)	can="$can$cansep#define $c	1	/* $p is $q */"
+					0)	can="$can$cansep#define $c	1	/* ${p#"$PACKAGEROOT"[\\/]} is $q */"
 						nan="$nan$cansep$c=1"
 						cansep=$nl
 						eval $c=1
@@ -2554,11 +2554,11 @@ int x;
 						esac
 						;;
 					1)	case $all$config$undef in
-						?1?|??1)can="$can$cansep#undef	$c		/* $p is not $q */"
+						?1?|??1)can="$can$cansep#undef	$c		/* ${p#"$PACKAGEROOT"[\\/]} is not $q */"
 							nan="$nan$cansep$c="
 							cansep=$nl
 							;;
-						1??)	can="$can$cansep#define $c	0	/* $p is not $q */"
+						1??)	can="$can$cansep#define $c	0	/* ${p#"$PACKAGEROOT"[\\/]} is not $q */"
 							nan="$nan$cansep$c=0"
 							cansep=$nl
 							;;

--- a/src/cmd/INIT/intl.c
+++ b/src/cmd/INIT/intl.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1994-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2023 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2025 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -22,6 +22,6 @@
 int
 main(void)
 {
-	gettext(0);
+	gettext("test");
 	return 0;
 }

--- a/src/cmd/INIT/mamake.c
+++ b/src/cmd/INIT/mamake.c
@@ -1112,7 +1112,7 @@ static void substitute(Buf_t *buf, char *s)
 				{	/*
 					 * Perform the expansion: append the value of the variable to the buffer.
 					 */
-					if (found_AR && strncmp(t, "mam_lib", 7) == 0 && state.strict < 2)
+					if (state.strict < 2 && found_AR && strncmp(t, "mam_lib", 7) == 0)
 					{	/*
 						 * Absurd AT&T hack from 2007. The relevant src/cmd/INIT/RELEASE entry:
 						 *	07-02-26 mamake.c: expand first of ${mam_lib*} for ${AR}

--- a/src/cmd/ksh93/edit/history.c
+++ b/src/cmd/ksh93/edit/history.c
@@ -116,7 +116,7 @@ static History_t *hist_ptr;
 		return 0;
 	if(!(cp = getlogin()))
 	{
-		struct passwd *userinfo = getpwuid(getuid());
+		struct passwd *userinfo = getpwuid(sh.userid);
 		if(userinfo)
 			cp = userinfo->pw_name;
 		else

--- a/src/cmd/ksh93/include/io.h
+++ b/src/cmd/ksh93/include/io.h
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1982-2012 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2025 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -20,6 +20,9 @@
  *	David Korn
  *
  */
+
+#ifndef _io_h_defined
+#define _io_h_defined	1
 
 #include	<ast.h>
 #include	<sfio.h>
@@ -114,3 +117,5 @@ extern const char	e_sysrc[];
 extern const char	e_stdprompt[];
 extern const char	e_supprompt[];
 extern const char	e_ambiguous[];
+
+#endif /* _io_h_defined */

--- a/src/cmd/ksh93/include/national.h
+++ b/src/cmd/ksh93/include/national.h
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1982-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2025 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -12,6 +12,7 @@
 *                                                                      *
 *                  David Korn <dgk@research.att.com>                   *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 /*
@@ -22,6 +23,9 @@
  *
  */
 
+#ifndef _national_h_defined
+#define _national_h_defined	1
+
 #if SHOPT_MULTIBYTE
 #   ifndef MARKER
 #	define MARKER		0xdfff	/* Must be invalid character */
@@ -29,3 +33,5 @@
 #endif /* SHOPT_MULTIBYTE */
 
 extern int sh_strchr(const char*,const char*);
+
+#endif /* _national_h_defined */

--- a/src/cmd/ksh93/include/shell.h
+++ b/src/cmd/ksh93/include/shell.h
@@ -454,7 +454,7 @@ extern int 		sh_trap(const char*,int);
 extern int 		sh_fun(Namval_t*,Namval_t*, char*[]);
 extern int 		sh_funscope(int,char*[],int(*)(void*),void*,int);
 extern Sfio_t		*sh_iogetiop(int,int);
-extern noreturn int	sh_main(int, char*[], Shinit_f);
+extern noreturn void	sh_main(int, char*[], Shinit_f);
 extern int		sh_run(int, char*[]);
 extern void		sh_menu(Sfio_t*, int, char*[]);
 extern Namval_t		*sh_addbuiltin(const char*, int(*)(int, char*[],Shbltin_t*), void*);

--- a/src/cmd/ksh93/include/shell.h
+++ b/src/cmd/ksh93/include/shell.h
@@ -454,7 +454,7 @@ extern int 		sh_trap(const char*,int);
 extern int 		sh_fun(Namval_t*,Namval_t*, char*[]);
 extern int 		sh_funscope(int,char*[],int(*)(void*),void*,int);
 extern Sfio_t		*sh_iogetiop(int,int);
-extern int		sh_main(int, char*[], Shinit_f);
+extern noreturn int	sh_main(int, char*[], Shinit_f);
 extern int		sh_run(int, char*[]);
 extern void		sh_menu(Sfio_t*, int, char*[]);
 extern Namval_t		*sh_addbuiltin(const char*, int(*)(int, char*[],Shbltin_t*), void*);

--- a/src/cmd/ksh93/include/terminal.h
+++ b/src/cmd/ksh93/include/terminal.h
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1982-2012 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2025 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -32,7 +32,6 @@ extern int	tty_get(int,struct termios*);
 extern int	tty_raw(int,int);
 extern int	tty_check(int);
 extern int	tty_set(int, int, struct termios*);
-extern int	sh_ioctl(int,int,void*,int);
 extern int	sh_tcgetattr(int,struct termios*);
 extern int	sh_tcsetattr(int,int,struct termios*);
 

--- a/src/cmd/ksh93/include/timeout.h
+++ b/src/cmd/ksh93/include/timeout.h
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1982-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2025 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -12,6 +12,7 @@
 *                                                                      *
 *                  David Korn <dgk@research.att.com>                   *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 /*
@@ -21,7 +22,9 @@
  *
  */
 
+#ifndef TGRACE
 #define TGRACE		60	/* grace period before termination */
 				/* The time_warn message contains this number */
 extern const char	e_timeout[];
 extern const char	e_timewarn[];
+#endif /* TGRACE */

--- a/src/cmd/ksh93/kshrc.sh
+++ b/src/cmd/ksh93/kshrc.sh
@@ -1,7 +1,7 @@
 ########################################################################
 #                                                                      #
 #              This file is part of the ksh 93u+m package              #
-#          Copyright (c) 2022-2024 Contributors to ksh 93u+m           #
+#          Copyright (c) 2022-2025 Contributors to ksh 93u+m           #
 #                      and is licensed under the                       #
 #                 Eclipse Public License, Version 2.0                  #
 #                                                                      #
@@ -141,7 +141,7 @@ function GITBRANCH.get
 function .rc.status.get
 {
 	typeset e=$?
-	typeset clr=${.rc.fmt[status$((e > 0))]}
+	typeset clr=${.rc.fmt[status$((e != 0))]}
 	typeset q1=$'\u00AB' q2=$'\u00BB'
 	((${#q1}==1 && ${#q2}==1)) || q1='<' q2='>'
 	if	((e>256))  # add signal name

--- a/src/cmd/ksh93/sh/array.c
+++ b/src/cmd/ksh93/sh/array.c
@@ -1597,7 +1597,7 @@ char	*nv_getsub(Namval_t* np)
 	{	/* enum subscript */
 		np = nv_namptr(ap->xp,0);
 		if(!np->nvalue)
-			np->nvalue = malloc(sizeof(uint16_t));
+			np->nvalue = sh_malloc(sizeof(uint16_t));
 		*((uint16_t*)np->nvalue) = ap->cur;
 		return nv_getval(np);
 	}

--- a/src/cmd/ksh93/sh/init.c
+++ b/src/cmd/ksh93/sh/init.c
@@ -624,7 +624,7 @@ static Sfdouble_t nget_seconds(Namval_t *np, Namfun_t *fp)
 }
 
 /*
- * Seeds the rand stucture using the same algorithm as srand48()
+ * Seeds the rand structure using the same algorithm as srand48()
  */
 static void seed_rand_uint(struct rand *rp, unsigned int seed)
 {

--- a/src/cmd/ksh93/sh/macro.c
+++ b/src/cmd/ksh93/sh/macro.c
@@ -2838,7 +2838,7 @@ static char *sh_tilde(const char *string)
 		if(cp = nv_getval(sh_scoped(HOME)))
 			return cp;
 		/* Fallback for unset HOME: get username and treat ~ like ~username */
-		if(!username && !((pw = getpwuid(getuid())) && (username = sh_strdup(pw->pw_name))))
+		if(!username && !((pw = getpwuid(sh.userid)) && (username = sh_strdup(pw->pw_name))))
 			return NULL;
 		string = username;
 	}

--- a/src/cmd/ksh93/sh/main.c
+++ b/src/cmd/ksh93/sh/main.c
@@ -91,7 +91,7 @@ static int sh_source(Sfio_t *iop, const char *file)
 #define REMOTE(m)	!(m)
 #endif
 
-int sh_main(int ac, char *av[], Shinit_f userinit)
+noreturn int sh_main(int ac, char *av[], Shinit_f userinit)
 {
 	char		*name;
 	int		fdin;

--- a/src/cmd/ksh93/sh/main.c
+++ b/src/cmd/ksh93/sh/main.c
@@ -91,7 +91,7 @@ static int sh_source(Sfio_t *iop, const char *file)
 #define REMOTE(m)	!(m)
 #endif
 
-noreturn int sh_main(int ac, char *av[], Shinit_f userinit)
+noreturn void sh_main(int ac, char *av[], Shinit_f userinit)
 {
 	char		*name;
 	int		fdin;

--- a/src/cmd/ksh93/sh/nvdisc.c
+++ b/src/cmd/ksh93/sh/nvdisc.c
@@ -714,7 +714,7 @@ int nv_adddisc(Namval_t *np, const char **names, Namval_t **funs)
 }
 
 /*
- * push, pop, clne, or reorder disciplines onto node <np>
+ * push, pop, clone, or reorder disciplines onto node <np>
  * mode can be one of
  *    NV_FIRST:  Move or push <fp> to top of the stack or delete top
  *    NV_LAST:	 Move or push <fp> to bottom of stack or delete last

--- a/src/cmd/ksh93/sh/path.c
+++ b/src/cmd/ksh93/sh/path.c
@@ -1397,8 +1397,8 @@ static noreturn void exscript(char *path,char *argv[])
 	{
 		sabuf.ac_btime = time(NULL);
 		before = times(&buffer);
-		sabuf.ac_uid = getuid();
-		sabuf.ac_gid = getgid();
+		sabuf.ac_uid = sh.userid;
+		sabuf.ac_gid = sh.groupid;
 		strncpy(sabuf.ac_comm, (char*)path_basename(cmdname),
 			sizeof(sabuf.ac_comm));
 		shaccton = 1;

--- a/src/cmd/ksh93/sh/pmain.c
+++ b/src/cmd/ksh93/sh/pmain.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1982-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2025 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *

--- a/src/cmd/ksh93/sh/pmain.c
+++ b/src/cmd/ksh93/sh/pmain.c
@@ -38,5 +38,6 @@ int main(int argc, char *argv[])
 	mha.mha_pagesize = 64 * 1024;
 	(void)memcntl(NULL, 0, MC_HAT_ADVISE, (caddr_t)&mha, 0, 0);
 #endif
-	return sh_main(argc, argv, NULL);
+	sh_main(argc, argv, NULL);
+	UNREACHABLE();
 }

--- a/src/cmd/ksh93/sh/tdump.c
+++ b/src/cmd/ksh93/sh/tdump.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1982-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2025 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -126,14 +126,11 @@ static int p_tree(const Shnode_t *t)
 				return -1;
 			if((t->tre.tretyp&TPAREN)==TPAREN)
 				return p_tree(t->lst.lstlef);
-			else
-			{
-				if(p_arg(&(t->lst.lstlef->arg))<0)
-					return -1;
-				if((t->tre.tretyp&TBINARY))
-					return p_arg(&(t->lst.lstrit->arg));
-				return 0;
-			}
+			if(p_arg(&(t->lst.lstlef->arg))<0)
+				return -1;
+			if((t->tre.tretyp&TBINARY))
+				return p_arg(&(t->lst.lstrit->arg));
+			return 0;
 	}
 	return -1;
 }

--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -2786,12 +2786,11 @@ pid_t _sh_fork(pid_t parent,int flags,int *jobid)
 	sh_timerdel(NULL);
 	if(sh_isstate(SH_MONITOR))
 	{
-		parent = sh.current_pid;
 		if(postid==0)
-			job.curpgid = parent;
-		while(setpgid(0,job.curpgid)<0 && job.curpgid!=parent)
-			job.curpgid = parent;
-		if(job.jobcontrol && job.curpgid==parent && !(flags&FAMP))
+			job.curpgid = sh.current_pid;
+		while(setpgid(0,job.curpgid)<0 && job.curpgid!=sh.current_pid)
+			job.curpgid = sh.current_pid;
+		if(job.jobcontrol && job.curpgid==sh.current_pid && !(flags&FAMP))
 			tcsetpgrp(job.fd,job.curpgid);
 	}
 	if(job.jobcontrol)

--- a/src/cmd/ksh93/shell.3
+++ b/src/cmd/ksh93/shell.3
@@ -26,7 +26,7 @@ Shwait_f;
 .SS "FUNCTIONS"
 .nf
 .ft 5
-int		sh_main(int \fIargc\fP, char *\fIargv\fP[], Sh_init \fIfn\fP);
+noreturn void	sh_main(int \fIargc\fP, char *\fIargv\fP[], Sh_init \fIfn\fP);
 Shell_t		*sh_init(int \fIargc\fP, char *\fIargv\fP[]);
 Shell_t		*sh_getinterp(void);
 

--- a/src/cmd/ksh93/tests/heredoc.sh
+++ b/src/cmd/ksh93/tests/heredoc.sh
@@ -582,8 +582,8 @@ exp=$'\t\tTest line 1\n\tTest line 2'
 
 # ======
 # $@ and $* in here-document
-# Note: POSIX sys that $@ has unspecified behaviour in this context because
-# field generation is not posible, but ksh's traditional behaviour is to pull
+# Note: POSIX says that $@ has unspecified behaviour in this context because
+# field generation is not possible, but ksh's traditional behaviour is to pull
 # a space out of a hat and use it as the output field separator. Only $* makes
 # sense in a here-document. In any scalar context (in which field splittig is
 # not possible), POSIX specifies that $* uses the first character of $IFS as

--- a/src/cmd/ksh93/tests/options.sh
+++ b/src/cmd/ksh93/tests/options.sh
@@ -2,7 +2,7 @@
 #                                                                      #
 #               This software is part of the ast package               #
 #          Copyright (c) 1982-2012 AT&T Intellectual Property          #
-#          Copyright (c) 2020-2024 Contributors to ksh 93u+m           #
+#          Copyright (c) 2020-2025 Contributors to ksh 93u+m           #
 #                      and is licensed under the                       #
 #                 Eclipse Public License, Version 2.0                  #
 #                                                                      #
@@ -450,13 +450,16 @@ print $'#!'$SHELL$'\nkill -KILL $$' > command-kill
 print $'kill -KILL $$' > script-kill
 chmod +x command-kill script-kill
 export PATH=.:$PATH
+exp='Killed'
+exp2=$exp
+expmsg="'$exp'"
+unset exp2
 if [[ $(uname) == Haiku ]]; then
-	# On Haiku signal numbers 9 and 21 (SIGKILL and SIGKILLTHR)
-	# both result in a 'Kill Thread' message, regardless of which
-	# shell or kill utility used.
-	exp='Kill Thread'
-else
-	exp='Killed'
+	# On older versions of Haiku signal numbers 9 and 21
+	# (SIGKILL and SIGKILLTHR) may both issue a 'Kill Thread'
+	# message.
+	exp2='Kill Thread'
+	expmsg+=" or '$exp2'"
 fi
 for ((S=0; S<${#SUB[@]}; S++))
 do	for ((P=0; P<${#PAR[@]}; P++))
@@ -466,7 +469,9 @@ do	for ((P=0; P<${#PAR[@]}; P++))
 				eval got="$cmd"
 				got=${got##*': '}
 				got=${got%%'('*}
-				[[ $got == "$exp" ]] || err_exit "$cmd failed -- got '$got', expected '$exp'"
+				if [[ $got != "$exp" ]] && [[ $got != "$exp2" ]]
+				then	err_exit "$cmd failed -- got '$got', expected $expmsg"
+				fi
 			done
 		done
 	done

--- a/src/lib/libast/RELEASE
+++ b/src/lib/libast/RELEASE
@@ -641,7 +641,7 @@ ____
 04-07-27 features/common,features/limits.c: ULL suffix for unsigned _ast_int8_t
 04-07-22 include/ast.h,comp/eaccess.c: add eaccess() for effective access()
 04-07-19 comp/open.c,sfio/_sfopen.c: { O_RDONLY O_WRONLY O_RDWR } are values
-04-06-28 misc/error.c: check level after error_info.auxilliary
+04-06-28 misc/error.c: check level after error_info.auxiliary
 04-06-24 string/strmatch.c: strgrpmatch() match[] now variable size array
 04-06-17 features/common: change _DLL null define to (the standard AST) 1
 04-06-11 misc/optget.c: allow optional [-|+|--|++] optstr() option prefix
@@ -1703,7 +1703,7 @@ ____
 	 snarf vmalloc from kpv
 95-08-11 fix malloc bug in magic
 	 update Linux and BSD 386 magic entries
-	 error_info.auxilliary returns new level, |=ERROR_OUTPUT if msg done
+	 error_info.auxiliary returns new level, |=ERROR_OUTPUT if msg done
 	 drop fnmatch from strmatch for SPARC (Solaris) until it collates
 95-07-17 fix port/astconf universe initialization
 	 fix misc/optget opt_info.nopt initialization

--- a/src/lib/libast/cdt/dtdisc.c
+++ b/src/lib/libast/cdt/dtdisc.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2012 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2023 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2025 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -38,9 +38,9 @@ static void* dtmemory(Dt_t* 	dt,	/* dictionary			*/
 		{	free(addr);
 			return NULL;
 		}
-		else	return realloc(addr,size);
+		return realloc(addr,size);
 	}
-	else	return size > 0 ? malloc(size) : NULL;
+	return size > 0 ? malloc(size) : NULL;
 }
 
 Dtdisc_t* dtdisc(Dt_t* dt, Dtdisc_t* disc, int type)

--- a/src/lib/libast/comp/setlocale.c
+++ b/src/lib/libast/comp/setlocale.c
@@ -508,7 +508,7 @@ static int
 utf8_mbtowc(wchar_t* wp, const char* str, size_t n)
 {
 	unsigned char*	sp = (unsigned char*)str;
-	int		m;
+	size_t		m;
 	int		i;
 	int		c;
 	wchar_t		w = 0;

--- a/src/lib/libast/include/ast_std.h
+++ b/src/lib/libast/include/ast_std.h
@@ -167,14 +167,14 @@ extern char*		setlocale(int, const char*);
 #define AST_LC_LANG		255
 
 #define AST_LC_internal		1
-#define AST_LC_7bit		(1L << 24)
-#define AST_LC_utf8		(1L << 25)
-#define AST_LC_test		(1L << 26)
-#define AST_LC_setenv		(1L << 27)
-#define AST_LC_find		(1L << 28)
-#define AST_LC_debug		(1L << 29)
-#define AST_LC_setlocale	(1L << 30)
-#define AST_LC_translate	(1L << 31)
+#define AST_LC_7bit		(1 << 23)
+#define AST_LC_utf8		(1 << 24)
+#define AST_LC_test		(1 << 25)
+#define AST_LC_setenv		(1 << 26)
+#define AST_LC_find		(1 << 27)
+#define AST_LC_debug		(1 << 28)
+#define AST_LC_setlocale	(1 << 29)
+#define AST_LC_translate	(1 << 30)
 
 #ifndef LC_ALL
 #define LC_ALL			(-AST_LC_ALL)

--- a/src/lib/libast/include/error.h
+++ b/src/lib/libast/include/error.h
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2012 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2023 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2025 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -136,7 +136,7 @@ struct Error_info_s			/* error state			*/
 
 	char*	version;		/* ERROR_SOURCE command version	*/
 
-	int	(*auxilliary)(Sfio_t*, int, int); /* aux info to append	*/
+	int	(*auxiliary)(Sfio_t*, int, int); /* aux info to append	*/
 
 	ERROR_CONTEXT			/* top of context stack		*/
 

--- a/src/lib/libast/include/proc.h
+++ b/src/lib/libast/include/proc.h
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2025 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -40,7 +40,7 @@
 #define PROC_ORPHAN	(1<<18)	/* create orphaned process		*/
 #define PROC_OVERLAY	(1<<7)	/* overlay current process if possible	*/
 #define PROC_PARANOID	(1<<8)	/* restrict everything			*/
-#define PROC_PRIVELEGED	(1<<9)	/* setuid(0), setgid(getegid())		*/
+#define PROC_PRIVILEGED	(1<<9)	/* setuid(0), setgid(getegid())		*/
 #define PROC_READ	(1<<10)	/* proc pipe fd 1 returned		*/
 #define PROC_SESSION	(1<<11)	/* session leader			*/
 #define PROC_UID	(1<<12)	/* setuid(getuid())			*/

--- a/src/lib/libast/man/iblocks.3
+++ b/src/lib/libast/man/iblocks.3
@@ -41,7 +41,7 @@
 ..
 .TH IBLOCKS 3
 .SH NAME
-iblocks \- compute number file blocks used
+iblocks \- compute the number of blocks used by a file
 .SH SYNOPSIS
 .EX
 #include <ls.h>

--- a/src/lib/libast/man/proc.3
+++ b/src/lib/libast/man/proc.3
@@ -239,7 +239,7 @@ is used to execute
 .I command
 if it is a shell script.
 .TP
-.L PROC_PRIVELEGED
+.L PROC_PRIVILEGED
 If the effective user ID is
 .L 0
 then the child real user ID is set to

--- a/src/lib/libast/misc/error.c
+++ b/src/lib/libast/misc/error.c
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 /*
@@ -50,7 +51,7 @@ static Error_info_t	_error_info_ =
 	2, exit, write,
 	0,0,0,0,0,0,0,0,
 	0,			/* version			*/
-	0,			/* auxilliary			*/
+	0,			/* auxiliary			*/
 	0,0,0,0,0,0,0,		/* top of old context stack	*/
 	0,0,0,0,0,0,0,		/* old empty context		*/
 	0,			/* time				*/
@@ -523,8 +524,8 @@ errorv(const char* id, int level, va_list ap)
 					errno = 0;
 				error_info.last_errno = (level >= 0) ? 0 : errno;
 			}
-			if (error_info.auxilliary && level >= 0)
-				level = (*error_info.auxilliary)(stkstd, level, flags);
+			if (error_info.auxiliary && level >= 0)
+				level = (*error_info.auxiliary)(stkstd, level, flags);
 			sfputc(stkstd, '\n');
 		}
 		if (level > 0)

--- a/src/lib/libast/misc/optget.c
+++ b/src/lib/libast/misc/optget.c
@@ -447,9 +447,6 @@ secname(char* section)
 		case 'C':
 			s = "COMPATIBILITY ";
 			break;
-		case 'U':
-			s = "UWIN ";
-			break;
 		case 'X':
 			s = "MISCELLANEOUS ";
 			break;

--- a/src/lib/libast/misc/procopen.c
+++ b/src/lib/libast/misc/procopen.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2012 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2025 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -575,7 +575,7 @@ procopen(const char* cmd, char** argv, char** envv, int64_t* modv, int flags)
 			modify(proc, forked, PROC_sys_pgrp, -1, 0);
 		if (forked || (flags & PROC_OVERLAY))
 		{
-			if ((flags & PROC_PRIVELEGED) && !geteuid())
+			if ((flags & PROC_PRIVILEGED) && !geteuid())
 			{
 				setuid(geteuid());
 				setgid(getegid());

--- a/src/lib/libast/regex/regcoll.c
+++ b/src/lib/libast/regex/regcoll.c
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 /*

--- a/src/lib/libast/regex/regcoll.c
+++ b/src/lib/libast/regex/regcoll.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2012 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2023 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2025 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *

--- a/src/lib/libcmd/cut.c
+++ b/src/lib/libcmd/cut.c
@@ -102,7 +102,7 @@ typedef struct Cut_s
 #define C_BYTES		1
 #define C_CHARS		2
 #define C_FIELDS	4
-#define C_SUPRESS	8
+#define C_SUPPRESS	8
 #define C_NOSPLIT	16
 #define C_NONEWLINE	32
 
@@ -154,7 +154,7 @@ cutinit(int mode, char* str, Delim_t* wdelim, Delim_t* ldelim, size_t reclen)
 	cut->space[cut->eob] = SP_LINE;
 	cut->cflag = (mode&C_CHARS) && cut->mb;
 	cut->nosplit = (mode&(C_BYTES|C_NOSPLIT)) == (C_BYTES|C_NOSPLIT) && cut->mb;
-	cut->sflag = (mode&C_SUPRESS) != 0;
+	cut->sflag = (mode&C_SUPPRESS) != 0;
 	cut->nlflag = (mode&C_NONEWLINE) != 0;
 	cut->reclen = reclen;
 	lp = cut->list;
@@ -660,7 +660,7 @@ b_cut(int argc, char** argv, Shbltin_t* context)
 				reclen = opt_info.num;
 			continue;
 		case 's':
-			mode |= C_SUPRESS;
+			mode |= C_SUPPRESS;
 			continue;
 		case ':':
 			error(2, "%s", opt_info.arg);
@@ -686,7 +686,7 @@ b_cut(int argc, char** argv, Shbltin_t* context)
 	}
 	if(!*cp)
 		error(3, "non-empty b, c or f option must be specified");
-	if((mode & (C_FIELDS|C_SUPRESS)) == C_SUPRESS)
+	if((mode & (C_FIELDS|C_SUPPRESS)) == C_SUPPRESS)
 		error(3, "s option requires f option");
 	cut = cutinit(mode, cp, &wdelim, &ldelim, reclen);
 	if(cp = *argv)

--- a/src/lib/libcmd/grep.c
+++ b/src/lib/libcmd/grep.c
@@ -13,6 +13,7 @@
 *                 Glenn Fowler <gsf@research.att.com>                  *
 *                  David Korn <dgk@research.att.com>                   *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 
@@ -207,7 +208,7 @@ labelcomp(const regex_t* re, const char* s, size_t len, regdisc_t* disc)
 	n = 0;
 	while (s < e)
 		n = (n << 3) + (*s++ - '0');
-	return (void*)((char*)0 + n);
+	return (void*)((uintptr_t)n);
 }
 
 static int
@@ -264,7 +265,7 @@ addre(State_t* state, char* s)
 	if (x)
 	{
 		b = (state->options & (REG_AUGMENTED|REG_EXTENDED)) ? "" : "\\";
-		sfprintf(state->tmp, "%s(?{%I*o})", b, sizeof(ptrdiff_t), (char*)x - (char*)0);
+		sfprintf(state->tmp, "%s(?{%I*o})", b, sizeof(ptrdiff_t), (intptr_t)x);
 		if (state->labels.tail)
 			state->labels.tail = state->labels.tail->next = x;
 		else

--- a/src/lib/libcmd/tee.c
+++ b/src/lib/libcmd/tee.c
@@ -158,14 +158,6 @@ b_tee(int argc, char** argv, Shbltin_t* context)
 	}
 	argv += opt_info.index;
 	argc -= opt_info.index;
-#if _ANCIENT_BSD_COMPATIBILITY
-	if (*argv && streq(*argv, "-"))
-	{
-		signal(SIGINT, SIG_IGN);
-		argv++;
-		argc--;
-	}
-#endif
 	if (argc > 0)
 	{
 		if (tp = stkalloc(stkstd, sizeof(Tee_t) + argc * sizeof(int)))

--- a/src/lib/libcmd/wclib.c
+++ b/src/lib/libcmd/wclib.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1992-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2025 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *

--- a/src/lib/libdll/dlllib.h
+++ b/src/lib/libdll/dlllib.h
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1997-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2025 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -12,8 +12,12 @@
 *                                                                      *
 *                 Glenn Fowler <gsf@research.att.com>                  *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
+
+#ifndef _DLLLIB_H
+#define _DLLLIB_H	1
 
 #include <ast.h>
 #include <dlldefs.h>
@@ -28,3 +32,5 @@ typedef struct Dllstate_s
 } Dllstate_t;
 
 extern Dllstate_t	state;
+
+#endif


### PR DESCRIPTION
- Prefer the already set `sh.userid` and `sh.groupid` over outright calls to `getuid()` and `getgid()`.
- Backported minor lint fixes from ksh2020 for redundant else statements (commits 4116459 and 18823be).
- Added include guards to some headers that were missing them.
- xec.c: After forking a child process, use `sh.current_pid` directly rather than misleadingly using `parent` as the child process PID.
- Add the `noreturn` attribute to `sh_main()`.
- kshrc.sh: Use a red color when the exit status is a negative number (e.g. a shell function returned -1).
- optget: Remove obsolete compat code for UWIN.
- tee: Remove unused code for ancient BSD.
- options.sh: Fix tests on Haiku again to cope for Haiku fixing their implementation of SIGKILL (which now properly outputs 'Killed').
- terminal.h: Removed extern for the no longer existing `sh_ioctl()`.
- Patch iffe to prevent it from leaking `PACKAGEROOT` while making the ast/dlldefs.h file; i.e., remove it from this line (re: 9b64328):
```c
 #define _LIB_ast	1	/* /home/johno/GitRepos/KornShell/ksh/arch/linux.i386-64/lib/libast.a is a library */
```
- mamake: For efficiency, check `MAMAKE_STRICT` before calling `strncmp`.
- Avoid passing NULL to `gettext` to fix a GCC analyzer warning.
- Removed null pointer arithmetic in the `grep` builtin.
- Moved the AST_LC_* bitflags into the 32-bit range a second time (re: 0a2302e2).
- Fixed a `-Wsign-compare` warning in `utf8_mbtowc()` by changing the int `m` to size_t. This seemingly innocuous change results in a small speedup in shellbench for ksh binaries on Linux x86_64 (10 runs of charsplit with CCFLAGS=-O2): 
```
--------------------------------------------------------
name           /tmp/ksh-int-gcc     /tmp/ksh-size_t-gcc
-------------------------------------------------------
charsplit.ksh  0.425 [0.422-0.431]  0.325 [0.289-0.358]
-------------------------------------------------------
---------------------------------------------------------
name           /tmp/ksh-int-clang   /tmp/ksh-size_t-clang
---------------------------------------------------------
charsplit.ksh  0.391 [0.389-0.393]  0.357 [0.355-0.360]
---------------------------------------------------------
```

(Side note: It's been far too long since I made a contribution; real life keeps getting in the way. Perhaps I'll find the time to finish one of my other unfinished projects.)
