### PR TITLE
Fixing Issue-915

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,9 @@ Uppercase BUG_* IDs are shell bug IDs as used by the Modernish shell library.
 
 2026-01-28:
 
+- Fixed a regression, introduced with the printf fixes on 2023-05-18, that
+  broke date specs relative to now, such as: printf '%T\n' 'in 10 weeks'
+
 - Fixed incorrect behaviour that occurred when IFS, PATH, SHELL,
   FPATH, CDPATH, SECONDS, ENV, LANG, LC_ALL, LC_CTYPE, LC_MESSAGES,
   LC_COLLATE, LC_NUMERIC, or LC_TIME were declared as a local

--- a/src/lib/libast/tm/tmxdate.c
+++ b/src/lib/libast/tm/tmxdate.c
@@ -1453,7 +1453,7 @@ tmxdate(const char* s, char** e, Time_t now)
 						case TM_PARTS+4:
 							tm = tmxtm(tm, tmxtime(tm, zone), tm->tm_zone, 0);
 							tm->tm_hour += m * 7 * 24;
-							set |= DAY;
+							set |= HOUR;
 							goto clear_hour;
 						case TM_PARTS+5:
 							tm->tm_mon += m;


### PR DESCRIPTION
commit 1a9d8ada introduced a bug
printf "%(%Y-%m-%d)T\n" "now in 10 week"
produce
2025-11-13
This fix produce the expecteed
2026-01-22

src/lib/libast/tm/tmxdate.c::1456
case TM_PARTS+4:
     tm = tmxtm(tm, tmxtime(tm, zone), tm->tm_zone, 0);
     tm->tm_hour += m * 7 * 24;
     set |= DAY; <======= TYPO HERE
goto clear_hour;

Since we are updating tm_hour then set HOUR