### PR TITLE
astconf.c: Fix invalid free crashes

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,12 @@ This documents significant changes in the dev branch of ksh 93u+m.
 For full details, see the git log at: https://github.com/ksh93/ksh
 Uppercase BUG_* IDs are shell bug IDs as used by the Modernish shell library.
 
+2026-03-07:
+
+- Fixed an invalid free crash that could occur when using the libcmd
+  builtins with /opt/ast/bin prefixed in the PATH and the POSIXLY_CORRECT
+  environment variable set to 1.
+
 2026-03-01:
 
 - Fixed a use-after-free crash that could occur when variables of custom

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -18,7 +18,7 @@
 #include <ast_release.h>
 #include "git.h"
 
-#define SH_RELEASE_DATE	"2026-03-01"	/* must be in this format for $((.sh.version)) */
+#define SH_RELEASE_DATE	"2026-03-07"	/* must be in this format for $((.sh.version)) */
 /*
  * This comment keeps SH_RELEASE_DATE a few lines away from SH_RELEASE_SVER to avoid
  * merge conflicts when cherry-picking dev branch commits onto a release branch.

--- a/src/lib/libast/port/astconf.c
+++ b/src/lib/libast/port/astconf.c
@@ -282,6 +282,23 @@ static State_t	state = { "getconf", "_AST_FEATURES", "CONFORMANCE = standard", "
 
 static char*	feature(Feature_t*, const char*, const char*, const char*, unsigned int, Error_f);
 
+static char *set_fp_value(Feature_t *fp, const char *str, Error_f conferror)
+{
+	if ((fp->flags & CONF_ALLOC) && fp->value && fp->value != null)
+		free(fp->value);
+	if(str == null)
+		return fp->value = null;
+	fp->value = strdup(str);
+	if (!fp->value)
+	{
+		if (conferror)
+			(*conferror)(&state, &state, 2, "set_fp_value(): out of memory");
+		fp->value = null;
+	}
+	fp->flags |= CONF_ALLOC;
+	return fp->value;
+}
+
 /*
  * return fmtbuf() copy of s
  */
