### PR TITLE
Sundrous fixes

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,11 @@ This documents significant changes in the dev branch of ksh 93u+m.
 For full details, see the git log at: https://github.com/ksh93/ksh
 Uppercase BUG_* IDs are shell bug IDs as used by the Modernish shell library.
 
+2025-07-30:
+
+- The editor typeahead buffer and the limit for the ${.sh.edchar} variable
+  (used with the KEYBD trap) has been increased from 80 to 500 bytes.
+
 2025-07-29:
 
 - Fixed a serious but rarely occurring regression that corrupts variable

--- a/NEWS
+++ b/NEWS
@@ -22,7 +22,7 @@ Uppercase BUG_* IDs are shell bug IDs as used by the Modernish shell library.
 
 - [v1.1] Fixed another bug with superfluous operands in test/[ that slipped
   through the cracks on 2024-12-08: test -n -a "" incorrectly returned 0. In
-  native mode, this is now an error (superflous operand to the unary -n
+  native mode, this is now an error (superfluous operand to the unary -n
   operator) and in POSIX mode, it returns 1/false, as POSIX-1.2017 rules
   require this to be a test for the non-emptiness of both strings -n and "".
 

--- a/src/cmd/ksh93/Mamfile
+++ b/src/cmd/ksh93/Mamfile
@@ -604,6 +604,7 @@ make install virtual
 		make sh/defs.c
 			prev include/jobs.h
 			prev include/defs.h
+			prev include/shlex.h
 			prev shopt.h
 		done
 

--- a/src/cmd/ksh93/include/edit.h
+++ b/src/cmd/ksh93/include/edit.h
@@ -25,14 +25,14 @@
  *
  */
 
-#define SEARCHSIZE	80
+#define SEARCHSIZE	500
 
 #include	"FEATURE/cmds"
 #include        "FEATURE/locale"
 #include	"terminal.h"
 
 #define STRIP		0377
-#define LOOKAHEAD	80
+#define LOOKAHEAD	500
 
 #if SHOPT_MULTIBYTE
 #   include	"national.h"

--- a/src/cmd/ksh93/include/shtable.h
+++ b/src/cmd/ksh93/include/shtable.h
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1982-2012 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2025 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -60,4 +60,4 @@ extern const Shtable_t		*sh_locate(const char*, const Shtable_t*, int);
 extern int			sh_lookopt(const char*, int*);
 extern Dt_t			*sh_inittree(const struct shtable2*);
 
-#endif /* SH_TABLE_H */
+#endif /* _SHTABLE_H */

--- a/src/cmd/ksh93/sh.1
+++ b/src/cmd/ksh93/sh.1
@@ -2144,7 +2144,8 @@ The first (default: \f3!\fP) signals the start of a history expansion.
 The second (default: \f3^\fP) is used for short-form substitutions.
 The third (default: \f3#\fP), when found as the first character of a word,
 causes history expansion to be skipped for the rest of the words on the line.
-Multi-byte characters (e.g. UTF-8) are not supported and produce undefined results.
+Multi-byte characters (e.g. UTF-8) are not supported and produce
+undefined results.
 .TP
 .B
 .SM HISTCMD
@@ -2437,7 +2438,8 @@ The number of CPU seconds spent in user mode.
 The number of CPU seconds spent in system mode.
 .TP
 .B %[\fIp\fP][l]C
-The total number of CPU seconds, i.e. the sum of the time spent in user and system mode.
+The total number of CPU seconds, i.e. the sum of the time spent in
+user and system mode.
 .TP
 .B %P
 The CPU percentage, computed as C / R.
@@ -3134,7 +3136,8 @@ Expands to the character control-\f2x\fP.
 Same as \eC. Deprecated.
 .TP
 .BI \ex hh
-Expands to the single-byte character indicated by up to two hexadecimal digits \f2h\fP.
+Expands to the single-byte character indicated by up to two
+hexadecimal digits \f2h\fP.
 Differently from C strings, no more than two hexadecimal digits are processed.
 The string of digits \f2h\fP may be enclosed in \f3[\fPsquare brackets\f3]\fP;
 this can resolve ambiguities with subsequent text.
@@ -4794,8 +4797,10 @@ Normally, this means that a command line with an erroneous history expansion
 is lost and needs to be retyped from scratch,
 but if the \f3histreedit\fP shell option is turned on
 and a line editor is active (see \f2In-line Editing Options\fP below),
-the erroneous line is pre-filled into the next prompt's input buffer for correcting.
-The \f3histverify\fP option causes the same to be done for the results of successful
+the erroneous line is pre-filled into the next prompt's input buffer
+for correcting.
+The \f3histverify\fP option causes the same to be done for the results
+of successful
 history expansions, allowing verification and editing before execution.
 .PP
 A history expansion may have an \f2event specification\fP, which indicates
@@ -4843,12 +4848,14 @@ output by the \f3hist -l\fP command:
 The commands are shown with their event numbers.
 The current event, which we haven't typed in yet, is event 13.
 \f3!11\fP and \f3!\-2\fP refer to event 11.
-\f3!!\fP refers to the previous event, 12.  \f3!!\fP can be abbreviated \f3!\fP if it is
+\f3!!\fP refers to the previous event, 12.  \f3!!\fP can be
+abbreviated \f3!\fP if it is
 followed by \f3:\fP (see below).
 \f3!n\fP refers to event 9, which begins with \f3n\fP.
 \f3!?old?\fP also refers to event 12, which contains \f3old\fP.
-Without word designators or modifiers, history references simply expand to the
-entire event, so we might type \f3!cp\fP to redo the copy command or \f3!!|more\fP
+Without word designators or modifiers, history references simply
+expand to the entire event, so we might type \f3!cp\fP to redo the
+copy command or \f3!!|more\fP
 if the \f3diff\fP output scrolled off the top of the screen.
 .PP
 To select words from an event,
@@ -4902,8 +4909,8 @@ arguments from the \f3cp\fP command.  If we didn't care about the order of the
 \f3diff\fP, we might have said \f3diff !\-2:1\-2\fP or simply \f3diff !\-2:*\fP.
 The \f3cp\fP command might have been written \f3cp wumpus.man !#:1.old\fP,
 using \f3#\fP to refer to the current event.
-\f3!n:\- hurkle.man\fP would reuse the first two words from the \f3nroff\fP command
-to say \f3nroff \-man hurkle.man\fP.
+\f3!n:\- hurkle.man\fP would reuse the first two words from
+the \f3nroff\fP command to say \f3nroff \-man hurkle.man\fP.
 .PP
 The \f3:\fP separating the event specification from the word designator
 can be omitted if the argument selector begins with a
@@ -4911,7 +4918,8 @@ can be omitted if the argument selector begins with a
 For example, our \f3diff\fP command might have been \f3diff !!^.old !!^\fP
 or, equivalently, \f3diff !!$.old !!$\fP.
 However, if \f3!!\fP is abbreviated \f3!\fP,
-an argument selector beginning with \f3\-\fP will be interpreted as an event specification.
+an argument selector beginning with \f3\-\fP will be interpreted
+as an event specification.
 .PP
 The word(s) in a history reference can be edited
 by following them with one or more modifiers,
@@ -4946,7 +4954,8 @@ If \f2l\fP is empty,
 the \f2l\fP from the previous substitution is used,
 or if there is none,
 the \f2s\fP from the most recent \f3?\fP\f2s\fP\f3?\fP search.
-The trailing delimiter may be omitted if it is immediately followed by a newline.
+The trailing delimiter may be omitted if it is immediately followed
+by a newline.
 .TP 8
 .B &
 Repeat the previous substitution.
@@ -4981,8 +4990,10 @@ We might follow \f3mail \-s "I forgot my password" rot\fP
 with \f3!:s/rot/root\fP to correct the spelling of \f3root\fP.
 .PP
 History expansions also occur when an input line begins with \f3^\fP.
-When it is the first character on an input line, it is an abbreviation of \f3!:s^\fP.
-Thus we might have said \f3^rot^root\fP to make the spelling correction in the previous example.
+When it is the first character on an input line,
+it is an abbreviation of \f3!:s^\fP.
+Thus we might have said \f3^rot^root\fP to make the spelling correction
+in the previous example.
 This is the only history expansion that does not explicitly begin with \f3!\fP.
 .PP
 If a word on a command line begins with the history comment character \f3#\fP,
@@ -4990,7 +5001,8 @@ history expansion is ignored for the rest of that line.
 This usually causes the shell parser
 (which uses the same character to signal a comment)
 to treat the rest of the line as a comment as well,
-but as history expansion is parsed separately from the shell grammar and with different rules,
+but as history expansion is parsed separately from the shell grammar
+and with different rules,
 this cannot be guaranteed in all cases.
 If the history comment character is changed,
 the shell grammar comment character does not change along with it.
@@ -6410,9 +6422,11 @@ is given, the name
 and value of the alias is printed.
 The obsolete
 .B \-x
-option has no effect in most contexts, although if it's used with
+option has no effect in most contexts, but when it's used with
 .B \-t
-it will suppress all output.
+it will cause
+.B alias
+to do nothing.
 The exit status is non-zero if a
 .I name\^
 is given, but no value, and no alias has been defined for the

--- a/src/cmd/ksh93/sh/defs.c
+++ b/src/cmd/ksh93/sh/defs.c
@@ -24,6 +24,7 @@
 #include	"shopt.h"
 #include	"defs.h"
 #include	"jobs.h"
+#include	"shlex.h"
 
 Shell_t			sh = {0};
 

--- a/src/cmd/ksh93/sh/nvtype.c
+++ b/src/cmd/ksh93/sh/nvtype.c
@@ -115,7 +115,7 @@ typedef struct
 	char		*_dpointer;
 } _Align_;
 
-#define alignof(t)	((char*)&((_Align_*)0)->_d##t-(char*)&((_Align_*)0)->_c##t)
+#define alignof(t)	( offsetof(_Align_, _d##t) - offsetof(_Align_, _c##t) )
 
 static void put_type(Namval_t*, const char*, int, Namfun_t*);
 static Namval_t* create_type(Namval_t*, const char*, int, Namfun_t*);

--- a/src/cmd/ksh93/sh/nvtype.c
+++ b/src/cmd/ksh93/sh/nvtype.c
@@ -97,6 +97,8 @@ struct Namtype
 	unsigned short	nref;
 };
 
+#if !_std_align
+/* Pre-C11 fallback for alignof() */
 typedef struct
 {
 	char		_cSfdouble_t;
@@ -114,8 +116,8 @@ typedef struct
 	char		_cpointer;
 	char		*_dpointer;
 } _Align_;
-
 #define alignof(t)	((char*)&((_Align_*)0)->_d##t-(char*)&((_Align_*)0)->_c##t)
+#endif
 
 static void put_type(Namval_t*, const char*, int, Namfun_t*);
 static Namval_t* create_type(Namval_t*, const char*, int, Namfun_t*);
@@ -182,7 +184,11 @@ size_t nv_datasize(Namval_t *np, size_t *offset)
 		s = nv_size(np);
 	else
 	{
+#if !_std_align
 		a = alignof(pointer);
+#else
+		a = alignof(char*);
+#endif
 		s = nv_size(np);
 	}
 	if(a>1 && offset)

--- a/src/cmd/ksh93/sh/nvtype.c
+++ b/src/cmd/ksh93/sh/nvtype.c
@@ -97,8 +97,6 @@ struct Namtype
 	unsigned short	nref;
 };
 
-#if !_std_align
-/* Pre-C11 fallback for alignof() */
 typedef struct
 {
 	char		_cSfdouble_t;
@@ -116,8 +114,8 @@ typedef struct
 	char		_cpointer;
 	char		*_dpointer;
 } _Align_;
+
 #define alignof(t)	((char*)&((_Align_*)0)->_d##t-(char*)&((_Align_*)0)->_c##t)
-#endif
 
 static void put_type(Namval_t*, const char*, int, Namfun_t*);
 static Namval_t* create_type(Namval_t*, const char*, int, Namfun_t*);
@@ -184,11 +182,7 @@ size_t nv_datasize(Namval_t *np, size_t *offset)
 		s = nv_size(np);
 	else
 	{
-#if !_std_align
 		a = alignof(pointer);
-#else
-		a = alignof(char*);
-#endif
 		s = nv_size(np);
 	}
 	if(a>1 && offset)

--- a/src/lib/libast/features/align.c
+++ b/src/lib/libast/features/align.c
@@ -110,7 +110,7 @@ main(void)
 	printf("\n");
 	printf("#define ALIGN_CHUNK		%d\n", sizeof(char*) >= 4 ? 8192 : 1024);
 	printf("#define ALIGN_INTEGRAL		uintptr_t\n");
-	printf("#define ALIGN_INTEGER(x)	((char*)(x)-(char*)0)\n");
+	printf("#define ALIGN_INTEGER(x)	((intptr_t)(x))\n");
 	printf("#define ALIGN_POINTER(x)	((char*)(x))\n");
 	if (bits2 == (align2 - 1))
 		printf("#define ALIGN_ROUND(x,y)	ALIGN_POINTER(ALIGN_INTEGER((x)+(y)-1)&~((y)-1))\n");

--- a/src/lib/libast/features/common
+++ b/src/lib/libast/features/common
@@ -10,16 +10,6 @@ std	noreturn note{ noreturn ok }end compile{
 	int main(void) { foo(); }
 }end
 
