### PR TITLE
Add support for many math functions (primarily C23 additions)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,51 @@ This documents significant changes in the dev branch of ksh 93u+m.
 For full details, see the git log at: https://github.com/ksh93/ksh
 Uppercase BUG_* IDs are shell bug IDs as used by the Modernish shell library.
 
+2026-02-10:
+
+- Added support for the following math functions present in C23,
+  TS 18661-1:2014, TS 18661-3:2015, and glibc:
+  - acospi
+  - asinpi
+  - atan2pi
+  - atanpi
+  - compoundn
+  - cospi
+  - exp10m1
+  - exp2m1
+  - fadd
+  - fdiv
+  - ffma
+  - fmaximum
+  - fmaximum_mag
+  - fmaximum_mag_num
+  - fmaximum_num
+  - fmaxmag
+  - fminimum
+  - fminimum_mag
+  - fminimum_mag_num
+  - fminimum_num
+  - fminmag
+  - fmul
+  - fsqrt
+  - fsub
+  - iscanonical
+  - iseqsig
+  - issignaling
+  - log10p1
+  - log2p1
+  - logp1
+  - nextdown
+  - nextup
+  - pown
+  - powr
+  - rootn
+  - roundeven
+  - rsqrt
+  - scalbln
+  - sinpi
+  - tanpi
+
 2026-02-06:
 
 - Fixed a file descriptor leak introduced in 93u+ 2012-07-27 that occurred

--- a/src/cmd/ksh93/data/math.tab
+++ b/src/cmd/ksh93/data/math.tab
@@ -2,7 +2,7 @@
 #                                                                      #
 #               This software is part of the ast package               #
 #          Copyright (c) 1982-2013 AT&T Intellectual Property          #
-#          Copyright (c) 2020-2025 Contributors to ksh 93u+m           #
+#          Copyright (c) 2020-2026 Contributors to ksh 93u+m           #
 #                      and is licensed under the                       #
 #                 Eclipse Public License, Version 2.0                  #
 #                                                                      #
@@ -13,44 +13,71 @@
 #                  David Korn <dgk@research.att.com>                   #
 #                  Martijn Dekker <martijn@inlv.org>                   #
 #         hyenias <58673227+hyenias@users.noreply.github.com>          #
+#            Johnothan King <johnothanking@protonmail.com>             #
 #                                                                      #
 ########################################################################
 
 # <return type: i:integer f:floating-point> <#floating-point-args> <function-name> [<alias> ...]
 # <function-name>l variants are handled by features/math.sh
-# @(#)math.tab (ksh 93u+m) 2024-03-20
+# @(#)math.tab (ksh 93u+m) 2026-02-10
 f 1 acos
 f 1 acosh
+f 1 acospi
 f 1 asin
 f 1 asinh
+f 1 asinpi
 f 1 atan
 f 2 atan2
+f 2 atan2pi
 f 1 atanh
+f 1 atanpi
 f 1 cbrt
 f 1 ceil
+f 2 compoundn
 f 2 copysign
 f 1 cos
 f 1 cosh
+f 1 cospi
 f 1 erf
 f 1 erfc
 f 1 exp
 f 1 exp2
 f 1 exp10
 f 1 expm1
+f 1 exp2m1
+f 1 exp10m1
 f 1 fabs abs
+f 2 fadd
 f 2 fdim
+f 2 fdiv
+f 3 ffma
 i 1 finite
 f 1 float
 f 1 floor
 f 3 fma
 f 2 fmax
+f 2 fmaximum
+f 2 fmaximum_mag
+f 2 fmaximum_mag_num
+f 2 fmaximum_num
+f 2 fmaxmag
 f 2 fmin
+f 2 fminimum
+f 2 fminimum_mag
+f 2 fminimum_mag_num
+f 2 fminimum_num
+f 2 fminmag
 f 2 fmod
+f 2 fmul
 i 1 fpclassify
 i 1 fpclass
+f 2 fsqrt
+f 2 fsub
 f 2 hypot
 i 1 ilogb
 f 1 int
+i 1 iscanonical
+i 2 iseqsig
 i 1 isfinite
 i 2 isgreater
 i 2 isgreaterequal
@@ -61,6 +88,7 @@ i 2 islessequal
 i 2 islessgreater
 i 1 isnan
 i 1 isnormal
+i 1 issignaling
 i 1 issubnormal fpclassify=FP_SUBNORMAL
 i 2 isunordered
 i 1 iszero fpclassify=FP_ZERO fpclass=FP_NZERO|FP_PZERO {return a1==0.0||a1==-0.0;}
@@ -71,24 +99,37 @@ x 2 ldexp
 f 1 lgamma
 f 1 log
 f 1 log10
+f 1 log10p1
 f 1 log1p
 f 1 log2
+f 1 log2p1
 f 1 logb
+f 1 logp1
 f 1 nearbyint
 f 2 nextafter
+f 1 nextdown
 f 2 nexttoward
+f 1 nextup
 f 2 pow
+f 2 pown
+f 2 powr
 f 2 remainder
 f 1 rint
+f 2 rootn
 f 1 round {Sfdouble_t r;Sflong_t y;y=floor(2*a1);r=rint(a1);if(2*a1==y)r+=(r<a1)-(a1<0);return r;}
+f 1 roundeven
+f 1 rsqrt
 f 2 scalb
 f 2 scalbn
+f 2 scalbln
 i 1 signbit
 f 1 sin
 f 1 sinh
+f 1 sinpi
 f 1 sqrt
 f 1 tan
 f 1 tanh
+f 1 tanpi
 f 1 tgamma {Sfdouble_t r=exp(lgamma(a1));return (signgam<0)?-r:r;}
 f 1 trunc
 f 1 y0

