### PR TITLE
Use faccessat() and atomic_uint for slight performance improvements

### DIFF
--- a/src/cmd/ksh93/include/jobs.h
+++ b/src/cmd/ksh93/include/jobs.h
@@ -31,11 +31,11 @@
 #ifndef SIGINT
 #   include	<signal.h>
 #endif /* !SIGINT */
-#include	"terminal.h"
 #if !_std_atomic
 #   include	<aso.h>
 #   define	atomic_uint uint32_t
 #endif
+#include	"terminal.h"
 
 #ifndef SIGCHLD
 #   error ksh 93u+m requires SIGCHLD

--- a/src/cmd/ksh93/include/jobs.h
+++ b/src/cmd/ksh93/include/jobs.h
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1982-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2025 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -31,8 +31,11 @@
 #ifndef SIGINT
 #   include	<signal.h>
 #endif /* !SIGINT */
-#include	<aso.h>
 #include	"terminal.h"
+#if !_std_atomic
+#   include	<aso.h>
+#   define	atomic_uint uint32_t
+#endif
 
 #ifndef SIGCHLD
 #   error ksh 93u+m requires SIGCHLD
@@ -65,7 +68,7 @@ struct jobs
 	pid_t		mypgid;		/* process group ID of shell */
 	pid_t		mytgid;		/* terminal group ID of shell */
 	int		curjobid;
-	unsigned int	in_critical;	/* >0 => in critical region */
+	atomic_uint	in_critical;	/* >0 => in critical region */
 	int		savesig;	/* active signal */
 	int		numpost;	/* number of posted jobs */
 #if SHOPT_BGX
@@ -88,6 +91,18 @@ struct jobs
 
 extern struct jobs job;
 
+#if _std_atomic
+/* locking functions used when C11's atomic_uint is available */
+#define job_lock()	(job.in_critical++)
+#define job_unlock()	\
+	do { \
+		int	_sig; \
+		if (job.in_critical == 1 && (_sig = job.savesig)) \
+			job_reap(_sig); \
+		job.in_critical--; \
+	} while(0)
+#else
+/* fallbacks using the ASO functions provided by libast */
 #define job_lock()	asoincint(&job.in_critical)
 #define job_unlock()	\
 	do { \
@@ -96,6 +111,7 @@ extern struct jobs job;
 		    job_reap(_sig); \
 		asodecint(&job.in_critical); \
 	} while(0)
+#endif
 
 extern const char	e_jobusage[];
 extern const char	e_done[];

--- a/src/lib/libast/comp/eaccess.c
+++ b/src/lib/libast/comp/eaccess.c
@@ -18,7 +18,9 @@
 *                                                                      *
 ***********************************************************************/
 /*
- * access() EUID/EGID implementation
+ * AST eaccess() implementation
+ * Uses POSIX faccessat() for better portability and performance
+ * Fallbacks include native eaccess(), euidaccess(), EFF_ONLY_OK, and a custom implementation
  */
 
 #include <ast.h>
@@ -26,19 +28,21 @@
 
 #include "FEATURE/eaccess"
 
-#if _lib_eaccess
+#if _lib_eaccess && !_lib_faccessat
+#undef eaccess
+extern int eaccess(const char* path, int flags);
+#endif
 
-NoN(eaccess)
-
-#else
-
-extern int
-eaccess(const char* path, int flags)
+int
+_ast_eaccess(const char* path, int flags)
 {
-#ifdef EFF_ONLY_OK
+#if _lib_faccessat && defined(AT_EACCESS)
+	return faccessat(AT_FDCWD, path, flags, AT_EACCESS);
+#elif _lib_eaccess
+	return eaccess(path, flags);
+#elif defined(EFF_ONLY_OK)
 	return access(path, flags|EFF_ONLY_OK);
-#else
-#if _lib_euidaccess
+#elif _lib_euidaccess
 	return euidaccess(path, flags);
 #else
 	int		mode;
@@ -125,7 +129,4 @@ eaccess(const char* path, int flags)
 	errno = EACCES;
 	return -1;
 #endif
-#endif
 }
-
-#endif

--- a/src/lib/libast/comp/eaccess.c
+++ b/src/lib/libast/comp/eaccess.c
@@ -28,7 +28,7 @@
 
 #include "FEATURE/eaccess"
 
