### PR TITLE
compond_variable assignment

### DIFF
--- a/src/cmd/ksh93/sh/name.c
+++ b/src/cmd/ksh93/sh/name.c
@@ -512,7 +512,7 @@ void nv_setlist(struct argnod *arg,int flags, Namval_t *typ)
 						if(!nv_isnull(np) && np->nvalue!=Empty && !nv_isvtree(np))
 							sub=1;
 					}
-					else if(((np->nvalue && np->nvalue!=Empty)||nv_isvtree(np)|| nv_arrayptr(np)) && !nv_type(np))
+					else if(((np->nvalue.cp && np->nvalue.cp!=Empty)) && !nv_type(np))
 					{
 						int was_assoc_array = ap && ap->fun;
 						nv_unset(np,NV_EXPORT);  /* this can free ap */


### PR DESCRIPTION
Adding fix on behalf on IBM AIX 
This is related assignment of compound_variables. 

Below is the example test case to assign compond_variable 
using set-x to display the values. 

```
set -x

complex=( real=1 img=2 )
+ complex.real=1
+ complex.img=2

complex=( real1=3 img1=4 )
+ complex.real1=3
+ complex.img1=4

RC=$?
+ RC=0

real=`echo "${complex.real}"`
+ echo ''
+ real=''   >> here the variable should be 1

img=`echo "${complex.img}"`
+ echo ''
+ img='' 	>> here the variable should be 2

real1=`echo "${complex.real1}"`
+ echo 3
+ real1=3

img1=`echo "${complex.img1}"`
+ echo 4
+ img1=4
```

The goal of the test was to ensure all parts of the complex compound variable were preserved after setting additional fields. The fix ensures that the variable isn't overwritten and that all expected values (1, 2, 3, 4) are correctly retained and verified.
 