--- a/src/cmd/ksh93/include/streval.h
+++ b/src/cmd/ksh93/include/streval.h
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1982-2012 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -84,7 +84,7 @@ struct lval
 
 struct mathtab
 {
-	char		fname[16];
+	char		fname[18];
 	Sfdouble_t	(*fnptr)(Sfdouble_t,...);
 };
 

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -18,7 +18,7 @@
 #include <ast_release.h>
 #include "git.h"
 
-#define SH_RELEASE_DATE	"2026-02-09"	/* must be in this format for $((.sh.version)) */
+#define SH_RELEASE_DATE	"2026-02-10"	/* must be in this format for $((.sh.version)) */
 /*
  * This comment keeps SH_RELEASE_DATE a few lines away from SH_RELEASE_SVER to avoid
  * merge conflicts when cherry-picking dev branch commits onto a release branch.

--- a/src/cmd/ksh93/sh.1
+++ b/src/cmd/ksh93/sh.1
@@ -3300,13 +3300,14 @@ without using the parameter expansion syntax.
 When a variable is referenced, its value is evaluated as
 an arithmetic expression.
 .PP
-Any of the following math library functions that are in the C math library
-can be used within an arithmetic expression:
+Any of the following math library functions can be used within an arithmetic
+expression if the function called is provided by the operating system's
+native C math library:
 .PP
 .if t .RS
 .B
-.if n abs acos acosh asin asinh atan atan2 atanh cbrt ceil copysign cos cosh erf erfc exp exp10 exp2 expm1 fabs fdim finite float floor fma fmax fmin fmod fpclass fpclassify hypot ilogb int isfinite isgreater isgreaterequal isinf isinfinite isless islessequal islessgreater isnan isnormal issubnormal isunordered iszero j0 j1 jn ldexp lgamma log log10 log1p log2 logb nearbyint nextafter nexttoward pow remainder rint round scalb scalbn signbit sin sinh sqrt tan tanh tgamma trunc y0 y1 yn
-.if t abs   acos   acosh   asin   asinh   atan   atan2   atanh   cbrt   ceil   copysign   cos   cosh   erf   erfc   exp   exp10   exp2   expm1   fabs   fdim   finite   float   floor   fma   fmax   fmin   fmod   fpclass   fpclassify   hypot   ilogb   int   isfinite   isgreater   isgreaterequal   isinf   isinfinite   isless   islessequal   islessgreater   isnan   isnormal   issubnormal   isunordered   iszero   j0   j1   jn   ldexp   lgamma   log   log10   log1p   log2   logb   nearbyint   nextafter   nexttoward   pow   remainder   rint   round   scalb   scalbn   signbit   sin   sinh   sqrt   tan   tanh   tgamma   trunc   y0   y1   yn
+.if n abs acos acosh acospi asin asinh asinpi atan atan2 atan2pi atanh atanpi cbrt ceil compoundn copysign cos cosh cospi erf erfc exp exp2 exp10 expm1 exp2m1 exp10m1 fabs fadd fdim fdiv ffma finite float floor fma fmax fmaximum fmaximum_mag fmaximum_mag_num fmaximum_num fmaxmag fmin fminimum fminimum_mag fminimum_mag_num fminimum_num fminmag fmod fmul fpclassify fpclass fsqrt fsub hypot ilogb int iscanonical iseqsig isfinite isgreater isgreaterequal isinf isinfinite isless islessequal islessgreater isnan isnormal issignaling issubnormal isunordered iszero j0 j1 jn ldexp lgamma log log10 log10p1 log1p log2 log2p1 logb logp1 nearbyint nextafter nextdown nexttoward nextup pow pown powr remainder rint rootn round roundeven rsqrt scalb scalbn scalbln signbit sin sinh sinpi sqrt tan tanh tanpi tgamma trunc y0 y1 yn
+.if t abs   acos   acosh   acospi   asin   asinh   asinpi   atan   atan2   atan2pi   atanh   atanpi   cbrt   ceil   compoundn   copysign   cos   cosh   cospi   erf   erfc   exp   exp2   exp10   expm1   exp2m1   exp10m1   fabs   fadd   fdim   fdiv   ffma   finite   float   floor   fma   fmax   fmaximum   fmaximum_mag   fmaximum_mag_num   fmaximum_num   fmaxmag   fmin   fminimum   fminimum_mag   fminimum_mag_num   fminimum_num   fminmag   fmod   fmul   fpclassify   fpclass   fsqrt   fsub   hypot   ilogb   int   iscanonical   iseqsig   isfinite   isgreater   isgreaterequal   isinf   isinfinite   isless   islessequal   islessgreater   isnan   isnormal   issignaling   issubnormal   isunordered   iszero   j0   j1   jn   ldexp   lgamma   log   log10   log10p1   log1p   log2   log2p1   logb   logp1   nearbyint   nextafter   nextdown   nexttoward   nextup   pow   pown   powr   remainder   rint   rootn   round   roundeven   rsqrt   scalb   scalbn   scalbln   signbit   sin   sinh   sinpi   sqrt   tan   tanh   tanpi   tgamma   trunc   y0   y1   yn
 .if t .RE
 
 In addition, arithmetic functions can be defined as shell functions with a


### PR DESCRIPTION
src/cmd/ksh93/{data/math.tab,sh.1}:
- Added support for 40 additional math functions from C23, TS 18661-1:2014, TS 18661-3:2015 and glibc.
- Note that math function support varies depending on what the native math library actually has.

src/cmd/ksh93/include/streval.h:
- Increase the char array to 18 bytes to fit the full name length for the newly added math functions.