-#if _lib_eaccess && !_lib_faccessat
+#if _lib_eaccess && !(_lib_faccessat && defined(AT_EACCESS))
 #undef eaccess
 extern int eaccess(const char* path, int flags);
 #endif

--- a/src/lib/libast/features/common
+++ b/src/lib/libast/features/common
@@ -10,6 +10,13 @@ std	noreturn note{ noreturn ok }end compile{
 	int main(void) { foo(); }
 }end
 
+std	atomic note{ _Atomic ok }end compile{
+	#include <stdlib.h>
+	#include <stdatomic.h>
+	static atomic_uint i = 0;
+	int main(void) { return i; }
+}end
+
 cat{
 	#if __clang__
 	#pragma clang diagnostic ignored "-Wmissing-braces"
@@ -66,6 +73,9 @@ cat{
 	#else
 	#define noreturn /* empty */
 	#endif /* _std_noreturn */
+	#if _std_atomic
+	#include <stdatomic.h>
+	#endif /* _std_atomic */
 }end
 
 if	tst - note{ <stdarg.h>+<wchar.h> works }end compile{

--- a/src/lib/libast/features/eaccess
+++ b/src/lib/libast/features/eaccess
@@ -1,4 +1,4 @@
-lib	eaccess,euidaccess
+lib	faccessat,eaccess,euidaccess
 macro{
 	#include <sys/types.h>
 	#include <unistd.h>

--- a/src/lib/libast/features/map.c
+++ b/src/lib/libast/features/map.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2025 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -47,6 +47,10 @@ main(void)
 	/* do the same with sigunblock(), just to be sure (e.g., native QNX sigunblock() is different) */
 	printf("#undef	sigunblock\n");
 	printf("#define sigunblock      _ast_sigunblock\n");
+	/* use AST eaccess(3) (which will prefer faccessat over native eaccess) */
+	printf("#undef	eaccess\n");
+	printf("#define eaccess         _ast_eaccess\n");
+	printf("extern int              eaccess(const char*, int);\n");
 	/* Override the native regex library in favor of libast's regex functions */
 	printf("#undef	regaddclass\n");
 	printf("#define regaddclass	_ast_regaddclass\n");


### PR DESCRIPTION
Change 1:
On some systems (i.e. those using glibc) POSIX `faccessat()` can be faster than `eaccess()`, so this pull request amends libast to prefer that function instead. Benchmark (glibc 2.42, base commit is 79ad2176):
```sh
$ cat /tmp/foo
for ((i=0; i!=300; i++)) do
    rm $(/opt/ast/bin/mktemp)
done
$ strace -c ksh /tmp/foo
faccessat:  100.00    0.053465           7      7328      1217 total
eaccess:    100.00    0.054799           6      8828      1217 total
```

Change 2:
The current workaround for the GCC optimizer bug affecting `job_lock()` and `job_unlock()` (re: 1560223d, 52067c3d, 595a0a56, 52067c3d, 07cc71b8) (which is actually triggered by using `-fstrict-aliasing` in particular) uses the `aso*()` functions in libast to portably perform atomic operations on `job.in_critical`. This works, but the generated assembly is inferior compared to the obsolete `__sync_fetch_and_add/sub` GCC builtins. Specifically, the aso functions called result in executing a total of 66 extra instructions on x86_64 (when compiling on the dev branch with defaults; use `objdump -S` to see the resulting assembly for the binary).

Only the lock instructions are truly necessary; everything else is superfluous. C11's `atomic_uint` provides the same functionality the old GCC builtins have, so for efficiency it's a better choice. (I initially thought this change sped up subshells, but with further benchmarking I found results to be too inconsistent when using different compilers versions and flags. In any case the C11 solution produces more efficient assembly than the libast ASO solution, so it ought be used instead when available.)

src/cmd/ksh93/include/jobs.h:
- Use C11 `atomic_uint` and regular increments/decrements when `_Atomic` is available.

src/lib/libast/features/{common,eaccess}:
- Add a `_std_atomic` test to detect the presence of `atomic_uint`.
- Add a probe for `faccessat()`.

src/lib/libast/{comp/eaccess.c,features/map.c}:
- Remap `eaccess` calls to `_ast_eaccess()`, which now prefers POSIX `faccessat()`.