-std	align note{ alignof ok }end compile{
-	#include <stdalign.h>
-	#include <stdio.h>
-	int main(void)
-	{
-		printf("Alignment of char = %zu\n", alignof(char));
-		return 0;
-	}
-}end
-
 cat{
 	#if __clang__
 	#pragma clang diagnostic ignored "-Wmissing-braces"
@@ -84,9 +74,6 @@ cat{
 	#else
 	#define noreturn /* empty */
 	#endif /* _std_noreturn */
-	#if _std_align
-	#include <stdalign.h>
-	#endif /* _std_align */
 }end
 
 if	tst - note{ <stdarg.h>+<wchar.h> works }end compile{

--- a/src/lib/libast/features/common
+++ b/src/lib/libast/features/common
@@ -10,18 +10,32 @@ std	noreturn note{ noreturn ok }end compile{
 	int main(void) { foo(); }
 }end
 
+std	align note{ alignof ok }end compile{
+	#include <stdalign.h>
+	#include <stdio.h>
+	int main(void)
+	{
+		printf("Alignment of char = %zu\n", alignof(char));
+		return 0;
+	}
+}end
+
 cat{
 	#if __clang__
 	#pragma clang diagnostic ignored "-Wmissing-braces"
 	#pragma clang diagnostic ignored "-Wparentheses"
 	#pragma clang diagnostic ignored "-Wstring-plus-int"
 	#pragma clang diagnostic ignored "-Wunused-value"
+	#pragma clang diagnostic ignored "-Wmissing-field-initializers"
+	#pragma clang diagnostic ignored "-Woverlength-strings"
 	#elif __GNUC__
 	#pragma GCC diagnostic ignored "-Wpragmas"
 	#pragma GCC diagnostic ignored "-Wmissing-braces"
 	#pragma GCC diagnostic ignored "-Wparentheses"
 	#pragma GCC diagnostic ignored "-Wunused-result"
 	#pragma GCC diagnostic ignored "-Wunused-value"
+	#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+	#pragma GCC diagnostic ignored "-Woverlength-strings"
 	#endif
 
 	/* AST backward compatibility macros */
@@ -70,6 +84,9 @@ cat{
 	#else
 	#define noreturn /* empty */
 	#endif /* _std_noreturn */
+	#if _std_align
+	#include <stdalign.h>
+	#endif /* _std_align */
 }end
 
 if	tst - note{ <stdarg.h>+<wchar.h> works }end compile{

--- a/src/lib/libast/features/signal.c
+++ b/src/lib/libast/features/signal.c
@@ -20,10 +20,12 @@
 #if __clang__
 #pragma clang diagnostic ignored "-Wparentheses"
 #pragma clang diagnostic ignored "-Wmissing-braces"
+#pragma clang diagnostic ignored "-Wmissing-field-initializers"
 #elif __GNUC__
 #pragma GCC diagnostic ignored "-Wpragmas"
 #pragma GCC diagnostic ignored "-Wparentheses"
 #pragma GCC diagnostic ignored "-Wmissing-braces"
+#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
 #endif
 /*
  * Glenn Fowler

--- a/src/lib/libast/features/standards
+++ b/src/lib/libast/features/standards
@@ -109,6 +109,7 @@ elif tst note{ SunOS (Solaris, illumos) }end compile{
 		#define _XPG4
 		#define _XPG3
 		#define __EXTENSIONS__	1
+		#undef _XOPEN_SOURCE
 		#define	_XOPEN_SOURCE	9900
 		#undef _POSIX_C_SOURCE
 		#include <limits.h>
@@ -136,6 +137,7 @@ elif tst note{ SunOS (Solaris, illumos) }end compile{
 		#define _XPG4
 		#define _XPG3
 		#define __EXTENSIONS__	1
+		#undef _XOPEN_SOURCE
 		#define	_XOPEN_SOURCE	9900
 		#undef _POSIX_C_SOURCE
 		/*

--- a/src/lib/libast/man/aso.3
+++ b/src/lib/libast/man/aso.3
@@ -109,18 +109,21 @@ int		asorelax(long);
 The functions on the type \f3uint32_t\fP will be fully described below.
 Other functions work similarly on their respective types.
 Some of the functions may be macros that call other functions.
-64 bit operations are provided if the compiler supports 64 bit integers and/or pointers.
+64 bit operations are provided if the compiler supports 64 bit integers
+and/or pointers.
 .Ss "TYPES"
 \f3uint8_t, uint16_t, uint32_t, uint64_t\fP
 
 These are \fIunsigned integer\fP types of different sizes in bits.
-For example, \f3uint32_t\fP represents the type of unsigned integer with 32 bits or 4 bytes.
+For example, \f3uint32_t\fP represents the type of unsigned integer
+with 32 bits or 4 bytes.
 .Ss "OPERATIONS"
 .Ss "  uint32_t asoget32(uint32_t* from);"
 This function returns the value \f3*from\fP.
 .Ss "  uint32_t asoinc32(uint32_t* dest);"
 .Ss "  uint32_t asodec32(uint32_t* dest);"
-These functions increment \f3*dest\fP by 1 and decrement \f3*dest\fP by 1 in an atomic step.
+These functions increment \f3*dest\fP by 1 and decrement \f3*dest\fP by 1
+in an atomic step.
 The return value is the old value in \f3*dest\fP.
 
 Consider an example where two concurrent threads/processes call \f3asoinc32()\fP
@@ -128,22 +131,25 @@ on the same \f3dest\fP with values, say \fIv1\fP and \fIv2\fP.
 The eventual value in \f3dest\fP
 will be as if \f3*dest += 2\fP was performed in a single-threaded execution.
 
-That should be contrasted with a situation where, instead of \f3asoinc32()\fP or \f3asodec32()\fP,
+That should be contrasted with a situation where, instead of \f3asoinc32()\fP
+or \f3asodec32()\fP,
 only normal increment (++) or decrement (--) were used.
 Then, the end result could be either \f3*dest += 1\fP or \f3*dest += 2\fP,
 depending on states of the hardware cache and process scheduling.
 .Ss "  uint32_t asocas32(uint32_t* dest, uint32_t tstval, uint32_t newval);"
 This function provides the atomic \fIcompare-and-swap\fP operation.
-If the current content of \f3dest\fP is equal to \f3tstval\fP then it will be set to \f3newval\fP.
-If multiple threads/processes are performing the same operations only one will succeed with a
-return value of \f3tstval\fP.
+If the current content of \f3dest\fP is equal to \f3tstval\fP then it will be
+set to \f3newval\fP.
+If multiple threads/processes are performing the same operations only one
+will succeed with a return value of \f3tstval\fP.
 The return value is the old value in \f3*dest\fP.
 .Ss "  void asorelax(long nsec)"
 This function causes the calling process or thread to briefly pause
 for \f3nsec\fP nanoseconds.
 It is useful to implement tight loops that occasionally yield control.
 .Ss "  int asolock(unsigned int* lock, unsigned int key, int type)"
-This function uses \f3key\fP, a non-zero unsigned integer, to lock or unlock the \f3lock\fP.
+This function uses \f3key\fP, a non-zero unsigned integer, to lock or
+unlock the \f3lock\fP.
 It returns \f30\fP on success and \f3-1\fP on failure.
 The argument \f3type\fP can take one of the following values:
 .Tp
@@ -157,16 +163,19 @@ An error will result if the lock is already locked with a different key.
 .Tp
 \f3ASO_LOCK\fP:
 This is a regular locking call. If the lock is locked with a different key,
-this call will wait until the lock is open, then lock it with the given \f3key\fP.
+this call will wait until the lock is open, then lock it with
+the given \f3key\fP.
 .Tp
 \f3ASO_SPINLOCK\fP:
 Regardless of what key is currently locking the lock,
-this call will always wait until the lock is open, then lock it with the given \f3key\fP.
+this call will always wait until the lock is open, then lock it with
+the given \f3key\fP.
 Note that, if the lock is already locked with \f3key\fP, this call can result
 in a deadlock unless that lock can be opened by some other mechanism, e.g.,
 by a different process or thread.
 .Ss "  int asoloop(uintmax_t iteration);"
-This function is used to implement spin locks that periodically relinquish the processor:
+This function is used to implement spin locks that periodically relinquish
+the processor:
 .Cs
 uintmax_t iteration;
 iteration = 0;
@@ -176,9 +185,11 @@ for (;;) {
         /* an error occurred */;
 }
 .Ce
-The value of \f3iteration\fP should be \f31\fP (\fInot\fP \f30\fP) for the first loop iteration.
+The value of \f3iteration\fP should be \f31\fP (\fInot\fP \f30\fP) for the
+first loop iteration.
 \f30\fP is returned on success, \f3-1\fP on failure.
-If \f3iteration mod 4\fP is \f30\fP then \f3asorelax(1)\fP is called to temporarily relinquish
+If \f3iteration mod 4\fP is \f30\fP then \f3asorelax(1)\fP is called to
+temporarily relinquish
 the processor.
 If \f3Asodisc_t.hung != 0\fP and \f3Asodisc_t.errorf != 0\fP and
 \f3iteration mod (2**Asodisc_t.hung-1)\fP is \f30\fP,
@@ -186,98 +197,129 @@ then \f3Asodisc_t.errorf\fP is called with type \f3ASO_HUNG\fP
 and \f3-1\fP is returned.
 .Ss "DISCIPLINE"
 The Asodisc_t discipline structure allows the caller to modify default behavior.
-The \fIASO\fP discipline is global for all threads and forked children of the current process.
-The discipline is set and modified by the \f3asoinit()\fP function, described below.
+The \fIASO\fP discipline is global for all threads and forked children of the
+current process.
+The discipline is set and modified by the \f3asoinit()\fP function, described
+below.
 The structure members are:
 .Tp
 \f3uint32_t version;\fP
-This must be set to \f3ASO_VERSION\fP by the caller and is used by the implementation to detect
+This must be set to \f3ASO_VERSION\fP by the caller and is used by the
+implementation to detect
 release differences between the caller and the implementation.
-The version is integer of the form \fIYYYYMMDD\fP where \fIYYYY\fP is the release year, \fIMM\fP
+The version is integer of the form \fIYYYYMMDD\fP where \fIYYYY\fP is the
+release year, \fIMM\fP
 is the release month, and \fIDD\fP is the release day of month.
-This allows the implementation to be forwards and backwards binary compatible with all releases.
+This allows the implementation to be forwards and backwards binary compatible
+with all releases.
 .Tp
 \f3unsigned int hung;\fP
-An error occurs if \f3asoloop\fP() is called \f32**Asometh_t.hung\fP times without gaining access to the loop resource.
+An error occurs if \f3asoloop\fP() is called \f32**Asometh_t.hung\fP times
+without gaining access to the loop resource.
 The default value \f30\fP disables the test.
 .Tp
 \f3Asoerror_f errorf;\fP
 \f3int (*errorf)(int type, const char* mesg);\fP
-If \f3errorf\fP != \f30\fP then it is called for each \fIASO\fP fatal library condition.
-\f3type\fP may be one of: \f3ASO_METHOD\fP - a method error; \f3ASO_HUNG\fP - \f3asoloop\fP() was called
+If \f3errorf\fP != \f30\fP then it is called for each \fIASO\fP fatal
+library condition.
+\f3type\fP may be one of: \f3ASO_METHOD\fP - a method error;
+\f3ASO_HUNG\fP - \f3asoloop\fP() was called
 \f32**Asometh_t.hung\fP times with no access to the loop resource.
 \f3mesg\fP is a 0-terminated message description.
 .Ss "  void ASODISC(Asodisc_t* disc, Asoerror_f errorf);"
-This function-like-macro initializes \f3disc->version = ASO_VERSION\fP, \f3disc->errorf = errorf\fP,
+This function-like-macro initializes
+\f3disc->version = ASO_VERSION\fP, \f3disc->errorf = errorf\fP,
 and the remaining \f3disc\fP members to \f30\fP.
 .Ss "METHODS"
 Several atomic locking methods are implemented for atomic operations
 not supported by \fIintrinsic\fP functions or assembly instructions.
 Methods are controlled by the \f3asometh()\fP and \f3asoinit()\fP
 functions, described below.
-The \fIASO\fP method is global for all threads and forked children of the current process.
+The \fIASO\fP method is global for all threads and forked children of
+the current process.
 A given method may have multiple types.
 The methods types are:
 .Tp
 \f3ASO_INTRINSIC\fP:
-Some hardware platforms provide machine instructions to implement these operations directly.
-In that case, if a local compiler permits, calls to these \fIintrinsic\fP functions
+Some hardware platforms provide machine instructions to implement
+these operations directly.
+In that case, if a local compiler permits, calls to these
+\fIintrinsic\fP functions
 may be translated directly into their corresponding machine instructions.
-When necessary the implementation can use only the intrinsic \fIcompare-and-swap\fP
+When necessary the implementation can use only the
+intrinsic \fIcompare-and-swap\fP
 function on the largest integer type to emulate all other \fIASO\fP operations.
-The \f3ASO_INTRINSIC\fP method type is the default when supported by the compiler.
+The \f3ASO_INTRINSIC\fP method type is the default when supported
+by the compiler.
 It may be used for single-process single-thread, multi-thread, and
 multi-process applications.
-When supported by the hardware / compiler, the library provides the "\fBintrinsic\fP" method with type
+When supported by the hardware / compiler, the library provides the
+"\fBintrinsic\fP" method with type
 \f3ASO_INTRINSIC|ASO_PROCESS|ASO_THREAD|ASO_SIGNAL\fP.
 .Tp
 \f3ASO_SIGNAL\fP:
-This method type is suitable only for single-process single-thread applications.
+This method type is suitable only for single-process
+single-thread applications.
 It can be used to provide locking between asynchronous \fBsignal\fP(2) handlers
 and the main program.
 The library provides the "\fBsignal\fP" method with type \f3ASO_SIGNAL\fP.
 This is the default method type when \f3ASO_INTRINSIC\fP is not supported.
 .Tp
 \f3ASO_THREAD\fP:
-This method type is suitable for single-process single-thread, and multi-thread applications.
-It typically requires thread library support, and since the default \f3aso\fP library
-is not linked with a thread library, no \f3ASO_THREAD\fP method is provided by default.
-Threaded applications must link with \fB-ltaso\fP (before \fB-laso\fP or \fB-last\fP)
+This method type is suitable for single-process single-thread, and
+multi-thread applications.
+It typically requires thread library support, and since the default
+\f3aso\fP library is not linked with a thread library, no \f3ASO_THREAD\fP
+method is provided by default.
+Threaded applications must link with
+\fB-ltaso\fP (before \fB-laso\fP or \fB-last\fP)
 in order to access \f3ASO_THREAD\fP methods.
-The \fB-ltaso\fP library provides the "\fBspin\fP" (using \fBpthread_spin_lock\fP(3)) and
-"\fBmutex"\fP (using \fBpthread_mutex_lock\fP(3)) methods with type \f3ASO_THREAD|ASO_SIGNAL\fP.
+The \fB-ltaso\fP library provides the "\fBspin\fP" (using
+\fBpthread_spin_lock\fP(3)) and
+"\fBmutex"\fP (using \fBpthread_mutex_lock\fP(3)) methods with
+type \f3ASO_THREAD|ASO_SIGNAL\fP.
 .Tp
 \f3ASO_PROCESS\fP:
-This method type is suitable for single-process single-thread, and multi-process applications.
-Some \f3ASO_PROCESS\fP methods may also be suitable for multi-thread applications (if they have the \f3ASO_THREAD\fP type).
-These methods are typically and noticeably \fIslow\fP, up to 2 orders of magnitude slower than
+This method type is suitable for single-process single-thread,
+and multi-process applications.
+Some \f3ASO_PROCESS\fP methods may also be suitable for multi-thread
+applications (if they have the \f3ASO_THREAD\fP type).
+These methods are typically and noticeably \fIslow\fP, up to 2 orders
+of magnitude slower than
 \f3ASO_INTRINSIC\fP for some applications.
 They are provided as a last resort when other methods are not available.
-The library provides the "\fBsemaphore\fP" method with type \f3ASO_PROCESS|ASO_THREAD|ASO_SIGNAL\fP
+The library provides the "\fBsemaphore\fP" method with
+type \f3ASO_PROCESS|ASO_THREAD|ASO_SIGNAL\fP
 and the "\fBfcntl\fP" method with type \f3ASO_PROCESS|ASO_SIGNAL\fP.
 
 .Ss "  Asometh_t* asometh(int type, void* data);"
 This function looks up methods by type or name.
-If type is \f30\fP and \f3data\fP is \f30\fP then the current method is returned; a valid method
+If type is \f30\fP and \f3data\fP is \f30\fP then the current
+method is returned; a valid method
 will always be returned for this call.
-If type is \f30\fP then \f3data\fP is treated as a \f30\fP-terminated string method name;
+If type is \f30\fP then \f3data\fP is treated as a \f30\fP-terminated
+string method name;
 \f30\fP is returned if no matching method is found.
-The pseudo-type \f3ASO_NEXT\fP generates the list of all methods in successive calls:
+The pseudo-type \f3ASO_NEXT\fP generates the list of all methods
+in successive calls:
 .Cs
 Asometh_t* meth;
 meth = 0;
 while (meth = asometh(ASO_NEXT, meth))
 	/* examine meth->... */
 .Ce
-Otherwise if \f3type\fP is not \f30\fP and not \f3ASO_NEXT\fP it is treated as a combination of the ordered types
+Otherwise if \f3type\fP is not \f30\fP and not \f3ASO_NEXT\fP it is
+treated as a combination of the ordered types
 \f3ASO_THREAD\fP, \f3ASO_SIGNAL\fP, \f3ASO_INTRINSIC\fP, \f3ASO_PROCESS\fP:
 the first method with \f3(meth->type & type) != 0\fP is returned;
 \f30\fP is returned if no matching method is found.
 
 Method names are treated as a name, optionally followed by a list of
-\fB,\fP\fIname\fP=\fIvalue\fP details, and optionally ending with \fB,\fP\fIpathname\fP.
+\fB,\fP\fIname\fP=\fIvalue\fP details, and optionally ending
+with \fB,\fP\fIpathname\fP.
 The \fBsemaphore\fP method uses \fBsize\fP=\fInumber\fP to specify
-the number of semaphores and hashes \fIpathname\fP to determine the semaphore IPC key.
+the number of semaphores and hashes \fIpathname\fP to determine
+the semaphore IPC key.
 The \fBfcntl\fP method uses \fBsize\fP=\fInumber\fP to specify
 the number of 1 byte file locks and uses \fIpathname\fP as the
 file to lock using \f3fcntl(F_SETLCK[W])\fP.
@@ -323,18 +365,21 @@ A multi-process application would check for \f3(ASO_INTRINSIC|ASO_PROCESS)\fP
 instead of \f3(ASO_INTRINSIC|ASO_THREAD)\fP.
 
 .SH IMPLEMENTATION NOTES
-Unlike other \fIAST\fP library discipline/method functions which can instantiate
-multiple discipline/method handles within a single process, the \fIASO\fP
-library allows only one discipline and method to be set at a time, with the additional
-restriction that it may only be set by the main and only thread of the calling process.
+Unlike other \fIAST\fP library discipline/method functions
+which can instantiate
+multiple discipline/method handles within a single process,
+the \fIASO\fP library allows only one discipline and method to be set at a
+time, with the additional restriction that it may only be set by the main
+and only thread of the calling process.
 For this reason there is no open/close interface with an instantiation handle;
 instead the global discipline/method is simply initialized by \f3asoinit()\fP.
 
-\f3ASO_THREAD\fP and \f3ASO_PROCESS\fP methods rely on the \f3Asometh_t.lockf()\fP
-being sufficiently "heavy" to flush the calling thread/process memory cache
-so the subsequent \fIASO\fP operation operates on the physical memory location
-instead of the cached location. There is currently no other portable mechanism
-that guarantees this other than the \f3ASO_INTRINSIC\fP method.
+\f3ASO_THREAD\fP and \f3ASO_PROCESS\fP methods rely on
+the \f3Asometh_t.lockf()\fP being sufficiently "heavy" to flush the calling
+thread/process memory cache so the subsequent \fIASO\fP operation operates on
+the physical memory location instead of the cached location. There is currently
+no other portable mechanism that guarantees this other than the
+\f3ASO_INTRINSIC\fP method.
 
 .SH AUTHOR
 Kiem-Phong Vo, Adam Edgar, and Glenn Fowler

--- a/src/lib/libast/man/cdt.3
+++ b/src/lib/libast/man/cdt.3
@@ -123,18 +123,21 @@ This is the type of a dictionary handle.
 It contains a field \f3Dt_t.user\fP of type \f3Dtuser_t*\fP (see below).
 .Ss "  Dtdisc_t"
 This defines the type of a discipline structure which define the lay-out of
-an object and functions to compare, hash, make, delete objects, etc. (see \f3dtdisc()\fP).
+an object and functions to compare, hash, make, delete objects,
+etc. (see \f3dtdisc()\fP).
 .Ss "  Dtmethod_t"
 This defines the type of a container method.
 .Ss "  Dtlink_t"
 This is the type of a dictionary object holder (see \f3dtdisc()\fP).
 .Ss "  Dtstat_t"
-This is the type of a structure to return dictionary statistics (see \f3dtstat()\fP).
+This is the type of a structure to return dictionary
+statistics (see \f3dtstat()\fP).
 .Ss "  Dtuser_t"
 This is the type of a structure pointed to by \f3Dt_t.user\fP.
 If a discipline function \f3memoryf()\fP was defined, this structure
 will reside in memory allocated via \f3memoryf\fP.
-Although the structure is intended to be used by an application outside of CDT operations,
+Although the structure is intended to be used by an application
+outside of CDT operations,
 the functions \f3dtuserlock()\fP and \f3dtuserdata()\fP
 are provided for certain common usages of the defined fields.
 It should be emphasized, however, that a particular application can choose
@@ -161,10 +164,12 @@ See also the events \f3DT_CLOSE\fP and \f3DT_ENDCLOSE\fP below.
 .Ss "  void dtclear(Dt_t* dt)"
 This deletes all objects in \f3dt\fP without closing \f3dt\fP.
 .Ss "  Dtdisc_t* dtdisc(Dt_t* dt, const Dtdisc_t* disc, int type)"
-If \f3disc\fP is \f3NULL\fP, \f3dtdisc()\fP returns the current discipline.
+If \f3disc\fP is \f3NULL\fP, \f3dtdisc()\fP returns the
+current discipline.
 Otherwise, it changes the discipline of \f3dt\fP to \f3disc\fP.
 Objects may be rehashed, reordered, or removed as appropriate.
-\f3type\fP can be any bit combination of \f3DT_SAMECMP\fP and \f3DT_SAMEHASH\fP.
+\f3type\fP can be any bit combination of \f3DT_SAMECMP\fP
+and \f3DT_SAMEHASH\fP.
 \f3DT_SAMECMP\fP means that objects will compare exactly the same as before
 thus obviating the need for reordering or removing new duplicates.
 \f3DT_SAMEHASH\fP means that hash values of objects remain the same
@@ -177,22 +182,29 @@ Otherwise, it changes the storage method of \f3dt\fP to \f3meth\fP.
 Objects may be rehashed, reordered, or removed as appropriate.
 \f3dtmethod()\fP returns the previous method or \f3NULL\fP on error.
 .Ss "  Dt_t* dtview(Dt_t* dt, Dt_t* view)"
-A viewpath allows a search or walk starting from a dictionary to continue to another.
-\f3dtview()\fP first terminates any current view from \f3dt\fP to another dictionary.
-Then, if \f3view\fP is \f3NULL\fP, \f3dtview\fP returns the terminated view dictionary.
-If \f3view\fP is not \f3NULL\fP, a viewpath from \f3dt\fP to \f3view\fP is established.
+A viewpath allows a search or walk starting from a dictionary
+to continue to another.
+\f3dtview()\fP first terminates any current view from \f3dt\fP
+to another dictionary.
+Then, if \f3view\fP is \f3NULL\fP, \f3dtview\fP returns
+the terminated view dictionary.
+If \f3view\fP is not \f3NULL\fP, a viewpath from \f3dt\fP
+to \f3view\fP is established.
 \f3dtview()\fP returns \f3dt\fP on success and \f3NULL\fP on error.
 .PP
-It is an error to have dictionaries on a viewpath with different storage methods.
+It is an error to have dictionaries on a viewpath with
+different storage methods.
 In addition, dictionaries on the same view path should
-treat objects in a consistent manner with respect to comparison or hashing.
+treat objects in a consistent manner with respect to
+comparison or hashing.
 If not, undefined behaviors may result.
 .Ss "  int dtcustomize(Dt_t* dt, int type, int action)"
 This customizes a storage method. The \f3type\fP argument
 is composed of bits indicating different types of customization.
 The \f3action\fP argument, if positive, turns on the desired customization;
 else, turning it off.
-The return value is a bit vector telling the customization types successfully performed.
+The return value is a bit vector telling the customization
+types successfully performed.
 
 Here are the types:
 .Tp
@@ -227,7 +239,8 @@ An error will result if the dictionary was already locked with a different key.
 \f3action > 0\fP:
 Attempt to lock \f3dt->user->lock\fP with \f3key\fP.
 If \f3dt->user.lock\fP is already locked with a different key,
-the call will block until \f3dt->user->lock\fP can be locked with the given \f3key\fP.
+the call will block until \f3dt->user->lock\fP can be locked
+with the given \f3key\fP.
 
 Note that obtaining or removing a lock with \f3dtuserlock()\fP
 is just a service provided to the
@@ -256,7 +269,8 @@ Objects are ordered by comparisons.
 Objects are unordered.
 \f3Dtset\fP keeps unique objects.
 \f3Dtbag\fP allows repeatable objects.
-The underlying data structure is a hash table with chaining to handle collisions.
+The underlying data structure is a hash table with chaining
+to handle collisions.
 .Ss "  Dtrhset"
 .Ss "  Dtrhbag"
 These methods are like \f3Dtset\fP and \f3Dtbag\fP but are based on
@@ -301,13 +315,16 @@ defined in the type \f3Dtdisc_t\fP:
     } Dtdisc_t;
 .Ce
 .Ss "  ssize_t key, size"
-Each object \f3obj\fP is identified by a key used for object comparison or hashing.
+Each object \f3obj\fP is identified by a key used for object
+comparison or hashing.
 \f3key\fP should be non-negative and defines an offset into \f3obj\fP.
 If \f3size\fP is negative, the key is a null-terminated
 string with starting address \f3*(void**)((char*)obj+key)\fP.
-If \f3size\fP is zero, the key is a null-terminated string with starting address
+If \f3size\fP is zero, the key is a null-terminated string
+with starting address
 \f3(void*)((char*)obj+key)\fP.
-Finally, if \f3size\fP is positive, the key is a byte array of length \f3size\fP
+Finally, if \f3size\fP is positive, the key is a byte array
+of length \f3size\fP
 starting at \f3(void*)((char*)obj+key)\fP.
 .Ss "  ssize_t link"
 Let \f3obj\fP be an object to be inserted into \f3dt\fP.
@@ -320,7 +337,8 @@ i.e., at address \f3(Dtlink_t*)((char*)obj+link)\fP.
 If \f3makef\fP is not \f3NULL\fP,
 \f3dtinsert()\fP, \f3dtinstall()\fP or \f3dtappend()\fP will call it
 to make a copy of \f3obj\fP suitable for insertion into \f3dt\fP.
-If \f3makef\fP is \f3NULL\fP, \f3obj\fP itself will be inserted into \f3dt\fP.
+If \f3makef\fP is \f3NULL\fP, \f3obj\fP itself will be inserted
+into \f3dt\fP.
 .Ss "  void (*freef)(Dt_t* dt, void* obj, Dtdisc_t* disc)"
 If not \f3NULL\fP,
 \f3freef\fP is used to destroy data associated with \f3obj\fP.
@@ -341,8 +359,10 @@ If \f3hashf\fP is \f3NULL\fP, an internal function is used to hash
 the key as defined by the \f3Dtdisc_t.size\fP field.
 .Ss "  void* (*memoryf)(Dt_t* dt, void* addr, size_t size, Dtdisc_t* disc)"
 If not \f3NULL\fP, \f3memoryf\fP is used to allocate and free memory.
-When \f3addr\fP is \f3NULL\fP, a memory segment of size \f3size\fP is requested.
-If \f3addr\fP is not \f3NULL\fP and \f3size\fP is zero, \f3addr\fP is to be freed.
+When \f3addr\fP is \f3NULL\fP, a memory segment of
+size \f3size\fP is requested.
+If \f3addr\fP is not \f3NULL\fP and \f3size\fP is zero,
+\f3addr\fP is to be freed.
 If \f3addr\fP is not \f3NULL\fP and \f3size\fP is positive,
 \f3addr\fP is to be resized to the given size.
 If \f3memoryf\fP is \f3NULL\fP, \fImalloc(3)\fP is used.
@@ -360,15 +380,16 @@ is significant as follows:
 
 On a negative return value, \f3dtopen()\fP will return failure.
 
-On a zero return value, \f3eventf()\fP may set \f3*(void**)data\fP to some non-\f3NULL\fP
-value to indicate that the dictionary structure itself should be allocated
-along with the \f3Dt_t.data\fP section.
+On a zero return value, \f3eventf()\fP may set \f3*(void**)data\fP
+to some non-\f3NULL\fP value to indicate that the dictionary structure
+itself should be allocated along with the \f3Dt_t.data\fP section.
 Otherwise, it will be allocated separately with \f3malloc(3)\fP.
 
 On a positive return value, the dictionary is being reconstructed
 based on the existing states of some previous dictionary.
 In this case, \f3eventf()\fP should set \f3*(void**)data\fP to point to
-the field \f3Dt_t.data\fP of the corresponding previous dictionary (see \f3DT_CLOSE\fP below).
+the field \f3Dt_t.data\fP of the corresponding previous
+dictionary (see \f3DT_CLOSE\fP below).
 If the handle of the previous dictionary was created as discussed above
 in the case of the zero return value, it will be exactly restored.
 Otherwise, a new handle will be allocated with \f3malloc()\fP.
@@ -391,43 +412,52 @@ and associated memory freed.
 On a positive return value, allocated objects and memory will be kept intact.
 This means that \f3dt->data\fP remains intact and can be reused in some future
 dictionary (see \f3DT_OPEN\fP above).
-Note, however, that \f3dt\fP itself would still be freed if it was allocated with \f3malloc(3)\fP.
+Note, however, that \f3dt\fP itself would still be freed if it was
+allocated with \f3malloc(3)\fP.
 .Tp
 \f3DT_ENDCLOSE\fP:
 This event is raised at the end of the process to close a dictionary.
 The return value of \f3eventf()\fP will be ignored.
 .Tp
 \f3DT_DISC\fP:
-This event indicates that the discipline of \f3dt\fP is being changed to a new one given in
-\f3(Dtdisc_t*)data\fP.
+This event indicates that the discipline of \f3dt\fP is being changed
+to a new one given in \f3(Dtdisc_t*)data\fP.
 .Tp
 \f3DT_METH\fP:
-This event indicates that the method of \f3dt\fP is being changed to a new one given in
-\f3(Dtmethod_t*)data\fP.
+This event indicates that the method of \f3dt\fP is being changed to
+a new one given in \f3(Dtmethod_t*)data\fP.
 .Tp
 \f3DT_HASHSIZE\fP:
-This event is raised by the methods \f3Dtset\fP, \f3Dtbag\fP, \f3Dtrhset\fP and \f3Dtrhbag\fP
-to ask an application to suggest a size (measured in objects) for the data structure in use.
-This is useful, for example, to set a initial size for a hash table to reduce collisions and rehashing.
-On each call, \f3*(ssize_t*)data\fP will initially have the current size
+This event is raised by the methods \f3Dtset\fP, \f3Dtbag\fP, \f3Dtrhset\fP
+and \f3Dtrhbag\fP to ask an application to suggest a size (measured in objects)
+for the data structure in use. This is useful, for example, to set a initial
+size for a hash table to reduce collisions and rehashing. On each
+call, \f3*(ssize_t*)data\fP will initially have the current size
 (which should be \f30\fP on the first call).
 
 The return value of the event handling function indicates actions to be taken.
 If non-positive, the method will proceed with its default actions.
-Otherwise, the application may set \f3*(ssize_t*)data\fP to suggest a table size.
-The actual table size will be based on the absolute value of \f3*(ssize_t*)data\fP
+Otherwise, the application may set \f3*(ssize_t*)data\fP to suggest
+a table size.
+The actual table size will be based on the absolute value of
+\f3*(ssize_t*)data\fP
 but may be modified to suit for the data structure in use.
-Further, if \f3*(ssize_t*)data\fP was negative, the size of the hash table will be fixed going forward.
+Further, if \f3*(ssize_t*)data\fP was negative, the size of the hash
+table will be fixed going forward.
 .Tp
 \f3DT_ERROR\fP:
 This event states an error that occurred during some operations, e.g.,
-\f3dtinsert()\fP or \f3dtinstall()\fP failing to create a new object due to a memory allocation error.
-The argument \f3(char*)data\fP is a null-terminated string describing the problem.
+\f3dtinsert()\fP or \f3dtinstall()\fP failing to create a new object due
+to a memory allocation error.
+The argument \f3(char*)data\fP is a null-terminated string describing
+the problem.
 .Tp
 \f3DT_ANNOUNCE\fP:
-The event will be a combination of this bit and a bit indicating a successful operation.
+The event will be a combination of this bit and a bit indicating
+a successful operation.
 For example, \f3DT_ANNOUNCE|DT_SEARCH\fP announces that \f3dtsearch()\fP
-found the object that was searched for.  The \f3data\fP argument points to the object itself.
+found the object that was searched for.  The \f3data\fP argument points
+to the object itself.
 
 The bits representing operations that can cause an announcement are:
 \f3DT_INSERT\fP,
@@ -448,9 +478,11 @@ The bits representing operations that can cause an announcement are:
 
 Note that a call to \f3dtinsert()\fP or \f3dtattach()\fP may return
 a successfully inserted new object or a found matching object.
-For \f3dtinsert()\fP, the former case will be announced as \f3DT_ANNOUNCE|DT_INSERT\fP while
+For \f3dtinsert()\fP, the former case will be announced as
+\f3DT_ANNOUNCE|DT_INSERT\fP while
 the latter as \f3DT_ANNOUNCE|DT_INSERT|DT_SEARCH\fP.
-For \f3dtattach()\fP, the events will be similarly announced as \f3DT_ANNOUNCE|DT_ATTACH\fP
+For \f3dtattach()\fP, the events will be similarly announced as
+\f3DT_ANNOUNCE|DT_ATTACH\fP
 and \f3DT_ANNOUNCE|DT_ATTACH|DT_SEARCH\fP.
 .Ss "#define DTOFFSET(struct_s,member)"
 This macro function computes the offset of \f3member\fP from the start
@@ -478,7 +510,8 @@ Otherwise, the return value is either the newly inserted object
 or the matching object as noted.
 .Ss "  void* dtdelete(Dt_t* dt, void* obj)"
 .Ss "  void* dtremove(Dt_t* dt, void* obj)"
-When \f3obj\fP is not \f3NULL\fP, \f3dtdelete()\fP removes some object \fImatching\fP \f3obj\fP
+When \f3obj\fP is not \f3NULL\fP, \f3dtdelete()\fP removes some
+object \fImatching\fP \f3obj\fP
 while \f3dtremove()\fP removes \f3obj\fP itself if it exists.
 When \f3obj\fP is \f3NULL\fP, if the method is \f3Dtstack\fP or \f3Dtqueue\fP
 then the stack top or queue head is respectively deleted.
@@ -493,8 +526,10 @@ This function is similar to \f3dtdelete()\fP but the object to be deleted
 from \f3dt\fP will not be freed (via the discipline \f3freef\fP function).
 .Ss "  void* dtsearch(Dt_t* dt, void* obj)"
 .Ss "  void* dtmatch(Dt_t* dt, void* key)"
-These functions find an object matching \f3obj\fP or \f3key\fP either from \f3dt\fP or
-from some dictionary accessible from \f3dt\fP via a viewpath (see \f3dtview()\fP).
+These functions find an object matching \f3obj\fP or \f3key\fP
+either from \f3dt\fP or
+from some dictionary accessible from \f3dt\fP via a viewpath (see
+\f3dtview()\fP).
 The return value is the matching object or \f3NULL\fP.
 .Ss "  void* dtfirst(Dt_t* dt)"
 .Ss "  void* dtnext(Dt_t* dt, void* obj)"
@@ -532,7 +567,8 @@ or
 .Ce
 
 The argument \f3obj\fP of \f3dtnext()\fP or \f3dtprev()\fP is treated specially
-for a method that allows multiple equal elements such as \f3Dtobag\fP or \f3Dtbag\fP.
+for a method that allows multiple equal elements such as \f3Dtobag\fP
+or \f3Dtbag\fP.
 If it is in the dictionary, then the returned object will be respectively
 immediately before or after it in the implicitly defined object ordering.
 If it is not in the dictionary but still matching a group of objects,
@@ -556,10 +592,11 @@ As such, it is possible to call \f3dtatleast()\fP or \f3dtatmost()\fP
 on an object not in the dictionary and still get a meaningful result.
 Storage methods other than \f3Dtoset\fP and \f3Dtobag\fP do not have
 an explicit ordering so \f3dtatmost()\fP
-and \f3dtatleast()\fP will return \f3NULL\fP when there are no matching objects.
+and \f3dtatleast()\fP will return \f3NULL\fP when there are no
+matching objects.
 .Ss "  dtwalk(Dt_t* dt, int (*userf)(Dt_t*, void*, void*), void* data)"
-This function calls \f3(*userf)(walk,obj,data)\fP on each object in \f3dt\fP and
-other dictionaries viewable from it.
+This function calls \f3(*userf)(walk,obj,data)\fP on each object
+in \f3dt\fP and other dictionaries viewable from it.
 \f3walk\fP is the dictionary containing \f3obj\fP.
 If \f3userf()\fP returns a \f3<0\fP value,
 \f3dtwalk()\fP terminates and returns the same value.
@@ -597,20 +634,24 @@ On success, a structure
 to be used in \f3dtstep()\fP for walking the path is returned.
 Otherwise, \f3NULL\fP is returned.
 
-If \f3obj\fP is \f3NULL\fP, the path starts at the same object returned by \f3dtfirst()\fP.
-If \f3obj\fP is not \f3NULL\fP, it must match some object in the dictionary \f3dt\fP
+If \f3obj\fP is \f3NULL\fP, the path starts at the same object
+returned by \f3dtfirst()\fP.
+If \f3obj\fP is not \f3NULL\fP, it must match some object in the
+dictionary \f3dt\fP
 and the path will start there. No matching object will result in error.
 .Ss "  void* dtstop(Dt_t* dt, void* path);"
 This function ends a path and releases all memory source associated with it.
 .Ss "  void* dtstep(Dt_t* dt, void* path);"
 This function returns the object at current position in the given \f3path\fP.
-Successive calls move forward one object at a time in the same order that \f3dtnext()\fP
-does in the example \f3for(;;)\fP loop above. If there is no more object in the path,
+Successive calls move forward one object at a time in the same order
+that \f3dtnext()\fP
+does in the example \f3for(;;)\fP loop above.
+If there is no more object in the path,
 \f3dtstep()\fP returns \f3NULL\fP.
 
 Below is a code fragment showing how to create and walk a path of objects.
-This object walking method is more restricted than the \f3dtfirst()/dtnext()\fP method
-since viewpathed dictionaries are ignored.
+This object walking method is more restricted than the
+\f3dtfirst()/dtnext()\fP method since viewpathed dictionaries are ignored.
 However, it allows multiple paths to be traversed concurrently in the
 most efficient manner possible as supported by the underlying data structures.
 .Cs
@@ -623,7 +664,8 @@ most efficient manner possible as supported by the underlying data structures.
 .Ce
 .Ss "  Dtlink_t* dtextract(Dt_t* dt)"
 .Ss "  Dtlink_t* dtrestore(Dt_t* dt, Dtlink_t* list)"
-\f3dtextract()\fP extracts the list of objects from \f3dt\fP and makes it appear empty.
+\f3dtextract()\fP extracts the list of objects from \f3dt\fP and
+makes it appear empty.
 \f3dtrestore()\fP repopulates \f3dt\fP with
 a list of objects previously obtained via \f3dtextract()\fP.
 It is important that the same discipline and method are in use at both
@@ -647,14 +689,17 @@ It returns the number of objects stored in \f3dt\fP.
 \f3Dtstat_t\fP contains the below fields:
 .Tp
 \f3int meth\fP:
-This returns the method used for the dictionary, e.g., \f3DT_SET\fP, \f3DT_OSET\fP, etc.
+This returns the method used for the dictionary, e.g., \f3DT_SET\fP,
+\f3DT_OSET\fP, etc.
 .Tp
 \f3ssize_t size\fP:
 This has the number of objects in the dictionary.
 .Tp
 \f3ssize_t mlev\fP:
-This returns the maximum number of levels in the data structure used for object storage, i.e.,
-the binary tree (e.g., \f3Dtoset\fP) or the recursive hash table based on a trie structure (e.g., \f3Dtrhset\fP).
+This returns the maximum number of levels in the data structure used
+for object storage, i.e.,
+the binary tree (e.g., \f3Dtoset\fP) or the recursive hash table based
+on a trie structure (e.g., \f3Dtrhset\fP).
 For a hash table with chaining (e.g., \f3Dtset\fP and \f3Dtbag\fP),
 it gives the length of the longest chain.
 .Tp
@@ -665,7 +710,8 @@ a level is defined as objects at that position in their chains.
 The reported levels is limited to less than \f3DT_MAXSIZE\fP.
 .Tp
 \f3ssize_t tsize[]\fP:
-For a recursive hash table using a trie structure (\f3Dtrehash\fP), this counts the number of
+For a recursive hash table using a trie structure (\f3Dtrehash\fP),
+this counts the number of
 sub-tables at each level. For example, \f3tsize[0]\fP should be 1
 only for this hash table type.
 The reported levels is limited to less than \f3DT_MAXSIZE\fP.
@@ -674,23 +720,28 @@ The reported levels is limited to less than \f3DT_MAXSIZE\fP.
 A summary message of some of the statistics.
 .Ss "HASH FUNCTIONS"
 .Ss "  unsigned int dtstrhash(unsigned int h, char* str, int n)"
-This function computes a new hash value from string \f3str\fP and seed value \f3h\fP.
+This function computes a new hash value from string \f3str\fP and
+seed value \f3h\fP.
 If \f3n\fP is positive, \f3str\fP is a byte array of length \f3n\fP;
 otherwise, \f3str\fP is a null-terminated string.
 .PP
 .SH CONCURRENCY PROGRAMMING NOTES
-Applications requiring concurrent accesses of a dictionary whether via separate threads
+Applications requiring concurrent accesses of a dictionary whether
+via separate threads
 or processes using shared memory should turn on shared mode for the dictionary.
 CDT uses locking and lockless data structures to
 provide safe concurrent accesses of objects.
-Much of this work is based on the atomic scalar operations available in \fIlibaso(3)\fP.
+Much of this work is based on the atomic scalar operations
+available in \fIlibaso(3)\fP.
 
 Even though CDT only considers objects
 via the attributes specified in a discipline structure,
-practical objects will often have many more attributes germane to the needs of an application.
+practical objects will often have many more attributes germane
+to the needs of an application.
 Thus, beyond safe concurrent dictionary operations, an application must also
 protect objects in concurrent computations outside of CDT.
-In particular, both \fIobject deletion\fP and \fIobject creation\fP should be handled with care.
+In particular, both \fIobject deletion\fP and \fIobject creation\fP
+should be handled with care.
 
 The deletion case is relatively simple.
 No object should be destroyed as long as there is a reference to it.
@@ -706,10 +757,11 @@ The simplest way to ensure this is to completely construct an object before
 before inserting it into a shared dictionary.
 However, an application using complex objects may try
 to avoid unnecessary construction work as follows.
-First, only a partial object with minimal information needed for dictionary operations
-is constructed.
-Then, either\f3dtinsert()\fP or \f3dtattach()\fP is called to insert this partial object
-into the dictionary. If the call returns this same object, then it was properly inserted and
+First, only a partial object with minimal information needed
+for dictionary operations is constructed.
+Then, either\f3dtinsert()\fP or \f3dtattach()\fP is called to insert
+this partial object into the dictionary.
+If the call returns this same object, then it was properly inserted and
 the rest of its attributes could then be filled in.
 If only a matching object is returned, then the new object is simply discarded.
 Although this object construction strategy works well in single-threaded code,
@@ -778,23 +830,27 @@ the relevant operations to wait until the object is \fIready\fP (i.e.,
 all of its attributes are constructed) before proceeding.
 The \f3asorelax(1)\fP call yields control of the processor for 1 nanosecond
 so other processes can do their work.
-Note that the test for \f3~(DT_ANNOUNCE|DT_INSERT|DT_ATTACH)\fP in \f3eventf()\fP
+Note that the test for \f3~(DT_ANNOUNCE|DT_INSERT|DT_ATTACH)\fP
+in \f3eventf()\fP
 means that the loop will execute for all CDT operations except for
 the \f3dtinsert()\fP or \f3dtattach()\fP call that actually inserts \f3obj\fP
 into the dictionary (more on this below).
 
-When the \f3while\fP loop finished, the construction of object \f3obj\fP is known
-to be completed. \f3eventf()\fP increases the reference count \f3obj->refn\fP by one
+When the \f3while\fP loop finished, the construction of
+object \f3obj\fP is known
+to be completed. \f3eventf()\fP increases the reference
+count \f3obj->refn\fP by one
 before the respective operation returns \f3obj\fP to the calling code.
 On the other hand, \f3freef()\fP waits for the reference
 count to reach zero before proceeding to destroy the object.
-Waiting for object readiness in \f3freef()\fP before object destruction is necessary
-to avoid any issues with deleting uninitialized data.
+Waiting for object readiness in \f3freef()\fP before object destruction
+is necessary to avoid any issues with deleting uninitialized data.
 Again, it should be emphasized that reference counting
 is needed only for a memory management model where objects can be freed
 regardless of whether or not there are any references to them.
 Applications that use some form of garbage collection in general or
-for dictionary objects may ignore doing reference counting as done in this example.
+for dictionary objects may ignore doing reference counting as done
+in this example.
 
 Next, consider a fragment of code to access
 objects concurrently from different threads or processes:
@@ -820,8 +876,10 @@ Then, \f3dtdelete()\fP is called to delete the object.
 A possible danger is that concurrent calls to \f3dtdelete()\fP
 may end up causing the same memory to be freed more than once.
 Fortunately, this cannot happen.
-CDT guarantees that, of all the concurrent calls to \f3dtdelete()\fP on \f3obj\fP,
-only one will get far enough to make the \f3freef()\fP call while others do nothing.
+CDT guarantees that, of all the concurrent calls to \f3dtdelete()\fP
+on \f3obj\fP,
+only one will get far enough to make the \f3freef()\fP call while
+others do nothing.
 
 Finally, consider a code fragment to construct and use the object \f3obj\fP:
 
@@ -844,22 +902,27 @@ Finally, consider a code fragment to construct and use the object \f3obj\fP:
 .Ce
 
 After the \f3dtinsert()\fP call returns,
-all other concurrent computations invoking dictionary operations to access \f3obj\fP
-will be blocked in the \f3eventf()\fP function until \f3obj->ready\fP is set to 1
-by the above \f3asocaschar()\fP call.
+all other concurrent computations invoking dictionary operations to
+access \f3obj\fP will be blocked in the \f3eventf()\fP function until
+\f3obj->ready\fP is set to 1 by the above \f3asocaschar()\fP call.
 As this is a concurrent computing application,
 the above code fragment itself can be
 executed in parallel with different but equivalent versions of \f3obj\fP.
-In that case, only one \f3dtinsert()\fP call will succeed in inserting a new object
-while the others will report a matching object, i.e., the one actually inserted.
+In that case, only one \f3dtinsert()\fP call will succeed in
+inserting a new object while the others will report a matching object,
+i.e., the one actually inserted.
 The announcement of the successful case is \f3DT_ANNOUNCE|DT_INSERT\fP
-while the announcement of the other cases is \f3DT_ANNOUNCE|DT_INSERT|DT_SEARCH\fP.
+while the announcement of the other cases is
+\f3DT_ANNOUNCE|DT_INSERT|DT_SEARCH\fP.
 The bit \f3DT_SEARCH\fP causes \f3eventf()\fP to
-to run the loop waiting for object completion. Thus, overall, except for the single case
-of a successful insertion of a new object, all other dictionary accesses that involve
+to run the loop waiting for object completion.
+Thus, overall, except for the single case
+of a successful insertion of a new object,
+all other dictionary accesses that involve
 this object will return only when the object is ready.
 
-Note that, for simplicity, the possibility of failure was ignored in the example.
+Note that, for simplicity,
+the possibility of failure was ignored in the example.
 In both successful outcomes of \f3dtinsert()\fP, the reference count of an
 appropriate object will be increased by one. Thus, care must be taken to
 reduce that reference count for the object after it is no longer needed.
@@ -870,7 +933,8 @@ that avoids an infinite loop waiting for the reference count to drop to zero.
 However, a discussion of that is beyond the scope of this document.
 .PP
 .SH IMPLEMENTATION NOTES
-\f3Dtlist\fP, \f3Dtstack\fP, \f3Dtdeque\fP and \f3Dtqueue\fP are based on doubly linked list.
+\f3Dtlist\fP, \f3Dtstack\fP, \f3Dtdeque\fP and \f3Dtqueue\fP are
+based on doubly linked list.
 \f3Dtoset\fP and \f3Dtobag\fP are based on top-down splay trees.
 \f3Dtset\fP and \f3Dtbag\fP are based on hash tables with collision chains.
 \f3Dtrhset\fP and \f3Dtrhbag\fP are based on a recursive hashing data structure

--- a/src/lib/libast/man/find.3
+++ b/src/lib/libast/man/find.3
@@ -86,4 +86,5 @@ tw(1),
 find(1),
 strmatch(3)
 .br
-James A. Woods, \fIFast Find Algorithm\fP, Usenix ;login:, February/March, 1983, p. 8
+James A. Woods,
+\fIFast Find Algorithm\fP, Usenix ;login:, February/March, 1983, p. 8

--- a/src/lib/libast/man/ftwalk.3
+++ b/src/lib/libast/man/ftwalk.3
@@ -151,7 +151,8 @@ descendants have been completely processed.
 .IP
 FTW_DC: A directory that causes cycles. This is a terminal object.
 .IP
-FTW_DNR: A directory that cannot be opened for reading. This is a terminal object.
+FTW_DNR: A directory that cannot be opened for reading.
+This is a terminal object.
 .IP
 FTW_F: An ordinary file.
 .IP
@@ -167,8 +168,9 @@ The \fIstatus\fR field of \fIstruct FTW\fR is used to communicate information
 between \fIftwalk\fR and \fIuserf\fR. On calls to \fIuserf\fR, it has one of
 two values:
 .IP
-FTW_NAME: The name of the object as defined in \fIftw->name\fR should be used for
-accessing its file information. This is because \fIchdir\fR(2) has been used
+FTW_NAME: The name of the object as defined in \fIftw->name\fR
+should be used for accessing its file information.
+This is because \fIchdir\fR(2) has been used
 to set the current directory to a suitable place (see FTW_CHDIR).
 .IP
 FTW_PATH: The argument \fIpath\fR of \fIuserf\fR should be used

--- a/src/lib/libast/man/ip6.3
+++ b/src/lib/libast/man/ip6.3
@@ -53,8 +53,8 @@ formats the IPv6 address
 .L addr
 with optional prefix bits
 .L bits
-(0 if not a prefix) into a thread-specific 0-terminated temporary buffer and returns a pointer
-to the formatted value.
+(0 if not a prefix) into a thread-specific 0-terminated temporary buffer
+and returns a pointer to the formatted value.
 
 .PP
 .L strtoip6()

--- a/src/lib/libast/man/sfio.3
+++ b/src/lib/libast/man/sfio.3
@@ -223,7 +223,7 @@ int        sfulen(Sfulong_t v);
 int        sfllen(Sflong_t v);
 int        sfdlen(Sfdouble_t v);
 ssize_t    sfpkrd(int fd, void* buf, size_t n,
-                  int rsc, long tm, int action);
+                  int rc, long tm, int action);
 .ft 1
 .fi
 .Ss "FULL STRUCTURE SFIO_T"
@@ -243,7 +243,7 @@ int        sfdcdos(Sfio_t* f);
 int        sfdcfilter(Sfio_t* f, const char* cmd);
 int        sfdcseekable(Sfio_t* f);
 int        sfdcslow(Sfio_t* f);
-int        sfdcsubstream(Sfio_t* f, Sfio_t* parent,
+Sfio_t*    sfdcsubstream(Sfio_t* f, Sfio_t* parent,
                          Sfoff_t offset, Sfoff_t extent);
 int        sfdctee(Sfio_t* f, Sfio_t* tee);
 int        sfdcunion(Sfio_t* f, Sfio_t** array, int n);
@@ -262,7 +262,8 @@ cc ... -lstdio-mt -lsfio-mt
 .SH DESCRIPTION
 .PP
 Sfio provides I/O functions to manage buffered streams.
-Each Sfio stream is a \fIfile stream\fP, representing a file (see \f3open(2)\fP),
+Each Sfio stream is a \fIfile stream\fP,
+representing a file (see \f3open(2)\fP),
 or a \fIstring stream\fP, representing a memory segment.
 Beyond the usual I/O operations on streams,
 Sfio provides I/O disciplines for extended data processing,
@@ -273,18 +274,21 @@ to define their own conversion patterns as well as redefine existing ones.
 .PP
 A discipline defines analogues of
 the system calls \f3read(2), write(2)\fP and \f3lseek(2)\fP.
-Such system calls or their discipline replacements are used to process stream data.
+Such system calls or their discipline replacements are used
+to process stream data.
 Henceforth, ``\fIsystem call\fP'' will refer to either a system call
 or its discipline replacement.
 .PP
-A system call is said to cause an exception if its return value is non-positive.
+A system call is said to cause an exception if its
+return value is non-positive.
 Unless overridden by exception handlers (see \f3sfdisc()\fP),
 an interrupted system call (\f3errno == EINTR\fP on UNIX systems)
 will be automatically reinvoked to continue the ongoing operation.
 .PP
-The buffer of a stream is typically a memory segment allocated via \f3malloc(3)\fP
-or supplied by the application.
-File streams may also use memory mapping (\f3mmap(2)\fP) if that is more efficient.
+The buffer of a stream is typically a memory segment allocated
+via \f3malloc(3)\fP or supplied by the application.
+File streams may also use memory mapping (\f3mmap(2)\fP) if that is
+more efficient.
 When memory mapping is used,
 the underlying file should not be truncated while the stream is active.
 Memory mapping can be turned off using \f3sfsetbuf()\fP.
@@ -303,7 +307,8 @@ This defines an integral type suitable to address
 the largest possible file extent.
 .Ss "  Sfulong_t, Sflong_t, Sfdouble_t"
 These are respectively the largest
-unsigned integer, signed integer, and floating point value types on the local platform.
+unsigned integer, signed integer,
+and floating point value types on the local platform.
 .Ss "  Sfio_t"
 This defines the type of a stream handle.
 .Ss "  Sfdisc_t"
@@ -339,9 +344,10 @@ Following are the flags:
 The stream is memory-based.
 .Tp
 \f3SFIO_READ\fP, \f3SFIO_WRITE\fP, \f3SFIO_APPENDWR\fP:
-Flags \f3SFIO_READ\fP and \f3SFIO_WRITE\fP indicate readability and writability.
-Flag \f3SFIO_APPENDWR\fP asserts that the stream is a file opened in append mode
-(see \f3open(2)\fP and \f3fcntl(2)\fP)
+Flags \f3SFIO_READ\fP and \f3SFIO_WRITE\fP indicate readability
+and writability.
+Flag \f3SFIO_APPENDWR\fP asserts that the stream is a file
+opened in append mode (see \f3open(2)\fP and \f3fcntl(2)\fP)
 so that data is always output at the end of file.
 On systems without direct support for append mode,
 Sfio uses \f3lseek(2)\fP or its discipline replacement
@@ -370,12 +376,14 @@ the physical file position is made equal to the logical stream position.
 If \f3SFIO_PUBLIC\fP is set, there are two cases.
 If the physical file position has changed from its last known position,
 the logical stream position is made equal to the new physical file position.
-Finally, if the physical file location remains the same as its last known position,
+Finally, if the physical file location remains the same as its
+last known position,
 the physical file position is made the same as the logical stream position.
 
 For an unseekable stream (e.g., pipes or terminal devices), if possible,
 \f3SFIO_SHARE\fP means that
-the block and record I/O operations (\f3sfread()\fP, \f3sfwrite()\fP, \f3sfmove()\fP,
+the block and record I/O operations (\f3sfread()\fP,
+\f3sfwrite()\fP, \f3sfmove()\fP,
 \f3sfgetr()\fP, \f3sfputr()\fP, \f3sfreserve()\fP, \f3sfscanf()\fP
 and \f3sfvprintf()\fP) will ensure:
 (1) after each writing operation, the stream is synchronized and
@@ -383,7 +391,8 @@ and \f3sfvprintf()\fP) will ensure:
 Note, however, that (2) is not always possible
 without proper OS facilities such as \f3recv(2)\fP or \f3streamio(4)\fP.
 
-A standard stream that is seekable will be initialized with \f3SFIO_SHARE|SFIO_PUBLIC\fP.
+A standard stream that is seekable will be initialized
+with \f3SFIO_SHARE|SFIO_PUBLIC\fP.
 .Tp
 \f3SFIO_MALLOC\fP:
 The stream buffer was obtained via \f3malloc(3)\fP
@@ -403,16 +412,19 @@ or before a system call \f3read(2)\fP or \f3write(2)\fP (see \f3sfdisc()\fP).
 \f3SFIO_WHOLE\fP:
 This flag guarantees that data written in any single \f3sfwrite()\fP or
 \f3sfputr()\fP call will always be output as a whole to the output device.
-This is useful in certain applications (e.g., networking) where a complex object
+This is useful in certain applications (e.g., networking) where
+a complex object
 must be output without being split in different system calls.
-Note that the respective stream still buffers data as much as the buffer can accommodate.
+Note that the respective stream still buffers data as much as the buffer
+can accommodate.
 .Tp
 \f3SFIO_IOINTR\fP:
 This flag indicates that I/O system calls should not be resumed
 after being interrupted by signals. It is useful for
 aborting I/O operations on such interruptions. Note, however,
 that certain operating systems (e.g., BSD Unix systems) may automatically
-resume interrupted system calls outside the scope of the library. On such systems,
+resume interrupted system calls outside the scope of the library.
+On such systems,
 \f3SFIO_IOINTR\fP will be ineffective.
 .Ss "OPENING/CLOSING STREAMS"
 .Ss "  Sfio_t* sfnew(Sfio_t* f, void* buf, size_t size, int fd, int flags)"
@@ -448,12 +460,14 @@ If \f3string\fP is \f3NULL\fP,
 \f3f\fP is a file stream and
 \f3mode\fP does not imply a string stream,
 \f3sfopen()\fP changes the modes of \f3f\fP according to \f3mode\fP.
-In this case, \f3sfopen()\fP returns \f3f\fP on success and \f3NULL\fP on error.
+In this case, \f3sfopen()\fP returns \f3f\fP on success
+and \f3NULL\fP on error.
 This somewhat unusual usage of \f3sfopen()\fP is good for
 resetting certain predefined modes in standard streams including
-\fItext/binary\fP and \fIappend\fP that are inherited from some parent process.
-Note also that \f3SFIO_READ\fP and \f3SFIO_WRITE\fP can only be reset if the stream
-is not yet initialized.
+\fItext/binary\fP and \fIappend\fP that are inherited from some
+parent process.
+Note also that \f3SFIO_READ\fP and \f3SFIO_WRITE\fP can only
+be reset if the stream is not yet initialized.
 
 \f3sfopen()\fP is normally used to create a new stream or renew a stream.
 In this case, it returns the new stream on success and \f3NULL\fP on error.
@@ -478,7 +492,8 @@ If \f3s\fP is not specified, \f3string\fP defines a file name.
 
 \f3r\fP and \f3w\fP specify read and write modes.
 Write mode creates and/or truncates the given file to make an empty file.
-The \f3+\fP modifier indicates that the stream is opened for both read and write.
+The \f3+\fP modifier indicates that the stream is opened for
+both read and write.
 
 \f3a\fP specifies append mode, i.e., data is always output at end of file.
 
@@ -489,16 +504,20 @@ a file opened for writing should not already exist.
 .Ss "  Sfio_t* sfpopen(Sfio_t* f, const char* cmd, const char* mode)"
 This function opens a stream that corresponds to the coprocess \f3cmd\fP.
 The argument \f3mode\fP should be composed from \f3r\fP, \f3w\fP, and \f3+\fP.
-The argument \f3f\fP, if not \f3NULL\fP, is a stream to be renewed (see \f3sfnew()\fP).
+The argument \f3f\fP, if not \f3NULL\fP,
+is a stream to be renewed (see \f3sfnew()\fP).
 \f3sfpopen()\fP returns the new stream or \f3NULL\fP on error.
 
 The standard input/output of \f3cmd\fP
-is connected to the application via a pipe if the stream is opened for writing/reading.
+is connected to the application via a pipe if the stream is
+opened for writing/reading.
 If the stream is opened for both reading and writing,
-there will be two different associated file descriptors, one for each type of I/O
+there will be two different associated file descriptors,
+one for each type of I/O
 (note the effect on \f3sffileno()\fP).
 
-On opening a coprocess for writing (i.e., \f3mode\fP contains \f3w\fP or \f3+\fP),
+On opening a coprocess for writing (i.e., \f3mode\fP
+contains \f3w\fP or \f3+\fP),
 the signal handler for \f3SIGPIPE\fP in the parent application
 will be set to \f3SIG_IGN\fP if it is \f3SIG_DFL\fP at that time.
 This protects the parent application from being accidentally killed
@@ -509,10 +528,10 @@ disciplines and exception handlers (see \f3sfdisc()\fP).
 The command \f3cmd\fP
 is executed by an \fIinterpreter\fP which is either \f3/bin/sh\fP
 or an executable command defined by the environment variable \f3SHELL\fP.
-In either case, the interpreter is invoked with 2 arguments, respectively \f3-c\fP
-and the given command \f3cmd\fP. When the interpreter is \f3/bin/sh\fP or
-\f3/bin/ksh\fP, \f3sfpopen()\fP may execute the command \f3cmd\fP itself
-if there are no shell meta-characters in \f3cmd\fP.
+In either case, the interpreter is invoked with 2 arguments,
+respectively \f3-c\fP and the given command \f3cmd\fP. When the interpreter
+is \f3/bin/sh\fP or \f3/bin/ksh\fP, \f3sfpopen()\fP may execute the
+command \f3cmd\fP itself if there are no shell meta-characters in \f3cmd\fP.
 .Ss "  Sfio_t* sfstropen(void)"
 Shorthand that opens a new string buffer for reading and writing;
 same as \f3sfnew(NULL,NULL,-1,-1,SFIO_READ|SFIO_WRITE|SFIO_STRING)\fP.
@@ -522,11 +541,13 @@ See also
 This function creates a stream for temporary data.
 It returns the new stream or \f3NULL\fP on error.
 
-A stream created by \f3sftmp()\fP can be completely or partially memory-resident.
+A stream created by \f3sftmp()\fP can be completely or
+partially memory-resident.
 If \f3size\fP is \f3SFIO_UNBOUND\fP, the stream is a pure string stream.
 If \f3size\fP is zero, the stream is a pure file stream.
 Otherwise, the stream is first created as a string stream but when
-its buffer grows larger than \f3size\fP or on any attempt to change disciplines,
+its buffer grows larger than \f3size\fP or on any attempt to
+change disciplines,
 a temporary file is created.
 Two environment variables, \f3TMPPATH\fP and \f3TMPDIR\fP,
 direct where temporary files are created.
@@ -552,8 +573,8 @@ If \f3f\fP has disciplines,
 their exception handlers will be called twice.
 The first exception handler call has the \f3type\fP argument as one of
 \f3SFIO_CLOSING\fP or \f3SFIO_NEW\fP (see \f3sfdisc()\fP).
-The latter, \f3SFIO_NEW\fP is used when a stream is being closed via \f3sfnew()\fP
-so that it can be renewed.
+The latter, \f3SFIO_NEW\fP is used when a stream is being
+closed via \f3sfnew()\fP so that it can be renewed.
 The second call uses \f3type\fP as \f3SFIO_FINAL\fP
 and is done after all closing operations have succeeded but before
 the stream itself is deallocated.
@@ -577,7 +598,8 @@ This function attempts to write the byte \f3c\fP to \f3f\fP \f3n\fP times.
 It returns the number of bytes actually written or \f3-1\fP on failure.
 .Ss "  int sfungetc(Sfio_t* f, int c)"
 This function pushes the byte \f3c\fP back into \f3f\fP.
-If \f3c\fP matches the byte immediately before the current position in buffered data,
+If \f3c\fP matches the byte immediately before the current
+position in buffered data,
 the current position is simply backed up (note the effect on \f3sftell()\fP and
 \f3sfseek()\fP). There is no theoretical limit on the number of bytes that
 can be pushed back into a stream. Pushed back bytes not part of
@@ -621,12 +643,14 @@ This function reads a record of data ending in the record separator \f3rsc\fP.
 After \f3sfgetr()\fP returns, the length of the record even if it is incomplete
 can be retrieved with \f3sfvalue()\fP.
 \f3sfgetr()\fP returns the record on success and \f3NULL\fP on error.
-See also \f3sfmaxr()\fP for limiting the amount of data read to construct a record.
+See also \f3sfmaxr()\fP for limiting the amount of data
+read to construct a record.
 
 The \f3type\fP argument is composed of some subset of the below bit flags:
 .Tp
 \f3SFIO_STRING\fP:
-A null byte will replace the record separator to make the record into a C string.
+A null byte will replace the record separator
+to make the record into a C string.
 Otherwise, the record separator is left alone.
 .Tp
 \f3SFIO_LOCKR\fP:
@@ -639,7 +663,8 @@ This should be used only after a failed \f3sfgetr()\fP to retrieve
 the last incomplete record. In this case, \f3rsc\fP is ignored.
 .Ss "  ssize_t sfputr(Sfio_t* f, const char* s, int rsc)"
 This function writes the null-terminated string \f3s\fP to \f3f\fP.
-If \f3rsc\fP is non-negative, \f3(unsigned char)rsc\fP is output after the string.
+If \f3rsc\fP is non-negative, \f3(unsigned char)rsc\fP is
+output after the string.
 \f3sfputr()\fP returns the number of bytes written or \f3-1\fP on failure.
 .Ss "  Sfoff_t sfmove(Sfio_t* fr, Sfio_t* fw, Sfoff_t n, int rsc)"
 This function moves objects
@@ -699,7 +724,8 @@ Otherwise, the current position is the logical stream position.
 This function reserves a data block from the stream \f3f\fP.
 It returns the reserved data block on success and \f3NULL\fP on failure.
 
-If \f3f\fP is a \f3SFIO_READ\fP stream, the data block is a segment of input data.
+If \f3f\fP is a \f3SFIO_READ\fP stream,
+the data block is a segment of input data.
 If \f3f\fP is a \f3SFIO_WRITE\fP stream, the data block is a buffer
 suitable for writing output data.
 For consistency, if \f3f\fP is opened with \f3SFIO_READ|SFIO_WRITE\fP,
@@ -741,7 +767,8 @@ but does not consume it (as consistent with \f3n == 0\fP).
 If \f3type != 0\fP, no attempt will be made to read data into the buffer.
 For example, the call \f3sfreserve(f, 0, -1)\fP only returns the buffer status,
 i.e., size of existing buffered data and pointer to such data, if any.
-The call \f3sfreserve(f, 0, SFIO_LOCKR)\fP is similar but also locks the stream.
+The call \f3sfreserve(f, 0, SFIO_LOCKR)\fP is similar
+but also locks the stream.
 .Tp
 \f3n > 0\fP:
 \f3sfreserve()\fP will use attempt to get \fIat most\fP \f3n\fP bytes into
@@ -755,8 +782,9 @@ as follows:
 After a \f3sfreserve()\fP call with \f3type != SFIO_LOCKR\fP fails,
 there may be some left over data not accessible via conventional Sfio calls.
 Immediately after such a failed call,
-another call to \f3sfreserve\fP with \f3type == SFIO_LASTR\fP will return any left over
-data and also advance the stream I/O position by the amount of returned data.
+another call to \f3sfreserve\fP with \f3type == SFIO_LASTR\fP
+will return any left over data and also advance the stream I/O position
+by the amount of returned data.
 .Tp
 \f3type < 0\fP:
 If \f3n > 0\fP, the stream I/O position is advanced by \f3n\fP.
@@ -773,13 +801,15 @@ As appropriate to the stream type (\f3SFIO_READ\fP, \f3SFIO_WRITE\fP or both),
 \f3f\fP can be unlocked later
 with one of \f3sfread(f,rsrv,size)\fP or \f3sfwrite(f,rsrv,size)\fP
 where \f3rsrv\fP is the reserved data block and \f3size\fP is the amount of
-data to be consumed. For example, if \f3f\fP is a locked \f3SFIO_READ\fP stream,
+data to be consumed. For example, if \f3f\fP is a locked
+\f3SFIO_READ\fP stream,
 the call \f3sfread(f,rsrv,1)\fP will reopen the stream and simultaneously
 advance the stream I/O position by \f31\fP.
 Finally, a stream opened for both reading and writing
 can release the lock with either call (with associated operational semantics!)
 For example, the below code reads 10 bytes of data from a stream
-opened with both \f3SFIO_READ\fP and \f3SFIO_WRITE\fP, modifies the data in place,
+opened with both \f3SFIO_READ\fP and \f3SFIO_WRITE\fP,
+modifies the data in place,
 then rewrites the new data back to the stream:
 .nf
 .ft 5
@@ -796,7 +826,8 @@ Data printing and scanning are done via the
 \f3sfprintf()\fP and \f3sfscanf()\fP family of functions.
 These functions are similar to their
 ANSI C \f3fprintf()\fP and \f3fscanf()\fP counterparts.
-However, the Sfio versions have been extended for both portability and generality.
+However, the Sfio versions have been extended for both
+portability and generality.
 In particular, a notion of a formatting environment stack is introduced.
 Each formatting element on the stack
 defines a separate \fIformatting pair\fP of a format specification string,
@@ -804,7 +835,8 @@ defines a separate \fIformatting pair\fP of a format specification string,
 functions), and an argument list, \f3va_list args\fP (the third argument
 in functions \f3sfvprintf()\fP and \f3sfvscanf()\fP).
 A formatting environment element may also specify extension functions
-to obtain or assign arguments and to provide new semantics for pattern processing.
+to obtain or assign arguments and to provide new
+semantics for pattern processing.
 To simplify the description below, whenever we talk
 about an argument list, unless noted otherwise,
 it is understood that this means either the true
@@ -817,8 +849,8 @@ The pattern \f3%!\fP manipulates the formatting environment stack to
 (1) change the top environment to a new environment,
 (2) stack a new environment on top of the current top,
 or (3) pop the top environment.
-The bottom of the environment stack always contains a virtual environment with the
-original formatting pair and without any extension functions.
+The bottom of the environment stack always contains a virtual environment with
+the original formatting pair and without any extension functions.
 
 The top environment of a stack, say \f3fe\fP, is automatically popped whenever
 its format string is completely processed.
@@ -876,7 +908,8 @@ Its usage is discussed below.
 This is a function to process events as discussed earlier.
 .Tp
 \f3form\fP and \f3args\fP:
-This is the formatting pair of a specification string and corresponding argument list.
+This is the formatting pair of a specification string and
+corresponding argument list.
 When an environment \f3fe\fP is being inserted into the stack,
 if \f3fe->form\fP is \f3NULL\fP, the top environment is changed to \f3fe\fP
 and its associated extension functions
@@ -896,7 +929,8 @@ This is set to the pattern being processed or one of '.', 'I', '('.
 This is the size of the object being processed.
 .Tp
 \f3flags\fP:
-This is a collection of bits defining the formatting flags specified for the pattern.
+This is a collection of bits defining the formatting flags
+specified for the pattern.
 The bits are:
 
 \f3SFFMT_LEFT\fP: Flag \f3-\fP in \f3sfprintf()\fP.
@@ -923,7 +957,8 @@ The bits are:
 
 \f3SFFMT_CENTER\fP: flag \f3=\fP in \f3sfprintf()\fP and \f3sfscanf()\fP.
 
-\f3SFFMT_CHOP\fP: flag \f3-\fP in \fIprecis\fP in \f3sfprintf()\fP and \f3sfscanf()\fP.
+\f3SFFMT_CHOP\fP: flag \f3-\fP in \fIprecis\fP in \f3sfprintf()\fP
+and \f3sfscanf()\fP.
 
 \f3SFFMT_ALTER\fP: Flag \f3#\fP in \f3sfprintf()\fP and \f3sfscanf()\fP.
 
@@ -958,22 +993,27 @@ as soon as the pattern is recognized and before any scanning or formatting.
 On the other hand, when \f3pos$\fP is used in a format string,
 an argument may be used multiple times.
 In this case, all arguments shall be processed in order
-by calling \f3fe->extf\fP exactly once per argument before any pattern processing.
+by calling \f3fe->extf\fP exactly once per argument before
+any pattern processing.
 This case is signified by the flag \f3SFFMT_ARGPOS\fP in \f3fe->flags\fP.
 
 In addition to the predefined formatting patterns and other application-defined
 patterns, \f3fe->extf\fP may be called with \f3fe->fmt\fP being one
 of `\f3(\fP' (left parenthesis), `\f3.\fP' (dot), and `\f3I\fP'.
 
-The left parenthesis requests a string to be used as the \f3extfdata\fP string discussed below.
-In this case, upon returning, \f3fe->extf\fP should set the \f3fe->size\fP field
-to be the length of the string or a negative value to indicate a null-terminated string.
+The left parenthesis requests a string to be used as the \f3extfdata\fP string
+discussed below.
+In this case, upon returning, \f3fe->extf\fP should set
+the \f3fe->size\fP field
+to be the length of the string or a negative value to indicate a
+null-terminated string.
 
 The `\f3I\fP' requests an integer to define the object size.
 
 The dot requests an integer for width, precision, base, or a separator.
-In this case, the \f3fe->size\fP field will indicate how many dots have appeared
-in the pattern specification. Note that, if the actual conversion pattern is 'c' or 's',
+In this case, the \f3fe->size\fP field will indicate how
+many dots have appeared in the pattern specification.
+Note that, if the actual conversion pattern is 'c' or 's',
 the value \f3*form\fP will be one of these characters.
 .Tp
 \f3f\fP:
@@ -1018,10 +1058,12 @@ Likewise, for \f3sfscanf()\fP functions,
 an address to assign value should be obtained from the argument list.
 
 When \f3pos$\fP is present,
-if \f3fe->extf\fP changes \f3fe->fmt\fP, this pattern shall be used regardless of
-the pattern defined in the format string. On the other hand, if \f3fe->fmt\fP
-is unchanged by \f3fe->extf\fP, the pattern in the format string is used.
-In any case, the effective pattern should be one of the standardly defined pattern.
+if \f3fe->extf\fP changes \f3fe->fmt\fP, this pattern shall be
+used regardless of the pattern defined in the format string.
+On the other hand, if \f3fe->fmt\fP is unchanged by \f3fe->extf\fP,
+the pattern in the format string is used.
+In any case,
+the effective pattern should be one of the standardly defined pattern.
 Otherwise, it shall be treated as unmatched.
 .Tp
 \f3rv > 0:\fP
@@ -1032,11 +1074,13 @@ for scanning functions, if \f3fe->flags\fP does not contain
 the bit \f3SFFMT_SKIP\fP, the assignment count shall increase by 1.
 .Ss "void va_copy(va_list to, va_list fr)"
 This macro function portably copies the argument list \f3fr\fP to
-the argument list \f3to\fP. It should be used to set the field \f3Sffmt_t.args\fP.
+the argument list \f3to\fP.
+It should be used to set the field \f3Sffmt_t.args\fP.
 .Ss "long sffmtversion(Sffmt_t* fe, int type)"
 This macro function initializes
 the formatting environment \f3fe\fP with a version number if \f3type\fP is
-non-zero. Otherwise, it returns the current value of the version number of \f3fe\fP.
+non-zero.
+Otherwise, it returns the current value of the version number of \f3fe\fP.
 This is useful for applications to find out
 when the format of the structure \f3Sffmt_t\fP changes.
 Note that the version number corresponds to the Sfio version number
@@ -1053,7 +1097,8 @@ These functions format output data.
 \f3sfprintf()\fP and \f3sfvprintf()\fP write to output stream \f3f\fP.
 \f3sfsprintf()\fP and \f3sfvsprintf()\fP write to buffer \f3s\fP
 which is of size \f3n\fP.
-\f3sfprints()\fP and \f3sfvprints()\fP construct data in some Sfio-defined buffer.
+\f3sfprints()\fP and \f3sfvprints()\fP construct data in some
+Sfio-defined buffer.
 \f3sfaprints()\fP and \f3sfvaprints()\fP are similar to \f3sfprints()\fP
 and \f3sfvprints()\fP
 but they return a string constructed via \f3malloc()\fP in \f3*sp\fP
@@ -1069,7 +1114,8 @@ The length of string constructed by \f3sfprints()\fP, \f3sfsprintf()\fP, or
 The standard patterns are:
 \f3n, s, c, %, h, i, d, p, u, o, x, X, g, G, e, E, f\fP and \f3!\fP.
 Except for \f3!\fP (which is described under \f3%! and Sffmt_t\fP above),
-see the ANSI C specification of \f3fprintf(3)\fP for details on the other patterns.
+see the ANSI C specification of \f3fprintf(3)\fP for details on the
+other patterns.
 Let \f3z\fP be some pattern type. A formatting pattern is defined as below:
 .nf
 .ft 5
@@ -1080,16 +1126,18 @@ Let \f3z\fP be some pattern type. A formatting pattern is defined as below:
 \f3pos$\fP:
 A pattern can specify which argument in the argument list to use.
 This is done via \f3pos$\fP where \f3pos\fP is the argument position.
-Arguments are numbered so that the first argument after \f3format\fP is at position 1.
-If \f3pos\fP is not specified, the argument following the most recently used one
-will be used.
+Arguments are numbered so that the first argument after \f3format\fP
+is at position 1.
+If \f3pos\fP is not specified, the argument following the most
+recently used one will be used.
 The pattern \f3%!\fP (see \f3%! and Sffmt_t\fP above)
 cannot be used subsequent to a usage of \f3pos$\fP.
 Doing so may cause unexpected behaviors.
 .Tp
 \f3flag\fP:
 The flag characters are
-\f3h\fP, \f3hh\fP, \f3l\fP, \f3ll\fP, \f3L\fP, \f3I\fP, \f3j\fP, \f3t\fP, \f3z\fP,
+\f3h\fP, \f3hh\fP, \f3l\fP, \f3ll\fP, \f3L\fP, \f3I\fP,
+\f3j\fP, \f3t\fP, \f3z\fP,
 \f3\-\fP, \f3+\fP, \fIspace\fP, \f30\fP, \f3'\fP, \f3=\fP and \f3#\fP.
 
 Flag \f3I\fP defines the size or type of the object being formatted.
@@ -1104,7 +1152,8 @@ For conversion specifiers \f3s\fP and \f3c\fP, the flag is ignored.
 In the second case, a given decimal value would define a size while
 `*' would cause the size to be obtained from the argument list.
 Then, if the conversion specifier is \f3s\fP, this size defines the
-length of the string or strings being formatted (see the discussion of \f3base\fP below).
+length of the string or strings being
+formatted (see the discussion of \f3base\fP below).
 For integer and floating point patterns,
 the size is used to select a type from one of the below lists as
 indicated by the conversion specifier:
@@ -1116,7 +1165,8 @@ indicated by the conversion specifier:
 .ft 1
 .fi
 
-The selection algorithm always matches types from left to right in any given list.
+The selection algorithm always matches types from left to
+right in any given list.
 Although selection is generally based on sizes in bytes,
 for compatibility with Microsoft-C, the size 64
 is matched with an appropriate type with the same number of bits, if any.
@@ -1148,7 +1198,8 @@ select the types of input objects.
 For example, \f3%hd\fP indicates a \f3short int\fP,
 while \f3%ld\fP indicates a \f3long int\fP.
 
-Flag \f3hh\fP addresses the byte value types, i.e., \f3char\fP and \f3unsigned char\fP.
+Flag \f3hh\fP addresses the byte value types, i.e.,
+\f3char\fP and \f3unsigned char\fP.
 
 Flags \f3z\fP, \f3t\fP and \f3j\fP address respectively
 the types \f3size_t\fP, \f3ptrdiff_t\fP and \f3Sflong_t\fP.
@@ -1157,9 +1208,11 @@ Flags \f3ll\fP and \f3L\fP address respectively
 the largest integer and floating value types, i.e.,
 \f3Sfulong_t\fP, \f3Sflong_t\fP, and \f3Sfdouble_t\fP.
 
-Flag \f3-\fP left-justifies data within the field (otherwise, right-justification).
+Flag \f3-\fP left-justifies data within the
+field (otherwise, right-justification).
 
-Flag \f3+\fP means that a signed conversion will always begin with a plus or minus sign.
+Flag \f3+\fP means that a signed conversion will always
+begin with a plus or minus sign.
 
 Flag \fIspace\fP is ignored if \f3+\fP is specified; otherwise,
 it means that if the first character of a signed conversion
@@ -1217,16 +1270,18 @@ The digits to represent numbers are:
 .fi
 
 For \f3%s\fP and \f3%c\fP, \f3base\fP defines a separator.
-Then, for \f3%s\fP, the input argument is taken to be a NULL-terminated array of strings
+Then, for \f3%s\fP, the input argument is taken to be a
+NULL-terminated array of strings
 while, for \f3%c\fP, this is a null-terminated array of characters.
 The strings or characters will be formatted one of a time based
 on the usual width and precision rules.
 After each formatted string or character, except for the last one,
 the separator \f3base\fP is output if it is a non-zero.
 
-There are further restrictions on the syntax of \f3%s\fP and \f3%c\fP when
-a separator is defined.
-Below are the legitimate sequences for \f3%s\fP and \f3%c\fP after the second dot:
+There are further restrictions on the syntax of
+\f3%s\fP and \f3%c\fP when a separator is defined.
+Below are the legitimate sequences for \f3%s\fP and \f3%c\fP
+after the second dot:
 .nf
 \f3    s            c\fP
 \f3    *s           *c\fP
@@ -1269,7 +1324,8 @@ the number of items successfully scanned or \f3-1\fP on error.
 A white space character (blank, tab, or new-line) in \f3format\fP
 normally matches a maximal sequence of input white space characters.
 However, if the input stream is in \f3SFIO_LINE\fP mode (see \f3sfset()\fP),
-a new-line character only matches white spaces up to an input new-line character.
+a new-line character only matches white spaces up to
+an input new-line character.
 This is useful to avoid blocking when scanning typed inputs.
 .PP
 The standard scan patterns are:
@@ -1286,9 +1342,10 @@ Let \f3z\fP be some pattern type. A formatting pattern is specified as below:
 \f3pos$\fP:
 A pattern can specify which argument in the argument list to use.
 This is done via \f3pos$\fP where \f3pos\fP is the argument position.
-Arguments are numbered so that the first argument after \f3format\fP is at position 1.
-If \f3pos\fP is not specified, the argument following the most recently used one
-will be used.
+Arguments are numbered so that the first argument
+after \f3format\fP is at position 1.
+If \f3pos\fP is not specified,
+the argument following the most recently used one will be used.
 The pattern \f3%!\fP (see \f3%! and Sffmt_t\fP above)
 cannot be used subsequent to a usage of \f3pos$\fP.
 .Tp
@@ -1339,7 +1396,8 @@ In the second case, a given decimal value would define a size while
 `*' would cause the size to be obtained from the argument list.
 For string patterns such as \f3%s\fP or \f3%[\fP, this size defines the
 length of the buffer to store scanned data.
-Specifying a buffer size only limits the amount of data copied into the buffer.
+Specifying a buffer size only limits the
+amount of data copied into the buffer.
 Scanned data beyond the buffer limit will be discarded.
 For integer and floating point patterns,
 the size is used to select a type from one of the below lists as
@@ -1352,7 +1410,8 @@ indicated by the conversion specifier:
 .ft 1
 .fi
 
-The selection algorithm always matches types from left to right in any given list.
+The selection algorithm always matches types from left
+to right in any given list.
 Although selection is generally based on sizes in bytes,
 for compatibility with Microsoft-C, the size 64
 is matched with an appropriate type with the same number of bits, if any.
@@ -1390,7 +1449,8 @@ Except for octal, decimal and hexadecimal numbers with the usual formats,
 numbers in general bases are assumed to be of the form: \fIbase#value\fP
 where \fIbase\fP is a number in base 10 and \fIvalue\fP
 is a number in the given base.
-For example, \f32#1001\fP is the binary representation of the decimal value \f39\fP.
+For example, \f32#1001\fP is the binary representation
+of the decimal value \f39\fP.
 If \fIbase\fP is \f336\fP or less,
 the digits for \fIvalue\fP can be any combination of \f3[0-9], [a-z], [A-Z]\fP
 where upper and lower case digits are not distinguishable.
@@ -1411,7 +1471,8 @@ If a new buffer is successfully set and the old buffer has not been freed,
 After a \f3sfsetbuf()\fP call,
 \f3sfvalue()\fP returns the size of the returned buffer.
 
-Sfio attempts to read data in blocks likely to be serviced fast by the file system.
+Sfio attempts to read data in blocks likely to be serviced
+fast by the file system.
 This means block sizes being multiples of a suitable alignment value
 (e.g., 512, 1024 or 8192). By default, the alignment value
 is computed via some internal mechanism depending on the local platform but
@@ -1444,7 +1505,8 @@ In this case, no attempt will be made to synchronize the stream.
 This function synchronizes the logical and physical views of stream \f3f\fP.
 It returns a negative value for failure and \f30\fP for success.
 
-For a \f3SFIO_WRITE\fP stream, synchronization means to write out any buffered data.
+For a \f3SFIO_WRITE\fP stream,
+synchronization means to write out any buffered data.
 For a seekable \f3SFIO_READ\fP file stream,
 the physical file position is aligned with the logical stream position and,
 if \f3SFIO_SHARE\fP is on, buffered data is discarded.
@@ -1479,7 +1541,8 @@ of \f3flist\fP in the same relative order.
 \f3timeout\fP:
 This defines an elapse time in milliseconds
 to wait to see if any stream is ready for I/O.
-If \f3timeout\fP is negative, \f3sfpoll()\fP will block until some stream become ready.
+If \f3timeout\fP is negative,
+\f3sfpoll()\fP will block until some stream become ready.
 Note that \f3SFIO_STRING\fP and normal file streams never block
 and are always ready for I/O.
 If a stream with discipline is being polled and
@@ -1529,8 +1592,8 @@ the event \f3SFIO_PURGE\fP is raised.
 .PP
 A file stream uses the system calls \f3read(2)\fP, \f3write(2)\fP
 and \f3lseek(2)\fP to read, write and position in the underlying file.
-Disciplines enable application-defined I/O methods including exception handling and
-data pre/post-processing.
+Disciplines enable application-defined I/O methods
+including exception handling and data pre/post-processing.
 .Ss "  Sfdisc_t* sfdisc(Sfio_t* f, Sfdisc_t* disc)"
 Each stream has a discipline stack whose bottom is a virtual discipline
 representing the actual system calls.
@@ -1587,8 +1650,10 @@ functions \f3sfrd()\fP, \f3sfwr()\fP and \f3sfsk()\fP described below.
 .PP
 The exception function, \f3(*exceptf)()\fP announces exceptional events during
 I/O operations.
-It is called as \f3(*exceptf)(Sfio_t* f, int type, void* value, Sfdisc_t* disc)\fP.
-Unless noted otherwise, the return value of \f3(*exceptf)()\fP is used as follows:
+It is called
+as \f3(*exceptf)(Sfio_t* f, int type, void* value, Sfdisc_t* disc)\fP.
+Unless noted otherwise,
+the return value of \f3(*exceptf)()\fP is used as follows:
 .Tp
 \f3<0\fP:
 The on-going operation shall terminate.
@@ -1600,10 +1665,11 @@ For some events, e.g., \f3SFIO_DPOLL\fP, the return value may also have
 additional meanings.
 .Tp
 \f3=0\fP:
-The on-going operation performs default actions with respect to the raised event.
-For example, on a reading error or reaching end of file, the top stream of a stack
-will be popped and closed and the on-going operation continue with the new top
-stream.
+The on-going operation performs default actions with respect
+to the raised event.
+For example, on a reading error or reaching end of file,
+the top stream of a stack will be popped and closed and the on-going
+operation continue with the new top stream.
 .PP
 The argument \f3type\fP of \f3(*exceptf)()\fP
 identifies the particular exceptional event:
@@ -1634,7 +1700,8 @@ This event is raised when a seek operation fails.
 .Tp
 \f3SFIO_NEW\fP, \f3SFIO_CLOSING\fP, \f3SFIO_FINAL\fP:
 These events are raised during a stream closing.
-\f3SFIO_NEW\fP is raised for a stream about to be closed to be renewed (see \f3sfnew()\fP).
+\f3SFIO_NEW\fP is raised for a stream about to be closed
+to be renewed (see \f3sfnew()\fP).
 \f3SFIO_CLOSING\fP is raised for a stream about to be closed.
 \f3SFIO_FINAL\fP is raised after a stream has been closed and before
 its space is to be destroyed (see \f3sfclose()\fP).
@@ -1672,7 +1739,8 @@ I/O modes are ready.
 .Tp
 \f3SFIO_SYNC\fP, \f3SFIO_PURGE\fP:
 If \f3SFIO_IOCHECK\fP is set,
-these events are raised respectively for a \f3sfsync()\fP or \f3sfpurge()\fP call.
+these events are raised respectively for a \f3sfsync()\fP or
+\f3sfpurge()\fP call.
 In each case, the respective event is raised once before the appropriate
 operation (synchronization or purging) with \f3((int)value)\fP being \f31\fP
 and once after with \f3((int)value)\fP being \f30\fP.
@@ -1742,7 +1810,8 @@ specified flags.
 This function changes the file descriptor of \f3f\fP.
 Before a change is realized,
 \f3(*notify)(f,SFIO_SETFD,newfd)\fP (see \f3sfnotify()\fP) is called.
-\f3sfsetfd()\fP returns \f3-1\fP on failure and the new file descriptor on success.
+\f3sfsetfd()\fP returns \f3-1\fP on failure and the new
+file descriptor on success.
 .Tp
 \f3fd >= 0\fP:
 If the current file descriptor is non-negative,
@@ -1755,7 +1824,8 @@ the stream will be reinitialized.
 The stream is synchronized (see \f3sfsync()\fP) and its
 file descriptor will be set to this value.
 Then, except for \f3sfclose()\fP, the stream will be inaccessible
-until a future \f3sfsetfd()\fP call resets the file descriptor to a non-negative value.
+until a future \f3sfsetfd()\fP call resets the file descriptor to
+a non-negative value.
 Thus, \f3sfsetfd(f,-1)\fP can be used to avoid closing the file descriptor
 of \f3f\fP when \f3f\fP is closed.
 .Ss "  Sfio_t* sfstack(Sfio_t* base, Sfio_t* top)"
@@ -1788,7 +1858,8 @@ and returning a pointer to the beginning of the string.
 .Ss "  Sfio_t* sfswap(Sfio_t* f1, Sfio_t* f2)"
 This function swaps contents of \f3f1\fP and \f3f2\fP.
 This fails if either stream is in a stream stack but not being a base stream.
-If \f3f2\fP is \f3NULL\fP, a new stream is constructed as a duplicate of \f3f1\fP.
+If \f3f2\fP is \f3NULL\fP, a new stream is constructed as a
+duplicate of \f3f1\fP.
 \f3sfswap()\fP returns \f3f2\fP or \f3f1\fP duplicate on success and
 \f3NULL\fP on failure.
 .Ss "STREAM INFORMATION"
@@ -1829,13 +1900,15 @@ out of some discipline I/O function to restore the internal stream states.
 .Ss "  int sfnotify((void(*)notify)(Sfio_t*, int, void*) )"
 This sets a function \f3(*notify)()\fP to be called
 as \f3(*notify)(f, type, data)\fP on various stream events.
-Arguments \f3type\fP and \f3data\fP indicate the reason for the call and accompanying data:
+Arguments \f3type\fP and \f3data\fP indicate the reason for the call
+and accompanying data:
 .Tp
 \f3SFIO_NEW\fP:
 \f3f\fP is being opened and \f3data\fP is the underlying file descriptor.
 .Tp
 \f3SFIO_CLOSING\fP:
-\f3f\fP is the stream being closed and \f3data\fP is the underlying file descriptor.
+\f3f\fP is the stream being closed and \f3data\fP is the underlying
+file descriptor.
 .Tp
 \f3SFIO_SETFD\fP:
 The file descriptor of \f3f\fP is being changed to the one
@@ -1850,13 +1923,16 @@ An attempt to change \f3f\fP to write mode failed.
 \f3data\fP is the file descriptor of the stream.
 .Ss "  int sfwalk(Sfwalk_f walkf, void* data, int type)"
 This function invokes \f3(*walkf)(f, data)\fP on every open stream \f3f\fP
-whose flags as defined by \f3sfset()\fP contains all bit flags given in \f3type\fP.
+whose flags as defined by \f3sfset()\fP contains all bit flags
+given in \f3type\fP.
 On such a call, if the return value is negative, \f3sfwalk()\fP will terminate.
 \f3sfwalk()\fP returns 0 if no stream was processed.
-Otherwise, it returns the return value from the last invocation of \f3walkf()\fP.
+Otherwise, it returns the return value from the last invocation
+of \f3walkf()\fP.
 
-As an example, the call \f3sfwalk(walkf, data, SFIO_READ)\fP will iterate over all streams
-opened for reading. Similarly, \f3sfwalk(walkf, data, SFIO_READ|SFIO_WRITE)\fP
+As an example, the call \f3sfwalk(walkf, data, SFIO_READ)\fP will
+iterate over all streams opened for reading.
+Similarly, \f3sfwalk(walkf, data, SFIO_READ|SFIO_WRITE)\fP
 iterates over all streams opened for both reading and writing.
 Lastly, \f3sfwalk(walkf, data, 0)\fP iterates over all streams.
 .Ss "MISCELLANEOUS FUNCTIONS"
@@ -1864,7 +1940,8 @@ Lastly, \f3sfwalk(walkf, data, 0)\fP iterates over all streams.
 Certain records may require too much memory for storage, thus, causing
 undesirable side effects. Therefore, the library normally bounds the amount
 of memory used by \f3sfgetr()\fP. A different memory bound
-can be set via \f3sfmaxr()\fP. While a positive \f3maxr\fP hints to \f3sfgetr()\fP
+can be set via \f3sfmaxr()\fP. While a positive \f3maxr\fP
+hints to \f3sfgetr()\fP
 to use only about that much memory to construct a record, a non-positive bound
 allows \f3sfgetr()\fP to use as much memory as necessary.
 \f3sfmaxr()\fP sets the value only if \f3set\fP is non-zero.
@@ -1876,19 +1953,21 @@ by \f3sfsprintf()\fP or \f3sfprints()\fP.  See also \f3sfvalue()\fP.
 .Ss "  int sfllen(Sflong_t v)"
 .Ss "  int sfdlen(Sfdouble_t v)"
 These functions return respectively the number of bytes required to code the
-\f3Sfulong_t\fP, \f3Sflong_t\fP or \f3Sfdouble_t\fP value \f3v\fP by \f3sfputu()\fP,
+\f3Sfulong_t\fP, \f3Sflong_t\fP or \f3Sfdouble_t\fP value \f3v\fP
+by \f3sfputu()\fP,
 \f3sfputl()\fP or \f3sfputd()\fP.
-.Ss "  ssize_t sfpkrd(int fd, char* buf, size_t n, int rsc, long tm, int action)"
+.Ss "  ssize_t sfpkrd(int fd, char* buf, size_t n, int rc, long tm, int action)"
 This function acts directly on the file descriptor \f3fd\fP.
 It does a combination of peeking on incoming data and a time-out read.
 Upon success, it returns the number of bytes received.
-A return value of \f30\fP means that the end-of-file condition has been detected.
+A return value of \f30\fP means that the end-of-file condition has
+been detected.
 A negative value represents an error.
 .Tp
 \f3buf\fP, \f3n\fP:
 These define a buffer and its size to read data into.
 .Tp
-\f3rsc\fP:
+\f3rc\fP:
 If \f3>=0\fP, this defines a record separator.
 If the last returned byte is not the record separator, then
 the read data did not contain a complete record. Otherwise,
@@ -1896,23 +1975,27 @@ it contains one or more records.
 See also \f3action\fP below.
 .Tp
 \f3tm\fP:
-If \f3>=0\fP, this defines a time interval in milliseconds to wait for incoming data.
+If \f3>=0\fP,
+this defines a time interval in milliseconds to wait for incoming data.
 .Tp
 \f3action\fP:
 If \f3action > 0\fP, \f3sfpkrd()\fP will peek on incoming data but
-will not read past it. Therefore, a future \f3sfpkrd()\fP or \f3read(2)\fP will see
+will not read past it. Therefore, a future \f3sfpkrd()\fP
+or \f3read(2)\fP will see
 the same data again.
 If \f3action <= 0\fP, \f3sfpkrd()\fP will not peek and there are two cases.
-If \f3rsc < 0\fP, an attempt is made to read \f3n\fP bytes.
-If \f3rsc >= 0\fP, an attempt is made to read one record.
+If \f3rc < 0\fP, an attempt is made to read \f3n\fP bytes.
+If \f3rc >= 0\fP, an attempt is made to read one record.
 .Ss "FULL STRUCTURE SFIO_T"
 .Ss "  #include <sfio_t.h>"
 Most applications based on Sfio only need to include
 the header file \f3sfio.h\fP which defines an abbreviated \f3Sfio_t\fP
 structure without certain fields private to Sfio.
 However, there are times (e.g., debugging)
-when an application may require more details about the full \f3Sfio_t\fP structure.
-In such cases, the header file \f3sfio_t.h\fP can be used in place of \f3sfio.h\fP.
+when an application may require more details about the
+full \f3Sfio_t\fP structure.
+In such cases, the header file \f3sfio_t.h\fP can be used in
+place of \f3sfio.h\fP.
 Note that an application doing this will become sensitive to changes
 in the internal architecture of Sfio.
 .Ss "  #define SFNEW(buf,size,file,flags,disc)"
@@ -1951,7 +2034,7 @@ This creates a discipline that makes an unseekable reading stream seekable.
 .Ss "int sfdcslow(Sfio_t* f)"
 This creates a discipline that makes all Sfio operations return immediately
 on interrupts. This is useful for dealing with slow devices.
-.Ss "int sfdcsubstream(Sfio_t* f, Sfio_t* parent, Sfoff_t offset, Sfoff_t extent)"
+.Ss "Sfio_t *sfdcsubstream(Sfio_t* f, Sfio_t* parent, Sfoff_t offset, Sfoff_t extent)"
 This creates a discipline that makes \f3f\fP acts as if it
 corresponds exactly to the subsection of \f3parent\fP
 starting at \f3offset\fP with size \f3extent\fP.
@@ -1978,12 +2061,14 @@ a set of macros or inlined functions to map Stdio calls to Sfio ones.
 This mapping may benignly extend or change the meaning of certain
 original Stdio operations. For example, Sfio's version of
 \f3popen()\fP allows a coprocess to be opened for both reading and writing
-unlike the original call which only allows a coprocess to be opened for a single mode.
+unlike the original call which only allows a coprocess to be
+opened for a single mode.
 Similarly, Sfio's \f3fopen()\fP call can be used to create
 string streams in addition to file streams.
 .PP
 The standard streams \f3stdin\fP, \f3stdout\fP and \f3stderr\fP
-are mapped via \f3#define\fP to \f3sfstdin\fP, \f3sfstdout\fP and \f3sfstderr\fP.
+are mapped via \f3#define\fP to \f3sfstdin\fP, \f3sfstdout\fP
+and \f3sfstderr\fP.
 The latter are typically declared of the type \f3Sfio_t*\fP.
 Certain older Stdio applications require these to be declared
 as addresses of structures so that static initializations of

--- a/src/lib/libast/man/tm.3
+++ b/src/lib/libast/man/tm.3
@@ -721,7 +721,8 @@ ERA alternative for
 The ERA year.
 .TP
 .B 116-125
-Ordinal names: first, \fIno second!\fP, third, fourth, fifth, sixth, seventh, eighth, ninth, tenth.
+Ordinal names: first, \fIno second!\fP, third, fourth, fifth, sixth, seventh,
+eighth, ninth, tenth.
 .TP
 .B 126-128
 Final time references, as in \fIthe last in the list\fP: final, ending, nth.

--- a/src/lib/libast/tm/tminit.c
+++ b/src/lib/libast/tm/tminit.c
@@ -444,6 +444,8 @@ tminit(Tm_zone_t* zp, time_t now, const char newzone)
 {
 	static uint32_t		serial = ~(uint32_t)0;
 
+	if(tz_abbr)
+		free(tz_abbr);
 	tz_abbr = 0;
 	if (serial != ast.env_serial)
 	{


### PR DESCRIPTION
- align.c: Remove null pointer arithmetic.
- man pages: Fix mandoc warnings pertaining to lines exceeding 80 bytes.
  - Note that in the man pages, the use of the word [trie](https://en.wikipedia.org/wiki/Trie) is **not** a typo.
- Increase the `SEARCHSIZE` and `LOOKAHEAD` definitions from 80 to 500. (vide https://github.com/ksh93/ksh/issues/460#issuecomment-1340169469)
- `tminit()`: Fixed a small memory leak ASan was complaining about.
- Fixed a compiler error that broke `SHOPT_KIA` by including shlex.h in defs.c (cherrypicked from thickfold-size_t).
- Added pragmas to ignore some superfluous compiler warnings (cherrypicked from thickfold-size_t).
- Added undefs to fix compiler warnings on illumos (cherrypicked from thickfold-size_t).
- ~Fixed undefined behavior in nvtype by using the standard implementation of `alignof` provided by stdalign.h~ Reverted because the fix for that causes a crash in types.sh.