### PR TITLE
Fix window resize bug after exiting to ksh from vim (re: f1c8ecc)

### DIFF
--- a/src/cmd/ksh93/edit/edit.c
+++ b/src/cmd/ksh93/edit/edit.c
@@ -246,7 +246,9 @@ int tty_raw(int fd, int echomode)
  */
 int ed_window(void)
 {
-	int	cols = sh.columns - 1;
+	int	cols;
+	sh_winsize();
+	cols = sh.columns - 1;
 	if(cols < MINWINDOW)
 		cols = MINWINDOW;
 	else if(cols > MAXWINDOW)
@@ -624,6 +626,7 @@ int ed_read(void *context, int fd, char *buff, int size, int reedit)
 				flush_notifybuf();
 				goto skipwinch;
 			}
+			sh_winsize();
 			ed_putchar(ep,'\r');
 			/*
 			 * Try to move cursor to start of first line and pray it works... it's very


### PR DESCRIPTION
Reproducer (for a terminal with fullscreen support):
```sh
$ <F11>          # Maximize terminal to occupy entire screen while in ksh prompt
$ vim            # Open vim editor
: <F11>          # Unmaximize while in vim
: q!             # Quit vim
$ /b<Tab><Tab>   # Attempt to obtain completion list; triggers bug
$ kill -WINCH $$
$ /b<Tab><Tab>   # List works again after SIGWINCH
```

- Readd removed calls to `sh_winsize()` to fix the regression in the tab completion menu. The purpose of these is to obtain the correct window size in cases where ksh does not get sent SIGWINCH after the window size changes. Perhaps this is 'inefficient', but correct behavior is better (assuming such efficiency even matters that much in the editor modes).