@@ -469,9 +486,7 @@ synthesize(Feature_t* fp, const char* path, const char* value, Error_f conferror
 		n = 0;
 	if(!(newvalue = malloc(n + 1)))
 	{
-		if(fp->value && fp->value != null)
-			free(fp->value);
-		fp->value = null;
+		set_fp_value(fp, null, conferror);
 		if (conferror)
 			(*conferror)(&state, &state, 2, "synthesize(): out of memory");
 		return NULL;
@@ -631,11 +646,19 @@ format(Feature_t* fp, const char* path, const char* value, unsigned int flags, E
 	{
 
 	case OP_architecture:
+	   {
+		char *hostname = getenv("HOSTNAME");
 		if (!uname(&uts))
-			return fp->value = uts.machine;
-		if (!(fp->value = getenv("HOSTNAME")))
-			fp->value = "unknown";
+		{
+			set_fp_value(fp, uts.machine, conferror);
+			return fp->value;
+		}
+		if (!hostname)
+			set_fp_value(fp, "unknown", conferror);
+		else
+			set_fp_value(fp, hostname, conferror);
 		break;
+	   }
 
 	case OP_conformance:
 		if (value && STANDARD(value))
@@ -645,7 +668,7 @@ format(Feature_t* fp, const char* path, const char* value, unsigned int flags, E
 		error(-6, "state.std=%d %s [%s] std=%s ast=%s value=%s", state.std, fp->name, value, fp->std, fp->ast, fp->value);
 #endif
 		if (state.synthesizing && value == (char*)fp->std)
-			fp->value = (char*)value;
+			set_fp_value(fp, value, conferror);
 		else if (!synthesize(fp, path, value, conferror))
 			initialize(fp, path, NULL, fp->std, fp->value, conferror);
 #if DEBUG_astconf
@@ -667,12 +690,12 @@ format(Feature_t* fp, const char* path, const char* value, unsigned int flags, E
 		break;
 
 	case OP_path_attributes:
-		fp->value = pathicase(path) > 0 ? "c" : null;
+		set_fp_value(fp, pathicase(path) > 0 ? "c" : null, conferror);
 		break;
 
 	case OP_path_resolve:
 		if (state.synthesizing && value == (char*)fp->std)
-			fp->value = (char*)value;
+			set_fp_value(fp, value, conferror);
 		else if (!synthesize(fp, path, value, conferror))
 			initialize(fp, path, NULL, "logical", DEFAULT(OP_path_resolve), conferror);
 		break;
@@ -712,8 +735,8 @@ format(Feature_t* fp, const char* path, const char* value, unsigned int flags, E
 		{
 			if (state.synthesizing)
 			{
-				if (!(fp->flags & CONF_ALLOC))
-					fp->value = 0;
+				if (!(fp->flags & CONF_ALLOC) || fp->value == null)
+					fp->value = NULL;
 				n = strlen(value);
 				if (!(fp->value = newof(fp->value, char, n, 1)))
 				{
@@ -739,7 +762,7 @@ format(Feature_t* fp, const char* path, const char* value, unsigned int flags, E
 
 	default:
 		if (state.synthesizing && value == (char*)fp->std)
-			fp->value = (char*)value;
+			set_fp_value(fp, value, conferror);
 		else
 			synthesize(fp, path, value, conferror);
 		break;

--- a/src/lib/libast/port/astconf.c
+++ b/src/lib/libast/port/astconf.c
@@ -735,7 +735,7 @@ format(Feature_t* fp, const char* path, const char* value, unsigned int flags, E
 		{
 			if (state.synthesizing)
 			{
-				const char *mayfree;
+				char *mayfree;
 				if (!(fp->flags & CONF_ALLOC) || fp->value == null)
 					fp->value = NULL;
 				mayfree = fp->value;

--- a/src/lib/libast/port/astconf.c
+++ b/src/lib/libast/port/astconf.c
@@ -735,11 +735,14 @@ format(Feature_t* fp, const char* path, const char* value, unsigned int flags, E
 		{
 			if (state.synthesizing)
 			{
+				const char *mayfree;
 				if (!(fp->flags & CONF_ALLOC) || fp->value == null)
 					fp->value = NULL;
+				mayfree = fp->value;
 				n = strlen(value);
 				if (!(fp->value = newof(fp->value, char, n, 1)))
 				{
+					free(mayfree);
 					if (conferror)
 						(*conferror)(&state, &state, 2, "%s: out of memory", value);
 					fp->value = null;

--- a/src/lib/libast/port/astconf.c
+++ b/src/lib/libast/port/astconf.c
@@ -284,7 +284,7 @@ static char*	feature(Feature_t*, const char*, const char*, const char*, unsigned
 
 static char *set_fp_value(Feature_t *fp, const char *str, Error_f conferror)
 {
-	if ((fp->flags & CONF_ALLOC) && fp->value && fp->value != null)
+	if ((fp->flags & CONF_ALLOC) && fp->value != null)
 		free(fp->value);
 	if(str == null)
 		return fp->value = null;
@@ -494,7 +494,7 @@ synthesize(Feature_t* fp, const char* path, const char* value, Error_f conferror
 	/* memcpy comes before free because fp->value and value might share memory */
 	memcpy(newvalue, value, n);
 	newvalue[n] = 0;
-	if(fp->value && fp->value != null)
+	if(fp->value != null)
 		free(fp->value);
 	fp->flags |= CONF_ALLOC;
 	return fp->value = newvalue;


### PR DESCRIPTION
- Create `set_fp_value()` helper function which sets `fp->value` to a new string or to the not-`NULL` `null`.
- If `fp->value` points to `null` (which is different from `NULL`), don't free it with `free` or with `realloc` via the `newof` macro.
- If the `CONF_ALLOC` bit is set, free `fp->value` before allocating memory to avoid memory leaks.
- Always dup the not-`null` strings passed to `set_fp_value()` and indicate this with `CONF_ALLOC`. The string passed to `set_fp_value()` may become invalidated later (i.e. the returned string from `getenv(3)`), so always dup our own copy to avoid surprises.

Fixes https://github.com/ksh93/ksh/issues/939