### PR TITLE
sh_diropenat(): General improvements

### DIFF
--- a/src/cmd/ksh93/Mamfile
+++ b/src/cmd/ksh93/Mamfile
@@ -83,7 +83,7 @@ make install virtual
 		exec - %{iffe_run} %{<}
 	done
 
-	loop F options externs locale cmds poll rlimits
+	loop F options externs fchdir locale cmds poll rlimits
 		make FEATURE/%{F}
 			makp features/%{F}
 			exec - %{iffe_run} %{<}
@@ -268,6 +268,7 @@ make install virtual
 	make include/io.h
 		prev %{INCLUDE_AST}/sfio.h
 		prev %{INCLUDE_AST}/ast.h
+		prev FEATURE/fchdir
 	done
 
 	make include/jobs.h
@@ -355,6 +356,7 @@ make install virtual
 			prev include/test.h
 			prev %{INCLUDE_AST}/ls.h
 			prev include/builtins.h
+			prev include/io.h
 			prev include/name.h
 			prev include/path.h
 			prev include/variables.h

--- a/src/cmd/ksh93/features/fchdir
+++ b/src/cmd/ksh93/features/fchdir
@@ -1,0 +1,61 @@
+tst	fchdir_osearch_compat note{ can fchdir(2) use file descriptors obtained using O_PATH or O_SEARCH }end output{
+	#include <ast.h>
+	#include <wait.h>
+	#include <stdio.h>
+	#if !O_SEARCH
+	#error No O_SEARCH or O_PATH detected; fchdir is unreliable
+	#endif
+	int main(void)
+	{
+		char	dirname[64];
+		int	n;
+		pid_t	child;
+		sprintf(dirname,".dir2.%u",(unsigned int)getpid());
+		mkdir(dirname,0777);
+		child = fork();
+		if(child==0)
+		{
+	#if _lib_openat
+			if((n = openat(AT_FDCWD, dirname, O_DIRECTORY|O_NONBLOCK|O_cloexec|O_SEARCH)) < 0)
+	#else
+			if((n = open(dirname, O_DIRECTORY|O_cloexec|O_SEARCH)) < 0)  /* vulnerable to race, but that's not a concern */
+	#endif
+				return 1;  /* couldn't even obtain a file descriptor */
+			if(fchdir(n) < 0)
+				return 1;  /* couldn't change the directory (perhaps Linux <3.2.23) */
+			return 0;
+		}
+		else if(child==-1)
+		{
+			rmdir(dirname);
+			return 1;
+		}
+		/* a parent process removes the empty dir because that's safer than 'cd ..' */
+		waitpid(child, &n, 0);
+		rmdir(dirname);
+		return WEXITSTATUS(n);
+	}
+}end
+
+tst	openat_enotdir note{ does openat set ENOTDIR when it fails because the file isn't a directory }end output{
+	#include <ast.h>
+	#include <stdio.h>
+	#include <errno.h>
+	#if !_lib_openat
+	#error openat(2) doesn't exist, so this test is pointless
+	#endif
+	int main(void)
+	{
+		char	filename[64];
+		int	n, saverrno;
+		pid_t	child;
+		sprintf(filename,".file.%u",(unsigned int)getpid());
+		open(filename,O_RDWR|O_CREAT);  /* let the OS close the fd after completion */
+		openat(AT_FDCWD, filename, O_DIRECTORY|O_NONBLOCK|O_cloexec|O_SEARCH);
+		saverrno = errno;
+		unlink(filename);
+		if(saverrno != ENOTDIR)
+			return 1;
+		return 0;
+	}
+}end

--- a/src/cmd/ksh93/include/io.h
+++ b/src/cmd/ksh93/include/io.h
@@ -26,6 +26,7 @@
 
 #include	<ast.h>
 #include	<sfio.h>
+#include	"FEATURE/fchdir"
 
 #ifndef IOBSIZE
 #   define  IOBSIZE	(SFIO_BUFSIZE*sizeof(char*))
