### PR TITLE
Fix bug causing kitty protocol escape sequences to break multiline

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,8 +4,9 @@ Uppercase BUG_* IDs are shell bug IDs as used by the Modernish shell library.
 
 2025-05-31:
 
-- Fixed a bug that caused multiline to break when PS* prompts use the
-  kitty protocol (e.g. $'\E[4:5m' for formatting spaced dots).
+- Fixed a bug that caused the multiline option to break when PS*
+  prompts use the kitty terminal's escape sequence (e.g. $'\E[4:5m'
+  in the PS1 prompt for formatting spaced dots).
 
 2025-05-30:
 

--- a/NEWS
+++ b/NEWS
@@ -2,12 +2,17 @@ This documents significant changes in the dev branch of ksh 93u+m.
 For full details, see the git log at: https://github.com/ksh93/ksh
 Uppercase BUG_* IDs are shell bug IDs as used by the Modernish shell library.
 
-2025-07-30:
+2025-05-31:
+
+- Fixed a bug that caused multiline to break when PS* prompts use the
+  kitty protocol (e.g. $'\E[4:5m' for formatting spaced dots).
+
+2025-05-30:
 
 - The editor typeahead buffer and the limit for the ${.sh.edchar} variable
   (used with the KEYBD trap) has been increased from 80 to 500 bytes.
 
-2025-07-29:
+2025-05-29:
 
 - Fixed a serious but rarely occurring regression that corrupts variable
   names in assignments. It could be triggered in large scripts and cause a

--- a/NEWS
+++ b/NEWS
@@ -5,7 +5,7 @@ Uppercase BUG_* IDs are shell bug IDs as used by the Modernish shell library.
 2025-05-31:
 
 - Fixed a bug that caused the multiline option to break when PS*
-  prompts use the kitty terminal's escape sequence (e.g. $'\E[4:5m'
+  prompts use the kitty terminal's escape sequence (e.g. $'\E[4:4m'
   in the PS1 prompt for formatting spaced dots).
 
 2025-05-30:

--- a/src/cmd/ksh93/edit/edit.c
+++ b/src/cmd/ksh93/edit/edit.c
@@ -420,7 +420,7 @@ void	ed_setup(Edit_t *ep, int fd, int reedit)
 						skip = 0;
 						continue;
 					}
-					if(n==3 && (c=='?' || c=='!'))
+					if(n==3 && (c=='?' || c=='!' || c==':'))
 						continue;
 					else if(n>1 && c==';')
 						skip = 1;

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -18,7 +18,7 @@
 #include <ast_release.h>
 #include "git.h"
 
-#define SH_RELEASE_DATE	"2025-05-30"	/* must be in this format for $((.sh.version)) */
+#define SH_RELEASE_DATE	"2025-05-31"	/* must be in this format for $((.sh.version)) */
 /*
  * This comment keeps SH_RELEASE_DATE a few lines away from SH_RELEASE_SVER to avoid
  * merge conflicts when cherry-picking dev branch commits onto a release branch.


### PR DESCRIPTION
Reproducer (must be run in kitty or another terminal with support for kitty's escape sequences):
```
$ PS1=$'\E[4:4m→\E[0m '
→ <Enter a command prompt spanning multiple lines>
→ <Home> + <End>
```

The bottom line shifts over two characters more than it ought. This is because the ':' in the escape sequence causes ksh to calculate the wrong length for the sequence.

- Continue calculating the length of the escape sequence after encountering a ':' in the sequence.

vide https://sw.kovidgoyal.net/kitty/underlines/