### PR TITLE
Fix handling of close-on-exec bit

### DIFF
--- a/src/cmd/ksh93/bltins/hist.c
+++ b/src/cmd/ksh93/bltins/hist.c
@@ -212,7 +212,7 @@ int	b_hist(int argc,char *argv[], Shbltin_t *context)
 			errormsg(SH_DICT,ERROR_exit(1),e_create,"");
 			UNREACHABLE();
 		}
-		if((fdo=open(fname,O_CREAT|O_RDWR,S_IRUSR|S_IWUSR)) < 0)
+		if((fdo=open(fname,O_CREAT|O_RDWR|O_cloexec,S_IRUSR|S_IWUSR)) < 0)
 		{
 			errormsg(SH_DICT,ERROR_system(1),e_create,fname);
 			UNREACHABLE();

--- a/src/cmd/ksh93/features/externs
+++ b/src/cmd/ksh93/features/externs
@@ -219,7 +219,7 @@ tst	execve_dir_enoexec note{ does execve(3) set errno to ENOEXEC when trying to 
 	{
 		char	dirname[64];
 		int	e;
-		sprintf(dirname,".dir.%u",(unsigned)getpid());
+		sprintf(dirname,".dir.%u",(unsigned int)getpid());
 		mkdir(dirname,0777);
 		execve(dirname,argv,environ);
 		e = errno;

--- a/src/cmd/ksh93/include/io.h
+++ b/src/cmd/ksh93/include/io.h
@@ -72,7 +72,7 @@ extern void 	sh_ioinit(void);
 extern int 	sh_iomovefd(int);
 extern int	sh_iorenumber(int,int);
 extern void 	sh_pclose(int[]);
-extern int	sh_rpipe(int[]);
+extern int	sh_rpipe(int[],int);
 extern void 	sh_iorestore(int,int);
 extern Sfio_t 	*sh_iostream(int);
 extern int	sh_redirect(struct ionod*,int);

--- a/src/cmd/ksh93/include/shell.h
+++ b/src/cmd/ksh93/include/shell.h
@@ -475,7 +475,7 @@ extern Sfio_t		*sh_pathopen(const char*);
 extern ssize_t 		sh_read(int, void*, size_t);
 extern ssize_t 		sh_write(int, const void*, size_t);
 extern off_t		sh_seek(int, off_t, int);
-extern int 		sh_pipe(int[]);
+extern int 		sh_pipe(int[],int);
 extern mode_t 		sh_umask(mode_t);
 extern Shwait_f		sh_waitnotify(Shwait_f);
 extern Shscope_t	*sh_getscope(int,int);
@@ -500,7 +500,6 @@ extern Shell_t		sh;
 #   define close(a)	sh_close(a)
 #   define exit(a)	sh_exit(a)
 #   define fcntl(a,b,c)	sh_fcntl(a,b,c)
-#   define pipe(a)	sh_pipe(a)
 #   define read(a,b,c)	sh_read(a,b,c)
 #   define write(a,b,c)	sh_write(a,b,c)
 #   define umask(a)	sh_umask(a)

--- a/src/cmd/ksh93/sh/args.c
+++ b/src/cmd/ksh93/sh/args.c
@@ -716,7 +716,7 @@ char **sh_argbuild(int *nargs, const struct comnod *comptr,int flag)
 }
 
 #if _pipe_socketpair && !_socketpair_devfd
-#   define sh_pipe(a)	sh_rpipe(a)
+#   define sh_pipe(a,b)	sh_rpipe(a,b)
 #endif
 
 struct argnod *sh_argprocsub(struct argnod *argp)
@@ -736,7 +736,7 @@ struct argnod *sh_argprocsub(struct argnod *argp)
 #if SHOPT_DEVFD
 	sfwrite(sh.stk,e_devfdNN,8);
 	pv[2] = 0;
-	sh_pipe(pv);
+	sh_pipe(pv,0);
 #else
 	pv[0] = -1;
 	while(sh.fifo = pathtemp(0,0,0,"ksh.fifo",0), sh.fifo && mkfifo(sh.fifo,0)<0)

--- a/src/cmd/ksh93/sh/io.c
+++ b/src/cmd/ksh93/sh/io.c
@@ -95,9 +95,6 @@ static int	(*fdnotify)(int,int);
 #      ifndef SHUT_WR
 #         define SHUT_WR         1
 #      endif
-#      ifndef SOCK_CLOEXEC
-#         define SOCK_CLOEXEC 0
-#      endif
 #      if _socketpair_shutdown_mode
 #         define socketpipe(v,f) ((socketpair(AF_UNIX,SOCK_STREAM|((f)?SOCK_CLOEXEC:0),0,v)<0||shutdown((v)[1],SHUT_RD)<0||fchmod((v)[1],S_IWUSR)<0||shutdown((v)[0],SHUT_WR)<0||fchmod((v)[0],S_IRUSR)<0)?(-1):0)
 #      else

--- a/src/cmd/ksh93/sh/io.c
+++ b/src/cmd/ksh93/sh/io.c
@@ -79,6 +79,9 @@ static int	(*fdnotify)(int,int);
 #   include <sys/socket.h>
 #   include <netdb.h>
 #   include <netinet/in.h>
+#   ifndef SOCK_CLOEXEC
+#      define SOCK_CLOEXEC 0
+#   endif
 #   if !defined(htons) && !_lib_htons
 #      define htons(x)	(x)
 #   endif
@@ -92,10 +95,13 @@ static int	(*fdnotify)(int,int);
 #      ifndef SHUT_WR
 #         define SHUT_WR         1
 #      endif
+#      ifndef SOCK_CLOEXEC
+#         define SOCK_CLOEXEC 0
+#      endif
 #      if _socketpair_shutdown_mode
-#         define pipe(v) ((socketpair(AF_UNIX,SOCK_STREAM,0,v)<0||shutdown((v)[1],SHUT_RD)<0||fchmod((v)[1],S_IWUSR)<0||shutdown((v)[0],SHUT_WR)<0||fchmod((v)[0],S_IRUSR)<0)?(-1):0)
+#         define socketpipe(v,f) ((socketpair(AF_UNIX,SOCK_STREAM|((f)?SOCK_CLOEXEC:0),0,v)<0||shutdown((v)[1],SHUT_RD)<0||fchmod((v)[1],S_IWUSR)<0||shutdown((v)[0],SHUT_WR)<0||fchmod((v)[0],S_IRUSR)<0)?(-1):0)
 #      else
-#         define pipe(v) ((socketpair(AF_UNIX,SOCK_STREAM,0,v)<0||shutdown((v)[1],SHUT_RD)<0||shutdown((v)[0],SHUT_WR)<0)?(-1):0)
+#         define socketpipe(v,f) ((socketpair(AF_UNIX,SOCK_STREAM|((f)?SOCK_CLOEXEC:0),0,v)<0||shutdown((v)[1],SHUT_RD)<0||shutdown((v)[0],SHUT_WR)<0)?(-1):0)
 #      endif
 #   endif
 
@@ -292,6 +298,8 @@ inetopen(const char* path, int flags)
 			p->ai_protocol = hint.ai_protocol;
 		if (!p->ai_socktype)
 			p->ai_socktype = hint.ai_socktype;
+		if (flags & O_cloexec)
+			p->ai_socktype |= SOCK_CLOEXEC;
 		while ((fd = socket(p->ai_family, p->ai_socktype, p->ai_protocol)) >= 0)
 		{
 			if (server && !bind(fd, p->ai_addr, p->ai_addrlen) && !listen(fd, 5) || !server && !connect(fd, p->ai_addr, p->ai_addrlen))
@@ -633,10 +641,7 @@ static void io_preserve(Sfio_t *sp, int f2)
 	sh.sftable[fd] = sp;
 	sh.fdstatus[fd] = sh.fdstatus[f2];
 	if(fcntl(f2,F_GETFD,0)&1)
-	{
-		fcntl(fd,F_SETFD,FD_CLOEXEC);
-		sh.fdstatus[fd] |= IOCLEX;
-	}
+		sh_fcntl(fd,F_SETFD,FD_CLOEXEC);
 	sh.sftable[f2] = 0;
 }
 
@@ -862,13 +867,18 @@ int sh_open(const char *path, int flags, ...)
 	if((sp = sh.sftable[fd]) && (sfset(sp,0,0) & SFIO_STRING))
 	{
 		int n,err=errno;
-		if((n = sh_fcntl(fd,F_DUPFD,10)) >= 10)
+		int dupflag = (flags&O_cloexec) ? F_dupfd_cloexec : F_DUPFD;
+		if((n = fcntl(fd,dupflag,10)) >= 10)
 		{
 			while(close(fd) < 0 && errno == EINTR)
 				errno = err;
 			fd = n;
+			if((flags&O_cloexec) && F_dupfd_cloexec == F_DUPFD)
+				fcntl(fd,F_SETFD,FD_CLOEXEC);
 		}
 	}
+	if(flags&O_cloexec)
+		mode |= IOCLEX;
 	sh.fdstatus[fd] = mode;
 	return fd;
 }
@@ -893,13 +903,19 @@ int sh_chkopen(const char *name)
  */
 int sh_iomovefd(int fdold)
 {
-	int fdnew;
+	int fdnew, dupflags;
 	if(fdold >= sh.lim.open_max)
 		sh_iovalidfd(fdold);
 	if(fdold<0 || fdold>2)
 		return fdold;
-	fdnew = sh_iomovefd(dup(fdold));
-	sh.fdstatus[fdnew] = (sh.fdstatus[fdold]&~IOCLEX);
+	if(sh.fdstatus[fdold]&IOCLEX)
+		dupflags = F_dupfd_cloexec;
+	else
+		dupflags = F_DUPFD;
+	fdnew = sh_iomovefd(fcntl(fdold,dupflags,3));
+	if((sh.fdstatus[fdold]&IOCLEX) && F_dupfd_cloexec == F_DUPFD)
+		fcntl(fdnew,F_SETFD,FD_CLOEXEC);
+	sh.fdstatus[fdnew] = sh.fdstatus[fdold];
 	close(fdold);
 	sh.fdstatus[fdold] = IOCLOSE;
 	return fdnew;
@@ -908,52 +924,69 @@ int sh_iomovefd(int fdold)
 /*
  * create a pipe and print message on failure
  */
-int	sh_pipe(int pv[])
+int	sh_pipe(int pv[], int cloexec)
 {
 	int fd[2];
-#ifdef pipe
+#ifndef socketpipe
+	return sh_rpipe(pv,cloexec);
+#else
 	if(sh_isoption(SH_POSIX))
-		return sh_rpipe(pv);
-#endif
-	if(pipe(fd)<0 || (pv[0]=fd[0])<0 || (pv[1]=fd[1])<0)
+		return sh_rpipe(pv,cloexec);
+	if(socketpipe(fd,cloexec)<0 || (pv[0]=fd[0])<0 || (pv[1]=fd[1])<0)
 	{
 		errormsg(SH_DICT,ERROR_system(1),e_pipe);
 		UNREACHABLE();
 	}
-	pv[0] = sh_iomovefd(pv[0]);
-	pv[1] = sh_iomovefd(pv[1]);
-	sh.fdstatus[pv[0]] = IONOSEEK|IOREAD;
-	sh.fdstatus[pv[1]] = IONOSEEK|IOWRITE;
+	if(cloexec)
+		cloexec = IOCLEX;
+#if !SOCK_CLOEXEC
+	if(pv[0]>2 && cloexec)
+		fcntl(pv[0],F_SETFD,FD_CLOEXEC);
+	if(pv[1]>2 && cloexec)
+		fcntl(pv[1],F_SETFD,FD_CLOEXEC);
+#endif
+	sh.fdstatus[pv[0]] = IONOSEEK|IOREAD|cloexec;
+	sh.fdstatus[pv[1]] = IONOSEEK|IOWRITE|cloexec;
+	if(pv[0]<=2)
+		pv[0] = sh_iomovefd(pv[0]);
+	if(pv[1]<=2)
+		pv[1] = sh_iomovefd(pv[1]);
+	sh_subsavefd(pv[0]);
+	sh_subsavefd(pv[1]);
+	return 0;
+#endif /* socketpipe */
+}
+
+#if !_lib_pipe2 || !O_cloexec
+#    define pipe2(a,b)	pipe(a)
+#endif
+/* create a real pipe when pipe() is socketpair */
+int	sh_rpipe(int pv[], int cloexec)
+{
+	int fd[2];
+	if(pipe2(fd,cloexec?O_cloexec:0)<0 || (pv[0]=fd[0])<0 || (pv[1]=fd[1])<0)
+	{
+		errormsg(SH_DICT,ERROR_system(1),e_pipe);
+		UNREACHABLE();
+	}
+	if(cloexec)
+		cloexec = IOCLEX;
+#if !_lib_pipe2 || !O_cloexec
+	if(pv[0]>2 && cloexec)
+		fcntl(pv[0],F_SETFD,FD_CLOEXEC);
+	if(pv[1]>2 && cloexec)
+		fcntl(pv[1],F_SETFD,FD_CLOEXEC);
+#endif
+	sh.fdstatus[pv[0]] = IONOSEEK|IOREAD|cloexec;
+	sh.fdstatus[pv[1]] = IONOSEEK|IOWRITE|cloexec;
+	if(pv[0]<=2)
+		pv[0] = sh_iomovefd(pv[0]);
+	if(pv[1]<=2)
+		pv[1] = sh_iomovefd(pv[1]);
 	sh_subsavefd(pv[0]);
 	sh_subsavefd(pv[1]);
 	return 0;
 }
-
-#ifndef pipe
-   int	sh_rpipe(int pv[])
-   {
-   	return sh_pipe(pv);
-   }
-#else
-#  undef pipe
-   /* create a real pipe when pipe() is socketpair */
-   int	sh_rpipe(int pv[])
-   {
-	int fd[2];
-	if(pipe(fd)<0 || (pv[0]=fd[0])<0 || (pv[1]=fd[1])<0)
-	{
-		errormsg(SH_DICT,ERROR_system(1),e_pipe);
-		UNREACHABLE();
-	}
-	pv[0] = sh_iomovefd(pv[0]);
-	pv[1] = sh_iomovefd(pv[1]);
-	sh.fdstatus[pv[0]] = IONOSEEK|IOREAD;
-	sh.fdstatus[pv[1]] = IONOSEEK|IOWRITE;
-	sh_subsavefd(pv[0]);
-	sh_subsavefd(pv[1]);
-	return 0;
-   }
-#endif
 
 static size_t pat_line(const regex_t* rp, const char *buff, size_t n)
 {
@@ -1104,13 +1137,18 @@ int	sh_redirect(struct ionod *iop, int flag)
 	const char *message = e_open;
 	int o_mode;		/* mode flag for open */
 	static char io_op[7];	/* used for -x trace info */
-	int trunc=0, clexec=0, fn, traceon=0;
+	int trunc=0, clexec=0, fn, traceon=0, dupflags;
 	int r, indx = sh.topfd, perm= -1;
 	char *tname=0, *after="", *trace = sh.st.trap[SH_DEBUGTRAP];
 	Namval_t *np=0;
 
 	if(flag==2 && !sh_isoption(SH_POSIX))
+	{
 		clexec = 1;
+		dupflags = F_dupfd_cloexec;
+	}
+	else
+		dupflags = F_DUPFD;
 	if(iop)
 		traceon = sh_trace(NULL,0);
 	/*
@@ -1468,7 +1506,7 @@ int	sh_redirect(struct ionod *iop, int flag)
 				{
 					if(fd==fn)
 					{
-						if((r=sh_fcntl(fd,F_DUPFD,10)) > 0)
+						if((r=sh_fcntl(fd,dupflags,10)) > 0)
 						{
 							fd = r;
 							sh_close(fn);
@@ -1480,7 +1518,7 @@ int	sh_redirect(struct ionod *iop, int flag)
 				{
 					if(fd==fn)
 					{
-						if((r=sh_fcntl(fd,F_DUPFD,10)) > 0)
+						if((r=sh_fcntl(fd,dupflags,10)) > 0)
 						{
 							fd = r;
 							sh_close(fn);
@@ -1508,7 +1546,7 @@ int	sh_redirect(struct ionod *iop, int flag)
 					fn = fd;
 					if(fd<10)
 					{
-						if((fn=sh_fcntl(fd,F_DUPFD,10)) < 0)
+						if((fn=sh_fcntl(fd,dupflags,10)) < 0)
 							goto fail;
 						if(fn>=sh.lim.open_max && !sh_iovalidfd(fn))
 							goto fail;
@@ -1531,11 +1569,8 @@ int	sh_redirect(struct ionod *iop, int flag)
 						sh.inuse_bits |= (1<<fn);
 				}
 			}
-			if(fd >2 && clexec)
-			{
-				fcntl(fd,F_SETFD,FD_CLOEXEC);
-				sh.fdstatus[fd] |= IOCLEX;
-			}
+			if(fd>2 && clexec && !(sh.fdstatus[fd]&IOCLEX))
+				sh_fcntl(fd,F_SETFD,FD_CLOEXEC);
 		}
 		else
 			goto fail;
@@ -1687,7 +1722,7 @@ void sh_iosave(int origfd, int oldtop, char *name)
 		savefd = -1;
 	else
 	{
-		if((savefd = sh_fcntl(origfd, F_DUPFD, 10)) < 0 && errno!=EBADF)
+		if((savefd = sh_fcntl(origfd, F_dupfd_cloexec, 10)) < 0 && errno!=EBADF)
 		{
 			sh.toomany=1;
 			((struct checkpt*)sh.jmplist)->mode = SH_JMPERREXIT;
@@ -1703,7 +1738,8 @@ void sh_iosave(int origfd, int oldtop, char *name)
 	{
 		Sfio_t* sp = sh.sftable[origfd];
 		/* make saved file close-on-exec */
-		sh_fcntl(savefd,F_SETFD,FD_CLOEXEC);
+		if(F_dupfd_cloexec == F_DUPFD)
+			sh_fcntl(savefd,F_SETFD,FD_CLOEXEC);
 		if(origfd==job.fd)
 			job.fd = savefd;
 		sh.fdstatus[savefd] = sh.fdstatus[origfd];
@@ -2232,10 +2268,7 @@ static void	sftrack(Sfio_t* sp, int flag, void* data)
 		return;
 	mode = sfset(sp,0,0);
 	if(sp==sh.heredocs && fd < 10 && flag==SFIO_SETFD)
-	{
-		fd = sfsetfd(sp,10);
-		fcntl(fd,F_SETFD,FD_CLOEXEC);
-	}
+		fd = sfsetfd_cloexec(sp,10);
 	if(fd < 3)
 		return;
 	if(flag==SFIO_NEW)
@@ -2544,11 +2577,21 @@ int sh_fcntl(int fd, int op, ...)
 	if(newfd>=0) switch(op)
 	{
 	    case F_DUPFD:
+#if F_dupfd_cloexec != F_DUPFD
+	    case F_dupfd_cloexec:
+#endif
 		if(sh.fdstatus[fd] == IOCLOSE)
 			sh.fdstatus[fd] = 0;
 		if(newfd>=sh.lim.open_max)
 			sh_iovalidfd(newfd);
+#if F_dupfd_cloexec != F_DUPFD
+		if(op==F_DUPFD)
+			sh.fdstatus[newfd] = (sh.fdstatus[fd]&~IOCLEX);
+		else
+			sh.fdstatus[newfd] = (sh.fdstatus[fd]|IOCLEX);
+#else
 		sh.fdstatus[newfd] = (sh.fdstatus[fd]&~IOCLEX);
+#endif
 		if(fdnotify)
 			(*fdnotify)(fd,newfd);
 		break;

--- a/src/cmd/ksh93/sh/subshell.c
+++ b/src/cmd/ksh93/sh/subshell.c
@@ -105,10 +105,10 @@ void	sh_subtmpfile(void)
 		struct checkpt	*pp = (struct checkpt*)sh.jmplist;
 		struct subshell *sp = subshell_data->pipe;
 		/* save file descriptor 1 if open */
-		if((sp->tmpfd = fd = sh_fcntl(1,F_DUPFD,10)) >= 0)
+		if((sp->tmpfd = fd = sh_fcntl(1,F_dupfd_cloexec,10)) >= 0)
 		{
-			fcntl(fd,F_SETFD,FD_CLOEXEC);
-			sh.fdstatus[fd] = sh.fdstatus[1]|IOCLEX;
+			if(F_dupfd_cloexec == F_DUPFD)
+				sh_fcntl(fd,F_SETFD,FD_CLOEXEC);
 			close(1);
 		}
 		else if(errno!=EBADF)
@@ -559,18 +559,19 @@ Sfio_t *sh_subshell(Shnode_t *t, volatile int flags, int comsub)
 		}
 		if(sp->pwdfd<0)
 		{
-			int n = open(e_dot,O_SEARCH);
+			int n = sh_open(e_dot,O_SEARCH|O_cloexec);
 			if(n>=0)
 			{
 				sp->pwdfd = n;
 				if(n<10)
 				{
-					sp->pwdfd = sh_fcntl(n,F_DUPFD,10);
-					close(n);
+					sp->pwdfd = sh_fcntl(n,F_dupfd_cloexec,10);
+					sh_close(n);
 				}
 				if(sp->pwdfd>0)
 				{
-					fcntl(sp->pwdfd,F_SETFD,FD_CLOEXEC);
+					if(!(sh.fdstatus[sp->pwdfd]&IOCLEX))
+						sh_fcntl(sp->pwdfd,F_SETFD,FD_CLOEXEC);
 					sp->pwdclose = 1;
 				}
 			}
@@ -724,7 +725,7 @@ Sfio_t *sh_subshell(Shnode_t *t, volatile int flags, int comsub)
 			}
 			if(iop && sffileno(iop)==1)
 			{
-				int fd = sfsetfd(iop,sh_iosafefd(3));
+				int fd = sfsetfd_cloexec(iop,sh_iosafefd(3));
 				if(fd<0)
 				{
 					sh.toomany = 1;
@@ -735,7 +736,6 @@ Sfio_t *sh_subshell(Shnode_t *t, volatile int flags, int comsub)
 				if(fd >= sh.lim.open_max)
 					sh_iovalidfd(fd);
 				sh.sftable[fd] = iop;
-				fcntl(fd,F_SETFD,FD_CLOEXEC);
 				sh.fdstatus[fd] = (sh.fdstatus[1]|IOCLEX);
 				sh.fdstatus[1] = IOCLOSE;
 			}
@@ -874,7 +874,7 @@ Sfio_t *sh_subshell(Shnode_t *t, volatile int flags, int comsub)
 		else if(sp->pwd && strcmp(sp->pwd,sh.pwd))
 			path_newdir(sh.pathlist);
 		if(sp->pwdclose)
-			close(sp->pwdfd);
+			sh_close(sp->pwdfd);
 #endif /* _lib_openat */
 		free(sh.pwd);
 		sh.pwd = sp->pwd;

--- a/src/cmd/ksh93/tests/subshell.sh
+++ b/src/cmd/ksh93/tests/subshell.sh
@@ -607,7 +607,7 @@ then    integer i
 	for ((i=11; i < 29; i++))
 	do      if      ! [[ -r /dev/fd/$i  || -w /dev/fd/$i ]]
 		then    a=$($SHELL -c "[[ -r /dev/fd/$i || -w /dev/fd/$i ]]")
-			(( $? )) || err_exit "file descriptor $i not close on exec"
+			(( $? )) || err_exit "file descriptor $i not close-on-exec"
 		fi
 	done
 fi

--- a/src/lib/libast/features/lib
+++ b/src/lib/libast/features/lib
@@ -31,7 +31,7 @@ lib	gethostname,getpagesize,getrlimit,getuniverse
 lib	glob,iswblank,iswctype,killpg,link,localeconv,madvise
 lib	mbtowc,mbrtowc,memalign,memdup
 lib	mktemp,mktime
-lib	opendir,openat,pathconf
+lib	opendir,openat,pathconf,pipe2
 lib	rand_r
 lib	rewinddir,setlocale
 lib	setpgrp,setpgrp2,setreuid,setuid

--- a/src/lib/libast/features/lib
+++ b/src/lib/libast/features/lib
@@ -78,6 +78,7 @@ tst	lib_select sys/select.h note{ select() has standard 5 arg interface }end lin
 	#include <sys/types.h>
 	#include <sys/time.h>
 	#include <sys/socket.h>
+	#include <string.h>
 	int
 	main(void)
 	{	struct timeval	tmb;

--- a/src/lib/libast/include/sfio.h
+++ b/src/lib/libast/include/sfio.h
@@ -203,6 +203,7 @@ extern int		sfraise(Sfio_t*, int, void*);
 extern int		sfnotify(void(*)(Sfio_t*, int, void*));
 extern int		sfset(Sfio_t*, int, int);
 extern int		sfsetfd(Sfio_t*, int);
+extern int		sfsetfd_cloexec(Sfio_t*, int);
 extern Sfio_t*		sfpool(Sfio_t*, Sfio_t*, int);
 extern ssize_t		sfread(Sfio_t*, void*, size_t);
 extern ssize_t		sfwrite(Sfio_t*, const void*, size_t);

--- a/src/lib/libast/man/sfio.3
+++ b/src/lib/libast/man/sfio.3
@@ -190,6 +190,7 @@ SFIO_EVENT
 int        sfresize(Sfio_t* f, Sfoff_t size);
 int        sfset(Sfio_t* f, int flags, int i);
 int        sfsetfd(Sfio_t* f, int fd);
+int        sfsetfd_cloexec(Sfio_t* f, int fd);
 Sfio_t*    sfstack(Sfio_t* base, Sfio_t* top);
 char*      sfstruse(Sfio_t *f);
 Sfio_t*    sfswap(Sfio_t* f1, Sfio_t* f2);
@@ -1758,6 +1759,9 @@ Then, except for \f3sfclose()\fP, the stream will be inaccessible
 until a future \f3sfsetfd()\fP call resets the file descriptor to a non-negative value.
 Thus, \f3sfsetfd(f,-1)\fP can be used to avoid closing the file descriptor
 of \f3f\fP when \f3f\fP is closed.
+.Ss "  int sfsetfd_cloexec(Sfio_t* f, int fd)"
+This function is identical to \f3sfsetfd()\fP, with the exception that it will
+give duplicated file descriptors the close-on-exec flag.
 .Ss "  Sfio_t* sfstack(Sfio_t* base, Sfio_t* top)"
 This function stacks or unstacks stream.
 Every stream stack is identified by a base stream


### PR DESCRIPTION
This commit's main purpose is to robustify ksh93's handling of the close-on-exec bit. Much of this code is based on groundwork laid out in ksh93v-, though many other changes were made beyond that because the 93v- syscall intercepts were not backported.

- Avoid needlessly calling `fcntl` twice if `F_DUPFD_CLOEXEC` is available.
- Added support for `F_DUPFD_CLOEXEC` to `sh_fcntl`.
- Incidentally fixed file descriptor leakage in `histexceptf()`.
- Added support for close-on-exec to `sh_pipe()` and `sh_rpipe()`, which is implemented via `SOCK_CLOEXEC`, `pipe2` and (as a fallback) plain `fcntl` `F_SETFD`.
  - For process substitutions, rather than use another `fcntl` to undo close-on-exec (like in 93v-), instead add a second argument to `sh_pipe` and `sh_rpipe` that can be used to specify whether close-on-exec is wanted.
- Added support for `O_CLOEXEC` to `sh_open()`.
- Made it such that `sh_iomovefd` preserves the presence or absence of the close-on-exec bit.
  - The ksh93v- change to make `sh_iomovefd` return fds >9 broke one of the regression tests, so the current behavior (dup to 3 or higher) has been kept.