@@ -51,6 +52,12 @@
 #ifndef ARG_RAW
     struct ionod;
 #endif /* !ARG_RAW */
+
+/* if O_SEARCH/O_PATH is unreliable for fchdir, it's not worth using */
+#if !_fchdir_osearch_compat
+#undef O_SEARCH
+#define O_SEARCH 0
+#endif
 
 /*
  * Check if there is an editor active while avoiding repetitive #if flaggery.


### PR DESCRIPTION
- Avoid duplicating the file descriptor from `openat` when it's already >9 to increase performance and reliability.
- Add a feature test which tests the `errno` resulting from using `openat` on a non-directory with `O_DIRECTORY|O_SEARCH`. On illumos (and presumably Solaris) `openat` can misleadingly fail with `EACCES` rather than `ENOTDIR`, so account for that by testing the given directory in question with `stat` (but since `stat` is hardly performance-friendly, the feature test is used to ensure this is only compiled in when absolutely necessary).
- Added a feature test to see if file descriptors obtained via `O_SEARCH` or `O_PATH` can actually be used with `fchdir`. This is also relevant for `open` because of `O_SEARCH`'s usage in the fallback code in `sh_subshell()`.
- Ensure the close-on-exec bit is set for the file descriptor returned by `sh_diropenat()`.

These changes allow for the elimination of the double `openat` and should help mitigate the performance loss for cd's performance as observed after the merge of 3d7b7e19 (assuming the platform supports `F_DUPFD_CLOEXEC` and `O_CLOEXEC`):
vide https://github.com/ksh93/ksh/issues/816#issuecomment-2571454660

Results obtained on Linux amd64 using `CCFLAGS=-Os`.
Results for `typeset -i i; time for((i=0;i<500000;i++));do cd /dev; cd /;done`
```
ksh-no-openat-9b0b2603:
real    0m01.72s
ksh-dev-de530132:
real    0m03.55s
ksh-this-commit:
real    0m02.91s
ksh-this-commit-no-subshell-inode-test: (same due to no subshells)
real    0m02.90s
ksh93u+:
real    0m02.02s
```

I'll admit `cd` still isn't as fast as before, yet the trade off is still worthwhile because ksh93 scripts are bound to use subshells (particulary command substitutions) far more often than `cd`. In the contrived benchmark `cd` is called 1,000,000 times, which hardly reflects real world scripts. This also doesn't account for the practice of calling `cd` from within a subshell, which is common.

Results for `typeset -i i; time for((i=0;i<500000;i++));do (cd /dev); (cd /);done`
```
ksh-no-openat-9b0b2603:
real    0m06.73s
ksh-dev-de530132:
real    0m07.18s
ksh-this-commit:
real    0m06.34s
ksh-this-commit-no-subshell-inode-test:
real    0m04.77s
ksh93u+:
real    0m05.19s
```

Here a small uplift can be seen relative to both of the previous 93u+m iterations, but because of the inode sanity check present since 5ee290c7 `cd` is still a bit slower in subshells relative to ksh93u+. (Perhaps in a future commit a faster alternative could be looked into.)

Meanwhile the relevant shbench results are about the same (`-l 10`):
```
-----------------------------------------------------------------------------------------------------------------------------------
name           ksh-no-openat-9b0b2603  ksh-dev-de530132     ksh-this-commit      ksh-this-commit-no-inode-test  ksh93u+
-----------------------------------------------------------------------------------------------------------------------------------
fibonacci.ksh  0.247 [0.240-0.258]     0.227 [0.225-0.233]  0.235 [0.227-0.241]  0.235 [0.232-0.240]            0.258 [0.251-0.264]
parens.ksh     0.191 [0.185-0.197]     0.097 [0.095-0.098]  0.097 [0.095-0.100]  0.099 [0.095-0.101]            0.227 [0.221-0.234]
-----------------------------------------------------------------------------------------------------------------------------------
```