### PR TITLE
Bug-877: Memory fault when attempting to run /dev/fd/1 as a script

### DIFF
--- a/src/cmd/ksh93/sh/init.c
+++ b/src/cmd/ksh93/sh/init.c
@@ -1341,9 +1341,11 @@ Shell_t *sh_init(int argc,char *argv[], Shinit_f userinit)
 	else
 		sh_offoption(SH_PRIVILEGED);
 	/* shname for $0 in profiles and . scripts */
+#if 0 /* bug-877: Phi: No need for this /dev/fd0 is like /dev/stdin */
 	if(sh_isdevfd(argv[1]))
 		sh.shname = sh_strdup(argv[0]);
 	else
+#endif
 		sh.shname = sh_strdup(sh.st.dolv[0]);
 	/*
 	 * return here for shell script execution

--- a/src/cmd/ksh93/sh/main.c
+++ b/src/cmd/ksh93/sh/main.c
@@ -219,7 +219,8 @@ noreturn void sh_main(int ac, char *av[], Shinit_f userinit)
 			{
 				char *sp;
 				/* open stream should have been passed into shell */
-				if(strmatch(name,e_devfdNN))
+                                /* bug-877: Phi: No need for this */
+				if( 0 && strmatch(name,e_devfdNN))
 				{
 					fdin = (int)strtol(name+8, NULL, 10);
 					if(fstat(fdin,&statb)<0)


### PR DESCRIPTION
ksh /dev/fd/1 do core dump while ksh /dev/stdout don't

Based on this I remove in the itnt() path useless code base on filename match /dev/fd/ as there is no reasons to make special case for this.

Note the ksh /dev/fd/0 or /dev/fd/5 do not core dump and so chasing a proper fix for the specific case of /dev/fd/1 may be another option, but I think the excess code removal could be better.