### PR TITLE
bug-875: ${!foo*} again 

### DIFF
--- a/src/cmd/ksh93/sh/macro.c
+++ b/src/cmd/ksh93/sh/macro.c
@@ -1166,6 +1166,7 @@ static int varsub(Mac_t *mp)
 	char		*idx = 0;
 	int		var=1,addsub=0,oldpat=mp->pattern,idnum=0,flag=0,d;
 	Stk_t		*stkp = sh.stk;
+	char		have_dot=0; /* bug-875: Phi: */
 	mp->wasexpan = 1;
 retry1:
 	idbuff[0] = 0;
@@ -1292,7 +1293,11 @@ retry1:
 			do
 			{
 				if(LEN==1)
+				{ 
+				  if(c=='.')
+					have_dot=1;
 					sfputc(stkp,c);
+				}
 				else
 					sfwrite(stkp,fcseek(0)-LEN,LEN);
 			}
@@ -1609,7 +1614,8 @@ retry1:
 				dolg = -1;
 				nextname(mp,id,0);
 				/* Check if the prefix (id) itself exists. If so, start with that. */
-				if(nv_open(id,sh.var_tree,NV_NOREF|NV_NOADD|NV_VARNAME|NV_NOFAIL))
+				/* bug-875: Phi: Don't do that for namespaced var*/
+				if( !have_dot && nv_open(id,sh.var_tree,NV_NOREF|NV_NOADD|NV_VARNAME|NV_NOFAIL))
 					v = id;
 				else
 					v = nextname(mp,id,dolmax);

--- a/src/cmd/ksh93/tests/variables.sh
+++ b/src/cmd/ksh93/tests/variables.sh
@@ -1770,4 +1770,11 @@ got=$(./issue861.sh 2>&1)
 unset i
 
 # ======
+# https://github.com/ksh93/ksh/issues/861
+a=1 a.a=2 a.b=3 a.c=4 a.aa=5 a.ac=6
+got=$(echo ${!a.a*})
+exp="a.a a.aa a.ac"
+[[ $got == "$exp" ]] || err_exit "\${!a.*} not workig. expected '$exp' got '$got'"
+
+# ======
 exit $((Errors<125?Errors:125))


### PR DESCRIPTION
Fix regression introduced in Commit 4a8072e

src/cmd/ksh93/tests/variables.sh:
- In varsub(), add a local have_dot=0, during id scan record if we see a dot if so have_dot=1. During M_NAMESCAN loop avoid inserting the id itself if it have_dot.