### PR TITLE
size_t/ptrdiff_t transition part 2: SFIO, hash lib, fmt*(), strmatch()

### DIFF
--- a/src/cmd/ksh93/bltins/print.c
+++ b/src/cmd/ksh93/bltins/print.c
@@ -53,11 +53,11 @@ union types_t
 struct printf
 {
 	Sffmt_t		hdr;
-	int		argsize;
-	int		intvar;
 	char		**argv0; /* see reload() below */
 	char		**nextarg;
 	char		*lastarg;
+	ptrdiff_t	argsize;
+	int		intvar;
 	char		cescape;
 	char		err;
 };
@@ -83,9 +83,9 @@ static const struct printmap  Pmap[] =
 
 static int		echolist(Sfio_t*, int, char**);
 static int		extend(Sfio_t*,void*, Sffmt_t*);
-static int		reload(int argn, char fmt, void* v, Sffmt_t* fe);
+static ptrdiff_t	reload(ptrdiff_t argn, char fmt, void* v, Sffmt_t* fe);
 static char		*genformat(char*);
-static int		fmtvecho(const char*, struct printf*);
+static ptrdiff_t	fmtvecho(const char*, struct printf*);
 static ssize_t		fmtbase64(Sfio_t*, char*, int);
 struct print
 {
@@ -358,9 +358,9 @@ skip2:
 	}
 	if(!(outfile=sh.sftable[fd]))
 	{
+		unsigned short sfflags = SFIO_WRITE|((n&IOREAD)?SFIO_READ:0);
 		sh_onstate(SH_NOTRACK);
-		n = SFIO_WRITE|((n&IOREAD)?SFIO_READ:0);
-		sh.sftable[fd] = outfile = sfnew(NULL,sh.outbuff,IOBSIZE,fd,n);
+		sh.sftable[fd] = outfile = sfnew(NULL,sh.outbuff,IOBSIZE,fd,sfflags);
 		sh_offstate(SH_NOTRACK);
 		sfpool(outfile,sh.outpool,SFIO_WRITE);
 	}
@@ -388,7 +388,7 @@ printf_v:
 			sfprintf(outfile,"%!",&pdata);
 		} while(*pdata.nextarg && pdata.nextarg!=argv);
 		if(pdata.nextarg == nullarg && pdata.argsize>0)
-			if(sfwrite(outfile,stkptr(sh.stk,stktell(sh.stk)),pdata.argsize) < 0)
+			if(sfwrite(outfile,stkptr(sh.stk,stktell(sh.stk)),(size_t)pdata.argsize) < 0)
 				exitval = 1;
 		sfpool(sfstderr,pool,SFIO_WRITE);
 		if (pdata.err)
@@ -444,7 +444,7 @@ printf_v:
 static int echolist(Sfio_t *outfile, int raw, char *argv[])
 {
 	char	*cp;
-	int	n;
+	ptrdiff_t n;
 	struct printf pdata;
 	pdata.cescape = 0;
 	pdata.err = 0;
@@ -453,7 +453,7 @@ static int echolist(Sfio_t *outfile, int raw, char *argv[])
 		if(!raw  && (n=fmtvecho(cp,&pdata))>=0)
 		{
 			if(n)
-				if(sfwrite(outfile,stkptr(sh.stk,stktell(sh.stk)),n) < 0)
+				if(sfwrite(outfile,stkptr(sh.stk,stktell(sh.stk)),(size_t)n) < 0)
 					exitval = 1;
 		}
 		else
@@ -470,14 +470,12 @@ static int echolist(Sfio_t *outfile, int raw, char *argv[])
 /*
  * modified version of stresc for generating formats
  */
-static char strformat(char *s)
+static void strformat(char *s)
 {
-	char*		t;
+	char*		t = s;
 	int		c;
-	char*		b;
 	char*		p;
 	int		w;
-	b = t = s;
 	for (;;)
 	{
 		switch (c = *s++)
@@ -508,9 +506,9 @@ static char strformat(char *s)
 			break;
 		    case 0:
 			*t = 0;
-			return t - b;
+			return;
 		}
-		*t++ = c;
+		*t++ = (char)c;
 	}
 }
 
@@ -527,7 +525,8 @@ static char *genformat(char *format)
 static char *fmthtml(const char *string, int flags)
 {
 	const char *cp = string, *op;
-	int c, offset = stktell(sh.stk);
+	int c;
+	ptrdiff_t offset = stktell(sh.stk);
 	if(!(flags&SFFMT_ALTER))
 	{
 		/* Encode for HTML and XML, for main text and single- and double-quoted attributes. */
@@ -546,7 +545,7 @@ static char *fmthtml(const char *string, int flags)
 			else if(c == 39)		/* ' (&apos; is not HTML) */
 				sfputr(sh.stk,"&#39;",-1);
 			else
-				sfwrite(sh.stk, op, cp-op);
+				sfwrite(sh.stk, op, (size_t)(cp-op));
 		}
 	}
 	else
@@ -584,7 +583,7 @@ static ssize_t fmtbase64(Sfio_t *iop, char *string, int alt)
 {
 	char			*cp;
 	Sfdouble_t		d;
-	ssize_t			size;
+	size_t			size;
 	Namval_t		*np = nv_open(string, NULL, NV_VARNAME|NV_NOADD);
 	Namarr_t		*ap;
 	static union types_t	number;
@@ -650,7 +649,8 @@ static ssize_t fmtbase64(Sfio_t *iop, char *string, int alt)
 			return (*fp->disc->writef)(np, iop, 0, fp);
 		else
 		{
-			int n = nv_size(np);
+			size_t n = nv_size(np);
+			ssize_t ret;
 			if(nv_isarray(np))
 			{
 				nv_onattr(np,NV_RAW);
@@ -661,8 +661,8 @@ static ssize_t fmtbase64(Sfio_t *iop, char *string, int alt)
 				cp = np->nvalue;
 			if((size = n)==0)
 				size = strlen(cp);
-			size = sfwrite(iop, cp, size);
-			return n?n:size;
+			ret = sfwrite(iop, cp, size);
+			return n?(ssize_t)n:ret;
 		}
 	}
 	else if(nv_isarray(np) && (ap=nv_arrayptr(np)) && array_elem(ap) && (ap->nelem&(ARRAY_UNDEF|ARRAY_SCAN)))
@@ -670,7 +670,7 @@ static ssize_t fmtbase64(Sfio_t *iop, char *string, int alt)
 		nv_outnode(np,iop,(alt?-1:0),0);
 		if(sfputc(iop,')') < 0)
 			exitval = 1;
-		return sftell(iop);
+		return (ssize_t)sftell(iop);
 	}
 	else
 	{
@@ -688,14 +688,15 @@ static ssize_t fmtbase64(Sfio_t *iop, char *string, int alt)
 	}
 }
 
-static int varname(const char *str, int n)
+static int varname(const char *str, ptrdiff_t n)
 {
-	int c,dot=1,len=1;
+	int c,dot=1;
+	ptrdiff_t len=1;
 	if(n < 0)
 	{
 		if(*str=='.')
 			str++;
-		n = strlen(str);
+		n = (ptrdiff_t)strlen(str);
 	}
 	for(;n > 0; n-=len)
 	{
@@ -719,7 +720,7 @@ static const char *mapformat(Sffmt_t *fe)
 	const struct printmap *pm = Pmap;
 	while(pm->size>0)
 	{
-		if(pm->size==fe->n_str && strncmp(pm->name,fe->t_str,fe->n_str)==0)
+		if((ssize_t)pm->size==fe->n_str && strncmp(pm->name,fe->t_str,(size_t)fe->n_str)==0)
 			return pm->map;
 		pm++;
 	}
@@ -734,7 +735,8 @@ static int extend(Sfio_t* sp, void* v, Sffmt_t* fe)
 	Sfdouble_t	longmax = LDBL_LLONG_MAX;
 	int		format = fe->fmt;
 	int		n;
-	int		fold = fe->base;
+	ptrdiff_t	m;
+	int		fold = (int)fe->base;
 	union types_t*	value = (union types_t*)v;
 	struct printf*	pp = (struct printf*)fe;
 	char*		argp = *pp->nextarg;
@@ -801,7 +803,7 @@ static int extend(Sfio_t* sp, void* v, Sffmt_t* fe)
 		case 'T':
 			fe->fmt = 'd';
 			tm_info.flags = 0;
-			value->ll = tmxgettime();
+			value->ll = (Sflong_t)tmxgettime();
 			break;
 		case '.':
 			fe->fmt = 'd';
@@ -885,7 +887,7 @@ static int extend(Sfio_t* sp, void* v, Sffmt_t* fe)
 			else if(fe->base >=0)
 				value->s = argp;
 			else
-				value->c = *argp;
+				value->c = (unsigned char)*argp;
 			fe->flags &= ~SFFMT_LONG;
 			break;
 		case 'o':
@@ -1008,7 +1010,7 @@ static int extend(Sfio_t* sp, void* v, Sffmt_t* fe)
 			UNREACHABLE();
 		}
 		if (format == '.')
-			value->i = value->ll;
+			value->i = (int)value->ll;
 		if(*lastchar)
 		{
 			errormsg(SH_DICT,ERROR_warn(0),e_argtype,format);
@@ -1024,21 +1026,21 @@ static int extend(Sfio_t* sp, void* v, Sffmt_t* fe)
 		value->c = 0;
 		break;
 	case 'b':
-		if((n=fmtvecho(value->s,pp))>=0)
+		if((m=fmtvecho(value->s,pp))>=0)
 		{
 			if(pp->nextarg == nullarg)
 			{
-				pp->argsize = n;
+				pp->argsize = m;
 				return -1;
 			}
 			value->s = stkptr(sh.stk,stktell(sh.stk));
-			fe->size = n;
+			fe->size = (ptrdiff_t)m;
 		}
 		break;
 	case 'B':
 		if(!sh.strbuf2)
 			sh.strbuf2 = sfstropen();
-		fe->size = fmtbase64(sh.strbuf2,value->s, fe->flags&SFFMT_ALTER);
+		fe->size = (ptrdiff_t)fmtbase64(sh.strbuf2,value->s, fe->flags&SFFMT_ALTER);
 		value->s = sfstruse(sh.strbuf2);
 		fe->flags |= SFFMT_SHORT;
 		break;
@@ -1074,7 +1076,7 @@ static int extend(Sfio_t* sp, void* v, Sffmt_t* fe)
 		}
 		else
 		{
-			value->s = fmtelapsed(value->ll, 1);
+			value->s = fmtelapsed((unsigned long)value->ll, 1);
 			fe->fmt = 's';
 			fe->size = -1;
 		}
@@ -1082,12 +1084,13 @@ static int extend(Sfio_t* sp, void* v, Sffmt_t* fe)
 	case 'T':
 		if(fe->n_str>0)
 		{
-			n = fe->t_str[fe->n_str];
+			char nc;
+			nc = fe->t_str[fe->n_str];
 			fe->t_str[fe->n_str] = 0;
-			value->s = fmttmx(fe->t_str, value->ll);
-			fe->t_str[fe->n_str] = n;
+			value->s = fmttmx(fe->t_str, (Time_t)value->ll);
+			fe->t_str[fe->n_str] = nc;
 		}
-		else value->s = fmttmx(NULL, value->ll);
+		else value->s = fmttmx(NULL, (Time_t)value->ll);
 		fe->fmt = 's';
 		fe->size = -1;
 		break;
@@ -1110,11 +1113,10 @@ static int extend(Sfio_t* sp, void* v, Sffmt_t* fe)
  * In that case, argv[0] and argv[4] are consumed and nextarg push
  * to &argv[5] argv[1..3] is ignored.
  */
-static int reload(int argn, char fmt, void* v, Sffmt_t* fe)
+static ptrdiff_t reload(ptrdiff_t argn, char fmt, void* v, Sffmt_t* fe)
 {
 	struct printf*	pp = (struct printf*)fe;
-	int		r;
-	int		n;
+	ptrdiff_t	n, r;
 	if(fmt == 0)
 	{
 		/* Set nextarg */
@@ -1146,11 +1148,11 @@ static int reload(int argn, char fmt, void* v, Sffmt_t* fe)
  * Otherwise, puts null-terminated result on stack, but doesn't freeze it
  * returns length of output.
  */
-static int fmtvecho(const char *string, struct printf *pp)
+static ptrdiff_t fmtvecho(const char *string, struct printf *pp)
 {
 	const char *cp = string, *cpmax;
 	int c;
-	int offset = stktell(sh.stk);
+	ptrdiff_t offset = stktell(sh.stk), d;
 	int chlen;
 	if(mbwide())
 	{
@@ -1168,14 +1170,14 @@ static int fmtvecho(const char *string, struct printf *pp)
 			;
 	if(c==0)
 		return -1;
-	c = --cp - string;
-	if(c>0)
-		sfwrite(sh.stk,string,c);
+	d = --cp - string;
+	if(d>0)
+		sfwrite(sh.stk,string,(size_t)d);
 	for(; c= *cp; cp++)
 	{
 		if (mbwide() && ((chlen = mbsize(cp)) > 1))
 		{
-			sfwrite(sh.stk,cp,chlen);
+			sfwrite(sh.stk,cp,(size_t)chlen);
 			cp +=  (chlen-1);
 			continue;
 		}
@@ -1227,8 +1229,8 @@ static int fmtvecho(const char *string, struct printf *pp)
 		sfputc(sh.stk,c);
 	}
 done:
-	c = stktell(sh.stk)-offset;
+	d = stktell(sh.stk)-offset;
 	sfputc(sh.stk,0);
 	stkseek(sh.stk,offset);
-	return c;
+	return d;
 }

--- a/src/lib/libast/features/stdio
+++ b/src/lib/libast/features/stdio
@@ -267,7 +267,7 @@ cat{
 	extern int	setbuffer(FILE*, char*, int);
 	extern int	setlinebuf(FILE*);
 	extern int	setvbuf(FILE*, char*, int, size_t);
-	extern int	snprintf(char*, int, const char*, ...);
+	extern int	snprintf(char*, size_t, const char*, ...);
 	extern int	sprintf(char*, const char*, ...);
 	extern int	sscanf(const char*, const char*, ...);
 	extern FILE*	tmpfile(void);
@@ -277,7 +277,7 @@ cat{
 	extern int	vfscanf(FILE*, const char*, va_list);
 	extern int	vprintf(const char*, va_list);
 	extern int	vscanf(const char*, va_list);
-	extern int	vsnprintf(char*, int, const char*, va_list);
+	extern int	vsnprintf(char*, size_t, const char*, va_list);
 	extern int	vsprintf(char*, const char*, va_list);
 	extern int	vsscanf(const char*, const char*, va_list);
 
@@ -326,11 +326,11 @@ cat{
 	#define feof(f)		sfeof(f)
 	#define ferror(f)	sferror(f)
 	#define fileno(f)	sffileno(f)
-	#define fputc(c,f)	sfputc(f,c)
+	#define fputc(c,f)	((int)sfputc(f,c))
 	#define getc(f)		sfgetc(f)
 	#define getchar()	sfgetc(sfstdin)
-	#define putc(c,f)	sfputc(f,c)
-	#define putchar(c)	sfputc(sfstdout,c)
+	#define putc(c,f)	((int)sfputc(f,c))
+	#define putchar(c)	((int)sfputc(sfstdout,c))
 
 	#else
 
@@ -341,14 +341,14 @@ cat{
 	#define feof(f)		(_sf_(f)->_flags&_SFIO_EOF)
 	#define ferror(f)	(_sf_(f)->_flags&_SFIO_ERROR)
 	#define fileno(f)	(_sf_(f)->_file)
-	#define fputc(c,f)	(_sf_(f)->_next>=_sf_(f)->_endw?_sfflsbuf(_sf_(f),(int)((unsigned char)(c))):(int)(*_sf_(f)->_next++=(unsigned char)(c)))
-	#define getc(f)		(_sf_(f)->_next>=_sf_(f)->_endr?_sffilbuf(_sf_(f),0):(int)(*_sf_(f)->_next++))
+	#define fputc(c,f)	(_sf_(f)->_next>=_sf_(f)->_endw?(int)_sfflsbuf(_sf_(f),(int)((unsigned char)(c))):(int)(*_sf_(f)->_next++=(unsigned char)(c)))
+	#define getc(f)		(_sf_(f)->_next>=_sf_(f)->_endr?(int)_sffilbuf(_sf_(f),0):(int)(*_sf_(f)->_next++))
 	#define getchar()	getc(stdin)
 	#define putc(c,f)	fputc(c,f)
 	#define putchar(c)	fputc(c,stdout)
 
-	extern int		_sffilbuf(FILE*, int);
-	extern int		_sfflsbuf(FILE*, int);
+	extern ssize_t		_sffilbuf(FILE*, ssize_t);
+	extern ssize_t		_sfflsbuf(FILE*, ssize_t);
 
 	#endif
 }end

--- a/src/lib/libast/hash/hashalloc.c
+++ b/src/lib/libast/hash/hashalloc.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 /*
@@ -66,7 +67,7 @@ hashalloc(Hash_table_t* ref, ...)
 	tab->bucketsize = (sizeof(Hash_header_t) + sizeof(char*) - 1) / sizeof(char*);
 	if (ref)
 	{
-		tab->flags = ref->flags & ~HASH_RESET;
+		tab->flags = (short)(ref->flags & ~HASH_RESET);
 		tab->root = ref->root;
 		internal = HASH_INTERNAL;
 	}
@@ -97,9 +98,9 @@ hashalloc(Hash_table_t* ref, ...)
 			tab->root->local->alloc = va_arg(ap, Hash_alloc_f);
 			break;
 		case HASH_bucketsize:
-			n = (va_arg(ap, int) + sizeof(char*) - 1) / sizeof(char*);
+			n = (va_arg(ap, int) + (int)sizeof(char*) - 1) / (int)sizeof(char*);
 			if (n > UCHAR_MAX) goto out;
-			if (n > tab->bucketsize) tab->bucketsize = n;
+			if (n > tab->bucketsize) tab->bucketsize = (unsigned char)n;
 			break;
 		case HASH_clear:
 			tab->flags &= ~(va_arg(ap, int) & ~internal);
@@ -125,7 +126,7 @@ hashalloc(Hash_table_t* ref, ...)
 			break;
 		case HASH_namesize:
 			if (ref) goto out;
-			tab->root->namesize = va_arg(ap, int);
+			tab->root->namesize = (size_t)va_arg(ap, int);
 			break;
 		case HASH_region:
 			goto out;
@@ -176,11 +177,11 @@ hashalloc(Hash_table_t* ref, ...)
 			{
 				if (region)
 				{
-					if (!(tab->table = (Hash_bucket_t**)(*region)(handle, NULL, sizeof(Hash_bucket_t*) * tab->size, 0)))
+					if (!(tab->table = (Hash_bucket_t**)(*region)(handle, NULL, sizeof(Hash_bucket_t*) * (size_t)tab->size, 0)))
 						goto out;
-					memset(tab->table, 0, sizeof(Hash_bucket_t*) * tab->size);
+					memset(tab->table, 0, sizeof(Hash_bucket_t*) * (size_t)tab->size);
 				}
-				else if (!(tab->table = newof(0, Hash_bucket_t*, tab->size, 0))) goto out;
+				else if (!(tab->table = newof(0, Hash_bucket_t*, (size_t)tab->size, 0))) goto out;
 			}
 			if (!ref)
 			{

--- a/src/lib/libast/hash/hashdump.c
+++ b/src/lib/libast/hash/hashdump.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2023 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 /*
@@ -51,7 +52,7 @@ dumpbucket(Hash_table_t* tab, int flags)
 	Hash_bucket_t**		sp;
 	Hash_bucket_t*		b;
 	Hash_bucket_t**		sx;
-	int			n;
+	size_t			n;
 	unsigned char*		s;
 
 	NoP(flags);
@@ -64,7 +65,7 @@ dumpbucket(Hash_table_t* tab, int flags)
 				n++;
 		if (n)
 		{
-			sfprintf(sfstderr, "%5d %2d :", sp - tab->table, n);
+			sfprintf(sfstderr, "%5td %2zu :", sp - tab->table, n);
 			for (b = *sp; b; b = b->next)
 				if (!(b->hash & HASH_DELETED) && (!(tab->flags & HASH_VALUE) || b->value))
 				{
@@ -112,12 +113,12 @@ dumptable(Hash_table_t* tab, int flags)
 	sfprintf(sfstderr, "\n");
 	sfprintf(sfstderr, "        address:     0x%08lx\n", (unsigned long)tab);
 	sfprintf(sfstderr, "        flags:       ");
-	if (tab->frozen) sfprintf(sfstderr, "frozen=%d ", tab->frozen);
+	if (tab->frozen) sfprintf(sfstderr, "frozen=%u ", (unsigned int)tab->frozen);
 	dumpflags(tab->flags);
 	sfprintf(sfstderr, "\n");
-	sfprintf(sfstderr, "        size:        %d\n", tab->size);
+	sfprintf(sfstderr, "        size:        %jd\n", (intmax_t)tab->size);
 	sfprintf(sfstderr, "        buckets:     %d\n", tab->buckets);
-	sfprintf(sfstderr, "        bucketsize:  %d\n", tab->bucketsize * sizeof(char*));
+	sfprintf(sfstderr, "        bucketsize:  %zu\n", (size_t)tab->bucketsize * sizeof(char*));
 	sfprintf(sfstderr, "\n");
 	if ((flags | tab->flags) & HASH_BUCKET) dumpbucket(tab, flags);
 }
@@ -135,7 +136,7 @@ dumproot(Hash_root_t* root, int flags)
 	sfprintf(sfstderr, "        address:     0x%08lx\n", (unsigned long)root);
 	sfprintf(sfstderr, "        flags:       ");
 	dumpflags(root->flags);
-	if (root->namesize) sfprintf(sfstderr, "namesize=%d ", root->namesize);
+	if (root->namesize) sfprintf(sfstderr, "namesize=%zu ", root->namesize);
 	if (root->local->alloc) sfprintf(sfstderr, "alloc=0x%08lx ", (unsigned long)root->local->alloc);
 	if (root->local->compare) sfprintf(sfstderr, "compare=0x%08lx ", (unsigned long)root->local->compare);
 	if (root->local->free) sfprintf(sfstderr, "free=0x%08lx ", (unsigned long)root->local->free);

--- a/src/lib/libast/hash/hashfree.c
+++ b/src/lib/libast/hash/hashfree.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 /*
@@ -71,7 +72,7 @@ hashfree(Hash_table_t* tab)
 				else if (freevalue && p->value) (*freevalue)(p->value);
 				if (p->hash & HASH_FREENAME)
 				{
-					p->hash &= ~HASH_FREENAME;
+					p->hash &= (unsigned long)~HASH_FREENAME;
 					if (region) (*region)(handle, p->name, 0, 0);
 					else free(p->name);
 				}
@@ -82,7 +83,7 @@ hashfree(Hash_table_t* tab)
 				}
 				else if (p->hash & HASH_HIDES)
 				{
-					p->hash &= ~HASH_HIDES;
+					p->hash &= (unsigned long)~HASH_HIDES;
 					p->name = ((Hash_bucket_t*)p->name)->name;
 				}
 			}

--- a/src/lib/libast/hash/hashlib.h
+++ b/src/lib/libast/hash/hashlib.h
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2023 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 /*
@@ -54,10 +55,10 @@ typedef struct				/* root local pointers		*/
 
 #define _HASH_LAST_PRIVATE_ \
 	const char*	name;		/* last lookup name		*/ \
-	unsigned int	hash;		/* last lookup hash		*/
+	unsigned long	hash;		/* last lookup hash		*/
 
 #define _HASH_ROOT_PRIVATE_ \
-	int		namesize;	/* fixed name size: 0 => string	*/ \
+	size_t		namesize;	/* fixed name size: 0 => string	*/ \
 	int		meanchain;	/* resize mean chain length	*/ \
 	Hash_local_t*	local;		/* root local pointers		*/ \
 	Hash_root_t*	next;		/* next in list	of all roots	*/ \
@@ -74,7 +75,7 @@ typedef struct				/* root local pointers		*/
 #define HASHMINSIZE	(1<<4)		/* min table slots (power of 2)	*/
 #define HASHMEANCHAIN	2		/* def resize mean chain len	*/
 
-#define HASHMOD(t,h)	(h &= (t->size - 1))
+#define HASHMOD(t,h)	(h &= (unsigned long)(t->size - 1))
 #define HASHVAL(x)	((x)&~HASH_FLAGS)
 
 #define HASH(r,n,h)	if (r->local->hash) h = r->namesize ? (*r->local->hash)(n, r->namesize) : (*r->local->hash)(n);\
@@ -85,9 +86,9 @@ typedef struct				/* root local pointers		*/
 				if (r->namesize)\
 				{\
 					const char*	_hash_s2 = _hash_s1 + r->namesize;\
-					while (_hash_s1 < _hash_s2) HASHPART(h, *_hash_s1++);\
+					while (_hash_s1 < _hash_s2) HASHPART(h, (size_t)*_hash_s1++);\
 				}\
-				else while (*_hash_s1) HASHPART(h, *_hash_s1++);\
+				else while (*_hash_s1) HASHPART(h, (size_t)*_hash_s1++);\
 			}
 
 typedef struct				/* library private info		*/

--- a/src/lib/libast/hash/hashlook.c
+++ b/src/lib/libast/hash/hashlook.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 /*
@@ -33,11 +34,11 @@ char*
 hashlook(Hash_table_t* tab, const char* name, long flags, const char* value)
 {
 	Hash_bucket_t*	b;
-	unsigned int	n;
+	size_t		n;
 	Hash_last_t*	last;
 	Hash_table_t*	top;
 	Hash_bucket_t*	prev;
-	unsigned int	i;
+	size_t		i;
 
 	if ((flags & (HASH_LOOKUP|HASH_INTERNAL)) == (HASH_LOOKUP|HASH_INTERNAL))
 	{
@@ -50,7 +51,7 @@ hashlook(Hash_table_t* tab, const char* name, long flags, const char* value)
 		{
 			s2 = name;
 			n = 0;
-			while (c = *s2++) HASHPART(n, c);
+			while (c = *s2++) HASHPART(n, (size_t)c);
 		}
 		i = n;
 		for (;;)
@@ -162,7 +163,7 @@ hashlook(Hash_table_t* tab, const char* name, long flags, const char* value)
 				value = 0;
 				if (tab == top || (flags & HASH_SCOPE))
 				{
-					if (flags & HASH_OPAQUE) b->hash &= ~HASH_OPAQUED;
+					if (flags & HASH_OPAQUE) b->hash &= (unsigned long)~HASH_OPAQUED;
 					else if (!(tab->root->flags & HASH_BUCKET))
 					{
 						if (tab->root->local->free && b->value)
@@ -209,7 +210,7 @@ hashlook(Hash_table_t* tab, const char* name, long flags, const char* value)
 				}
 				else
 				{
-					int	m;
+					size_t	m;
 					char*	t;
 
 					if (!(i = tab->bucketsize))
@@ -231,7 +232,7 @@ hashlook(Hash_table_t* tab, const char* name, long flags, const char* value)
 				}
 				if (name && (b->hash & HASH_FREENAME))
 				{
-					b->hash &= ~HASH_FREENAME;
+					b->hash &= (unsigned long)~HASH_FREENAME;
 					if (tab->root->local->region) (*tab->root->local->region)(tab->root->local->handle, (char*)name, 0, 0);
 					else free((void*)name);
 				}
@@ -279,7 +280,7 @@ hashlook(Hash_table_t* tab, const char* name, long flags, const char* value)
 	}
 	else
 	{
-		int	m = tab->bucketsize * sizeof(char*);
+		size_t	m = tab->bucketsize * sizeof(char*);
 
 		if (flags & HASH_VALUE)
 		{
@@ -294,7 +295,7 @@ hashlook(Hash_table_t* tab, const char* name, long flags, const char* value)
 		else if (!(n = HASH_SIZEOF(flags)))
 		{
 			if (!(flags & HASH_FIXED)) n = m;
-			else if ((n = (int)integralof(value)) < m) n = m;
+			else if ((n = (size_t)integralof(value)) < m) n = m;
 		}
 		else if (n < m) n = m;
 		if (!prev && (tab->flags & HASH_ALLOCATE))

--- a/src/lib/libast/hash/hashscan.c
+++ b/src/lib/libast/hash/hashscan.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2023 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 /*
@@ -65,7 +66,7 @@ hashscan(Hash_table_t* tab, int flags)
 
 				while (sp < sx)
 					for (b = *sp++; b; b = b->next)
-						b->hash &= ~HASH_HIDDEN;
+						b->hash &= (unsigned long)~HASH_HIDDEN;
 			}
 		} while (tab = tab->scope);
 		tab = pos->tab;
@@ -114,7 +115,7 @@ hashnext(Hash_position_t* pos)
 				if (!(b->hash & HASH_DELETED)) break;
 			}
 		}
-		else b->hash &= ~HASH_HIDDEN;
+		else b->hash &= (unsigned long)~HASH_HIDDEN;
 	}
 	return pos->tab->root->last.bucket = pos->bucket = b;
 }

--- a/src/lib/libast/hash/hashsize.c
+++ b/src/lib/libast/hash/hashsize.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2023 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 /*
@@ -31,14 +32,14 @@
  */
 
 void
-hashsize(Hash_table_t* tab, int size)
+hashsize(Hash_table_t* tab, ssize_t size)
 {
 	Hash_bucket_t**		old_s;
 	Hash_bucket_t**		new_s;
 	Hash_bucket_t*		old_b;
 	Hash_bucket_t*		new_b;
 	Hash_bucket_t**		old_sx;
-	unsigned int		index;
+	unsigned long		index;
 	Hash_region_f		region;
 	void*			handle;
 
@@ -47,9 +48,9 @@ hashsize(Hash_table_t* tab, int size)
 		if (region = tab->root->local->region)
 		{
 			handle = tab->root->local->handle;
-			new_s = (Hash_bucket_t**)(*region)(handle, NULL, sizeof(Hash_bucket_t*) * size, 0);
+			new_s = (Hash_bucket_t**)(*region)(handle, NULL, sizeof(Hash_bucket_t*) * (size_t)size, 0);
 		}
-		else new_s = newof(0, Hash_bucket_t*, size, 0);
+		else new_s = newof(0, Hash_bucket_t*, (size_t)size, 0);
 		if (!new_s) tab->flags |= HASH_FIXED;
 		else
 		{

--- a/src/lib/libast/hash/hashview.c
+++ b/src/lib/libast/hash/hashview.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2023 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 /*
@@ -74,7 +75,7 @@ hashview(Hash_table_t* top, Hash_table_t* bot)
 			for (b = *sp++; b; b = b->next)
 				if (b->hash & HASH_HIDES)
 				{
-					b->hash &= ~HASH_HIDES;
+					b->hash &= (unsigned long)~HASH_HIDES;
 					b->name = ((Hash_bucket_t*)b->name)->name;
 				}
 		top->scope = 0;

--- a/src/lib/libast/hash/memhash.c
+++ b/src/lib/libast/hash/memhash.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2023 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 /*
@@ -29,12 +30,12 @@
  * return the hash of buffer s of length n
  */
 
-unsigned int
+size_t
 memhash(const void* as, int n)
 {
 	const unsigned char*	s = (const unsigned char*)as;
 	const unsigned char*	e = s + n;
-	unsigned int		c = 0;
+	size_t			c = 0;
 
 	while (s < e) HASHPART(c, *s++);
 	return c;

--- a/src/lib/libast/hash/strhash.c
+++ b/src/lib/libast/hash/strhash.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2023 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -30,12 +30,12 @@
  * return the hash of the null-terminated string s
  */
 
-unsigned int
+size_t
 strhash(const char* as)
 {
 	const unsigned char*	s = (const unsigned char*)as;
-	unsigned int		i = 0;
-	unsigned int		c;
+	size_t			i = 0;
+	size_t			c;
 
 	while (c = *s++) HASHPART(i, c);
 	return i;

--- a/src/lib/libast/hash/strsum.c
+++ b/src/lib/libast/hash/strsum.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2023 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 /*
@@ -40,7 +41,7 @@ strsum(const char* as, unsigned long c)
 	const unsigned char*	s = (const unsigned char*)as;
 	int			n;
 
-	while (n = *s++) HASHPART(c, n);
+	while (n = *s++) HASHPART(c, (size_t)n);
 #if LONG_MAX > 2147483647
 	return c & 0xffffffff;
 #else

--- a/src/lib/libast/include/ast.h
+++ b/src/lib/libast/include/ast.h
@@ -157,6 +157,11 @@
 #define PATH_TOUCH_VERBATIM	02
 
 /*
+ * regex flags type (included here for the strgrpmatch() family)
+ */
+typedef uint32_t regflags_t;
+
+/*
  * strgrpmatch() flags
  */
 
@@ -165,7 +170,6 @@
 #define STR_RIGHT	0x04		/* implicit right anchor	*/
 #define STR_ICASE	0x08		/* ignore case			*/
 #define STR_GROUP	0x10		/* (|&) inside [@|&](...) only	*/
-#define STR_INT		0x20		/* int* match array		*/
 
 /*
  * fmtquote() flags
@@ -216,7 +220,7 @@
 			( (p+=ast.mb.tmp_i),ast.mb.tmp_w) : (p+=ast.mb.sync+1,ast.mb.tmp_i) ) : (*(unsigned char*)(p++)) )
 #define mbsize(p)	mbnsize(p, mbmax())
 #define mbnsize(p,n)	( mbwide() ? (*ast.mb.len)((char*)(p), n) : ((p), 1) )
-#define mbconv(s,w)	( ast.mb.conv ? (*ast.mb.conv)(s,w) : ((*(s)=(w)), 1) )
+#define mbconv(s,w)	( ast.mb.conv ? (*ast.mb.conv)(s,w) : ((*(s)=(char)(w)), 1) )
 #define mbwidth(w)	( ast.mb.width ? (*ast.mb.width)(w) : (w >= 0 && w <= 255 && !iscntrl(w) ? 1 : -1) )
 #define mbalpha(w)	( ast.mb.alpha ? (*ast.mb.alpha)(w) : isalpha((w) & 0xff) )
 
@@ -232,7 +236,7 @@
 #define mbnchar(p,n)	mbchar(p)
 #define mbsize(p)	1
 #define mbnsize(p,n)	1
-#define mbconv(s,w)	( (*(s)=(w)), 1 )
+#define mbconv(s,w)	( (*(s)=(char)(w)), 1 )
 #define mbwidth(w)	( w >= 0 && w <= 255 && !iscntrl(w) ? 1 : -1 )
 #define mbalpha(w)	( isalpha((w) & 0xff) )
 
@@ -250,7 +254,6 @@
 #define oldof(p,t,n,x)	((p)?(t*)realloc((char*)(p),sizeof(t)*(n)+(x)):(t*)malloc(sizeof(t)*(n)+(x)))
 #define pointerof(x)	((void*)((uintptr_t)(x)))
 #define roundof(x,y)	(((x)+(y)-1)&~((y)-1))
-#define ssizeof(x)	((int)sizeof(x))
 
 #define streq(a,b)	(!strcmp(a,b))
 #define strneq(a,b,n)	(!strncmp(a,b,n))
@@ -318,7 +321,7 @@ extern char*		conformance(const char*, size_t);
 extern char*		getcodeset(void);
 extern char*		fmtbuf(size_t);
 extern char*		fmtclock(Sfulong_t);
-extern char*		fmtelapsed(unsigned long, int);
+extern char*		fmtelapsed(unsigned long, unsigned long);
 extern char*		fmtesc(const char*);
 extern char*		fmtesq(const char*, const char*);
 extern char*		fmtident(const char*);
@@ -327,18 +330,18 @@ extern char*		fmtfmt(const char*);
 extern char*		fmtgid(int);
 extern char*		fmtint(intmax_t, int);
 extern char*		fmtmatch(const char*);
-extern char*		fmtmode(int, int);
+extern char*		fmtmode(mode_t, int);
 extern char*		fmtnesq(const char*, const char*, size_t);
 extern char*		fmtnum(unsigned long, int);
-extern char*		fmtperm(int);
+extern char*		fmtperm(mode_t);
 extern char*		fmtquote(const char*, const char*, const char*, size_t, int);
 extern char*		fmtre(const char*);
-extern char*		fmtscale(Sfulong_t, int);
+extern char*		fmtscale(Sfulong_t, unsigned int);
 extern char*		fmtsignal(int);
 extern char*		fmttime(const char*, time_t);
 extern char*		fmtuid(int);
 extern void*		memdup(const void*, size_t);
-extern unsigned int	memhash(const void*, int);
+extern size_t		memhash(const void*, int);
 extern unsigned long	memsum(const void*, int, unsigned long);
 extern char*		pathaccess(char*, const char*, const char*, const char*, int);
 extern char*		pathaccess_20100601(const char*, const char*, const char*, int, char*, size_t);
@@ -350,7 +353,7 @@ extern char*		pathcat_20100601(const char*, int, const char*, const char*, char*
 extern int		pathcd(const char*, const char*);
 extern int		pathexists(char*, int);
 extern char*		pathfind(const char*, const char*, const char*, char*, size_t);
-extern int		pathgetlink(const char*, char*, int);
+extern ssize_t		pathgetlink(const char*, char*, size_t);
 extern int		pathicase(const char*);
 extern int		pathinclude(const char*);
 extern size_t		pathnative(const char*, char*, size_t);
@@ -371,12 +374,12 @@ extern int		strexp(char*, int);
 extern long		streval(const char*, char**, long(*)(const char*, char**));
 extern long		strexpr(const char*, char**, long(*)(const char*, char**, void*), void*);
 extern int		strgid(const char*);
-extern int		strgrpmatch(const char*, const char*, ssize_t*, int, int);
-extern int		strngrpmatch(const char*, size_t, const char*, ssize_t*, int, int);
-extern unsigned int	strhash(const char*);
+extern ssize_t		strgrpmatch(const char*, const char*, ssize_t*, ssize_t, regflags_t);
+extern ssize_t		strngrpmatch(const char*, size_t, const char*, ssize_t*, ssize_t, regflags_t);
+extern size_t		strhash(const char*);
 extern void*		strlook(const void*, size_t, const char*);
-extern int		strmatch(const char*, const char*);
-extern int		strmode(const char*);
+extern ssize_t		strmatch(const char*, const char*);
+extern mode_t		strmode(const char*);
 extern char*		strncopy(char*, const char*, size_t);
 extern int		strnpcmp(const char*, const char*, size_t);
 extern double		strntod(const char*, size_t, char**);
@@ -390,11 +393,11 @@ extern uintmax_t	strntoull(const char*, size_t, char**, int);
 extern int		strnvcmp(const char*, const char*, size_t);
 extern int		stropt(const char*, const void*, int, int(*)(void*, const void*, int, const char*), void*);
 extern int		strpcmp(const char*, const char*);
-extern int		strperm(const char*, char**, int);
+extern mode_t		strperm(const char*, char**, mode_t);
 extern void*		strpsearch(const void*, size_t, size_t, const char*, char**);
 extern void*		strsearch(const void*, size_t, size_t, Strcmp_f, const char*, void*);
 extern void		strsort(char**, int, int(*)(const char*, const char*));
-extern char*		strsubmatch(const char*, const char*, int);
+extern char*		strsubmatch(const char*, const char*, regflags_t);
 extern unsigned long	strsum(const char*, unsigned long);
 extern char*		strtape(const char*, char**);
 extern int		strtoip4(const char*, char**, uint32_t*, unsigned char*);

--- a/src/lib/libast/include/hash.h
+++ b/src/lib/libast/include/hash.h
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2023 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 /*
@@ -118,7 +119,7 @@ typedef struct Hash_table Hash_table_t;
 
 #define HASH_HEADER			/* common bucket header		*/ \
 	Hash_bucket_t*	next;		/* next in collision chain	*/ \
-	unsigned int	hash;		/* hash flags and value		*/ \
+	unsigned long	hash;		/* hash flags and value		*/ \
 	char*		name		/* key name			*/
 
 #define HASH_DEFAULT			/* HASH_VALUE bucket elements	*/ \
@@ -167,7 +168,7 @@ struct Hash_root			/* root hash table information	*/
 struct Hash_table			/* hash table information	*/
 {
 	Hash_root_t*	root;		/* root hash table information	*/
-	int		size;		/* table size			*/
+	ssize_t		size;		/* table size			*/
 	int		buckets;	/* active bucket count		*/
 	char*		name;		/* table name			*/
 	Hash_table_t*	scope;		/* scope covered table		*/
@@ -185,7 +186,7 @@ extern Hash_bucket_t*	hashlast(Hash_table_t*);
 extern char*		hashlook(Hash_table_t*, const char*, long, const char*);
 extern Hash_bucket_t*	hashnext(Hash_position_t*);
 extern Hash_position_t*	hashscan(Hash_table_t*, int);
-extern void		hashsize(Hash_table_t*, int);
+extern void		hashsize(Hash_table_t*, ssize_t);
 extern Hash_table_t*	hashview(Hash_table_t*, Hash_table_t*);
 extern int		hashwalk(Hash_table_t*, int, int (*)(const char*, char*, void*), void*);
 

--- a/src/lib/libast/include/modex.h
+++ b/src/lib/libast/include/modex.h
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 /*
@@ -28,8 +29,8 @@
 #include <ast_fs.h>
 #include <modecanon.h>
 
-extern int		modei(int);
-extern int		modex(int);
+extern mode_t		modei(mode_t);
+extern mode_t		modex(mode_t);
 
 #if _S_IDPERM
 #define modei(m)	((m)&X_IPERM)

--- a/src/lib/libast/include/regex.h
+++ b/src/lib/libast/include/regex.h
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2012 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2025 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -40,66 +40,66 @@
 
 /* regcomp flags */
 
-#define REG_AUGMENTED	0x00000001	/* enable ! & < >		*/
-#define REG_EXTENDED	0x00000002	/* enable ( | )			*/
-#define REG_ICASE	0x00000004	/* ignore case in match		*/
-#define REG_NEWLINE	0x00000008	/* ^/$ match embedded \n	*/
-#define REG_NOSUB	0x00000010	/* don't report subexp matches	*/
-#define REG_SHELL	0x00000020	/* shell pattern syntax		*/
+#define REG_AUGMENTED	0x00000001U	/* enable ! & < >		*/
+#define REG_EXTENDED	0x00000002U	/* enable ( | )			*/
+#define REG_ICASE	0x00000004U	/* ignore case in match		*/
+#define REG_NEWLINE	0x00000008U	/* ^/$ match embedded \n	*/
+#define REG_NOSUB	0x00000010U	/* don't report subexp matches	*/
+#define REG_SHELL	0x00000020U	/* shell pattern syntax		*/
 
 /* nonstandard regcomp flags */
 
-#define REG_LEFT	0x00000100	/* implicit ^...		*/
-#define REG_LITERAL	0x00000200	/* no operators			*/
-#define REG_MINIMAL	0x00000400	/* minimal match		*/
-#define REG_NULL	0x00000800	/* allow null patterns		*/
-#define REG_RIGHT	0x00001000	/* implicit ...$		*/
-#define REG_LENIENT	0x00002000	/* look the other way		*/
-#define REG_ESCAPE	0x00004000	/* \ escapes delimiter in [...]	*/
-#define REG_FIRST	0x00008000	/* first match found will do	*/
-#define REG_MULTIPLE	0x00010000	/* multiple \n sep patterns	*/
-#define REG_DISCIPLINE	0x00020000	/* regex_t.re_disc is valid	*/
-#define REG_SPAN	0x00040000	/* . matches \n			*/
-#define REG_COMMENT	0x00080000	/* ignore pattern space & #...\n*/
-#define REG_MULTIREF	0x00100000	/* multiple digit backrefs	*/
-#define REG_MUSTDELIM	0x08000000	/* all delimiters required	*/
-#define REG_DELIMITED	0x10000000	/* pattern[0] is delimiter	*/
-#define REG_CLASS_ESCAPE 0x80000000	/* \ escapes in [...]		*/
+#define REG_LEFT	0x00000100U	/* implicit ^...		*/
+#define REG_LITERAL	0x00000200U	/* no operators			*/
+#define REG_MINIMAL	0x00000400U	/* minimal match		*/
+#define REG_NULL	0x00000800U	/* allow null patterns		*/
+#define REG_RIGHT	0x00001000U	/* implicit ...$		*/
+#define REG_LENIENT	0x00002000U	/* look the other way		*/
+#define REG_ESCAPE	0x00004000U	/* \ escapes delimiter in [...]	*/
+#define REG_FIRST	0x00008000U	/* first match found will do	*/
+#define REG_MULTIPLE	0x00010000U	/* multiple \n sep patterns	*/
+#define REG_DISCIPLINE	0x00020000U	/* regex_t.re_disc is valid	*/
+#define REG_SPAN	0x00040000U	/* . matches \n			*/
+#define REG_COMMENT	0x00080000U	/* ignore pattern space & #...\n*/
+#define REG_MULTIREF	0x00100000U	/* multiple digit backrefs	*/
+#define REG_MUSTDELIM	0x08000000U	/* all delimiters required	*/
+#define REG_DELIMITED	0x10000000U	/* pattern[0] is delimiter	*/
+#define REG_CLASS_ESCAPE 0x80000000U	/* \ escapes in [...]		*/
 
-#define REG_SHELL_DOT	0x00200000	/* explicit leading . match	*/
-#define REG_SHELL_ESCAPED 0x00400000	/* \ not special		*/
-#define REG_SHELL_GROUP	0x20000000	/* (|&) inside [@|&](...) only	*/
-#define REG_SHELL_PATH	0x00800000	/* explicit / match		*/
+#define REG_SHELL_DOT	0x00200000U	/* explicit leading . match	*/
+#define REG_SHELL_ESCAPED 0x00400000U	/* \ not special		*/
+#define REG_SHELL_GROUP	0x20000000U	/* (|&) inside [@|&](...) only	*/
+#define REG_SHELL_PATH	0x00800000U	/* explicit / match		*/
 
-#define REG_REGEXP	0x40000000	/* <regexp.h> compatibility	*/
+#define REG_REGEXP	0x40000000U	/* <regexp.h> compatibility	*/
 
 /* regexec flags */
 
-#define REG_NOTBOL	0x00000040	/* ^ is not a special char	*/
-#define REG_NOTEOL	0x00000080	/* $ is not a special char	*/
+#define REG_NOTBOL	0x00000040U	/* ^ is not a special char	*/
+#define REG_NOTEOL	0x00000080U	/* $ is not a special char	*/
 
 /* nonstandard regexec flags */
 
-#define REG_INVERT	0x01000000	/* invert regrexec match sense	*/
-#define REG_STARTEND	0x02000000	/* subject==match[0].rm_{so,eo} */
-#define REG_ADVANCE	0x04000000	/* advance match[0].rm_{so,eo}	*/
+#define REG_INVERT	0x01000000U	/* invert regrexec match sense	*/
+#define REG_STARTEND	0x02000000U	/* subject==match[0].rm_{so,eo} */
+#define REG_ADVANCE	0x04000000U	/* advance match[0].rm_{so,eo}	*/
 
 /* regalloc flags */
 
-#define REG_NOFREE	0x00000001	/* don't free			*/
+#define REG_NOFREE	0x00000001U	/* don't free			*/
 
 /* regsubcomp/regsubexec flags */
 
-#define REG_SUB_ALL	0x00000001	/* substitute all occurrences	*/
-#define REG_SUB_LOWER	0x00000002	/* substitute to lower case	*/
-#define REG_SUB_UPPER	0x00000004	/* substitute to upper case	*/
-#define REG_SUB_PRINT	0x00000010	/* internal no-op		*/
-#define REG_SUB_NUMBER	0x00000020	/* internal no-op		*/
-#define REG_SUB_STOP	0x00000040	/* internal no-op		*/
-#define REG_SUB_WRITE	0x00000080	/* internal no-op		*/
-#define REG_SUB_LAST	0x00000100	/* last substitution option	*/
-#define REG_SUB_FULL	0x00000200	/* fully delimited		*/
-#define REG_SUB_USER	0x00001000	/* first user flag bit		*/
+#define REG_SUB_ALL	0x00000001U	/* substitute all occurrences	*/
+#define REG_SUB_LOWER	0x00000002U	/* substitute to lower case	*/
+#define REG_SUB_UPPER	0x00000004U	/* substitute to upper case	*/
+#define REG_SUB_PRINT	0x00000010U	/* internal no-op		*/
+#define REG_SUB_NUMBER	0x00000020U	/* internal no-op		*/
+#define REG_SUB_STOP	0x00000040U	/* internal no-op		*/
+#define REG_SUB_WRITE	0x00000080U	/* internal no-op		*/
+#define REG_SUB_LAST	0x00000100U	/* last substitution option	*/
+#define REG_SUB_FULL	0x00000200U	/* fully delimited		*/
+#define REG_SUB_USER	0x00001000U	/* first user flag bit		*/
 
 /* regex error codes */
 
@@ -129,7 +129,6 @@ struct regex_s; typedef struct regex_s regex_t;
 struct regdisc_s; typedef struct regdisc_s regdisc_t;
 
 typedef int (*regclass_t)(int);
-typedef uint32_t regflags_t;
 typedef int (*regerror_t)(const regex_t*, regdisc_t*, int, ...);
 typedef void* (*regcomp_t)(const regex_t*, const char*, size_t, regdisc_t*);
 typedef int (*regexec_t)(const regex_t*, void*, const char*, size_t, const char*, size_t, char**, regdisc_t*);
@@ -153,7 +152,7 @@ typedef struct regsub_s
 	regflags_t	re_flags;	/* regsubcomp() flags		*/
 	char*		re_buf;		/* regsubexec() output buffer	*/
 	size_t		re_len;		/* re_buf length		*/
-	int		re_min;		/* regsubcomp() min matches	*/
+	ssize_t		re_min;		/* regsubcomp() min matches	*/
 #ifdef _REG_SUB_PRIVATE_
 	_REG_SUB_PRIVATE_
 #endif

--- a/src/lib/libast/include/sfio.h
+++ b/src/lib/libast/include/sfio.h
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2012 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2025 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -60,7 +60,7 @@ struct _sfdisc_s
 typedef struct _sffmt_s	Sffmt_t;
 typedef int		(*Sffmtext_f)(Sfio_t*, void*, Sffmt_t*);
 typedef int		(*Sffmtevent_f)(Sfio_t*, int, void*, Sffmt_t*);
-typedef int		(*Sffmtreload_f)(int, char, void*, Sffmt_t*);
+typedef ptrdiff_t	(*Sffmtreload_f)(ptrdiff_t, char, void*, Sffmt_t*);
 struct _sffmt_s
 {	long		version;/* version of this structure		*/
 	Sffmtext_f	extf;	/* function to process arguments	*/
@@ -71,14 +71,14 @@ struct _sffmt_s
 	va_list		args;	/* corresponding arg list		*/
 
 	int		fmt;	/* format character			*/
-	ssize_t		size;	/* object size				*/
+	ptrdiff_t	size;	/* object size				*/
 	int		flags;	/* formatting flags			*/
-	int		width;	/* width of field			*/
-	int		precis;	/* precision required			*/
-	int		base;	/* conversion base			*/
+	ptrdiff_t	width;	/* width of field			*/
+	ptrdiff_t	precis;	/* precision required			*/
+	ptrdiff_t	base;	/* conversion base			*/
 
 	char*		t_str;	/* type string 				*/
-	ssize_t		n_str;	/* length of t_str 			*/
+	ptrdiff_t	n_str;	/* length of t_str 			*/
 
 	void*		mbs;	/* multibyte state for format string	*/
 };
@@ -86,7 +86,7 @@ struct _sffmt_s
 		((type) ? ((fe)->version = SFIO_VERSION) : (fe)->version)
 
 #define SFFMT_SSHORT	000000010 /* 'hh' flag, char			*/
-#define SFFMT_TFLAG	000000020 /* 't' flag, ptrdiff_t		*/
+#define SFFMT_TFLAG	000000020 /* 't' flag, ssize_t			*/
 #define SFFMT_ZFLAG	000000040 /* 'z' flag, size_t			*/
 
 #define SFFMT_LEFT	000000100 /* left-justification			*/
@@ -138,10 +138,6 @@ struct _sffmt_s
 #define SFIO_FLAGS	0177177	/* PUBLIC FLAGS PASSABLE TO SFNEW()	*/
 #define SFIO_SETS	0177163	/* flags passable to sfset()		*/
 
-#ifndef _SFIO_NO_OBSOLETE
-#define SFIO_BUFCONST	0400000 /* unused flag - for compatibility only	*/
-#endif
-
 /* for sfgetr/sfreserve to hold a record */
 #define SFIO_LOCKR	0000010	/* lock record, stop access to stream	*/
 #define SFIO_LASTR	0000020	/* get the last incomplete record	*/
@@ -184,7 +180,7 @@ extern Sfio_t		_Sfstdin;
 extern Sfio_t		_Sfstdout;
 extern Sfio_t		_Sfstderr;
 
-extern Sfio_t*		sfnew(Sfio_t*, void*, size_t, int, int);
+extern Sfio_t*		sfnew(Sfio_t*, void*, size_t, int, unsigned short);
 extern Sfio_t*		sfopen(Sfio_t*, const char*, const char*);
 extern Sfio_t*		sfpopen(Sfio_t*, const char*, const char*);
 extern Sfio_t*		sfstack(Sfio_t*, Sfio_t*);
@@ -211,17 +207,17 @@ extern Sfoff_t		sfmove(Sfio_t*, Sfio_t*, Sfoff_t, int);
 extern int		sfclose(Sfio_t*);
 extern Sfoff_t		sftell(Sfio_t*);
 extern Sfoff_t		sfseek(Sfio_t*, Sfoff_t, int);
-extern ssize_t		sfputr(Sfio_t*, const char*, int);
+extern ptrdiff_t	sfputr(Sfio_t*, const char*, int);
 extern char*		sfgetr(Sfio_t*, int, int);
 extern ssize_t		sfnputc(Sfio_t*, int, size_t);
 extern int		sfungetc(Sfio_t*, int);
-extern int		sfprintf(Sfio_t*, const char*, ...);
+extern ssize_t		sfprintf(Sfio_t*, const char*, ...);
 extern char*		sfprints(const char*, ...);
 extern ssize_t		sfaprints(char**, const char*, ...);
 extern ssize_t		sfsprintf(char*, size_t, const char*, ...);
 extern ssize_t		sfvsprintf(char*, size_t, const char*, va_list);
 extern ssize_t		sfvasprints(char**, const char*, va_list);
-extern int		sfvprintf(Sfio_t*, const char*, va_list);
+extern ssize_t		sfvprintf(Sfio_t*, const char*, va_list);
 extern int		sfscanf(Sfio_t*, const char*, ...);
 extern int		sfsscanf(const char*, const char*, ...);
 extern int		sfvsscanf(const char*, const char*, va_list);
@@ -238,11 +234,11 @@ extern int		sfdlen(Sfdouble_t);
 extern int		sfllen(Sflong_t);
 extern int		sfulen(Sfulong_t);
 
-extern int		sfputd(Sfio_t*, Sfdouble_t);
-extern int		sfputl(Sfio_t*, Sflong_t);
-extern int		sfputu(Sfio_t*, Sfulong_t);
-extern int		sfputm(Sfio_t*, Sfulong_t, Sfulong_t);
-extern int		sfputc(Sfio_t*, int);
+extern ssize_t		sfputd(Sfio_t*, Sfdouble_t);
+extern ssize_t		sfputl(Sfio_t*, Sflong_t);
+extern ssize_t		sfputu(Sfio_t*, Sfulong_t);
+extern ssize_t		sfputm(Sfio_t*, Sfulong_t, Sfulong_t);
+extern ssize_t		sfputc(Sfio_t*, int);
 
 extern Sfdouble_t	sfgetd(Sfio_t*);
 extern Sflong_t		sfgetl(Sfio_t*);
@@ -250,13 +246,13 @@ extern Sfulong_t	sfgetu(Sfio_t*);
 extern Sfulong_t	sfgetm(Sfio_t*, Sfulong_t);
 extern int		sfgetc(Sfio_t*);
 
-extern int		_sfputd(Sfio_t*, Sfdouble_t);
-extern int		_sfputl(Sfio_t*, Sflong_t);
-extern int		_sfputu(Sfio_t*, Sfulong_t);
-extern int		_sfputm(Sfio_t*, Sfulong_t, Sfulong_t);
-extern int		_sfflsbuf(Sfio_t*, int);
+extern ssize_t		_sfputd(Sfio_t*, Sfdouble_t);
+extern ssize_t		_sfputl(Sfio_t*, Sflong_t);
+extern ssize_t		_sfputu(Sfio_t*, Sfulong_t);
+extern ssize_t		_sfputm(Sfio_t*, Sfulong_t, Sfulong_t);
 
-extern int		_sffilbuf(Sfio_t*, int);
+extern ptrdiff_t	_sfflsbuf(Sfio_t*, ptrdiff_t);
+extern ptrdiff_t	_sffilbuf(Sfio_t*, ptrdiff_t);
 
 extern int		_sfdlen(Sfdouble_t);
 extern int		_sfllen(Sflong_t);
@@ -270,7 +266,7 @@ extern int		sferror(Sfio_t*);
 extern int		sffileno(Sfio_t*);
 extern int		sfstacked(Sfio_t*);
 extern ssize_t		sfvalue(Sfio_t*);
-extern ssize_t		sfslen(void);
+extern ptrdiff_t	sfslen(void);
 extern ssize_t		sfmaxr(ssize_t, int);
 
 /* coding long integers in a portable and compact fashion */
@@ -295,7 +291,7 @@ extern ssize_t		sfmaxr(ssize_t, int);
 #define __sf_putc(f,c)	(_SFIO_(f)->_next >= _SFIO_(f)->_endw ? \
 			 _sfflsbuf(_SFIO_(f),(int)((unsigned char)(c))) : \
 			 (int)(*_SFIO_(f)->_next++ = (unsigned char)(c)) )
-#define __sf_getc(f)	(_SFIO_(f)->_next >= _SFIO_(f)->_endr ? _sffilbuf(_SFIO_(f),0) : \
+#define __sf_getc(f)	(_SFIO_(f)->_next >= _SFIO_(f)->_endr ? (int)_sffilbuf(_SFIO_(f),0) : \
 			 (int)(*_SFIO_(f)->_next++) )
 
 #define __sf_dlen(v)	(_sfdlen((Sfdouble_t)(v)) )
@@ -364,7 +360,7 @@ __INLINE__ ssize_t sfmaxr(ssize_t n, int s)	{ return __sf_maxr(n,s); }
 #ifndef _SFSTR_H /* GSF's string manipulation stuff */
 #define _SFSTR_H		1
 
-#define sfstropen()		sfnew(0, 0, -1, -1, SFIO_READ|SFIO_WRITE|SFIO_STRING)
+#define sfstropen()		sfnew(0, 0, (size_t)-1, -1, SFIO_READ|SFIO_WRITE|SFIO_STRING)
 #define sfstrclose(f)		sfclose(f)
 
 #define sfstrseek(f,p,m) \

--- a/src/lib/libast/include/sfio_s.h
+++ b/src/lib/libast/include/sfio_s.h
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 #ifndef _SFIO_S_H
@@ -36,7 +37,7 @@ struct _sfio_s
 	unsigned char*	_endb;	/* end of buffer			*/
 	struct _sfio_s*	_push;	/* the stream that was pushed on	*/
 	unsigned short	_flags;	/* type of stream			*/
-	short		_file;	/* file descriptor			*/
+	int		_file;	/* file descriptor			*/
 	unsigned char*	_data;	/* base of data buffer			*/
 	ssize_t		_size;	/* buffer size				*/
 	ssize_t		_val;	/* values or string lengths		*/

--- a/src/lib/libast/include/sfio_t.h
+++ b/src/lib/libast/include/sfio_t.h
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2012 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2025 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -76,7 +76,7 @@
 	  (short)(file),				/* file		*/ \
 	  (unsigned char*)(data),			/* data		*/ \
 	  (ssize_t)(size),				/* size		*/ \
-	  (ssize_t)(-1),				/* val		*/ \
+	  -1,						/* val		*/ \
 	  0,						/* extent	*/ \
 	  0,						/* here		*/ \
 	  0,						/* ngetr	*/ \

--- a/src/lib/libast/man/fmt.3
+++ b/src/lib/libast/man/fmt.3
@@ -46,13 +46,13 @@ fmt \- string formatting routines
 
 char*      fmtint(intmax_t \fInumber\fP, int \fIunsign\fP);
 char*      fmtdev(struct stat* \fIst\fP);
-char*      fmtelapsed(unsigned long \fIcount\fP, int \fIpersec\fP)
+char*      fmtelapsed(unsigned long \fIcount\fP, unsigned long \fIpersec\fP)
 char*      fmtesc(const char* \fIstring\fP);
 char*      fmtfs(struct stat* \fIst\fP);
 char*      fmtgid(int \fIgid\fP);
 char*      fmtmatch(const char* \fIre\fP);
-char*      fmtmode(int \fImode\fP, int \fIexternal\fP);
-char*      fmtperm(int \fIperm\fP);
+char*      fmtmode(mode_t \fImode\fP, int \fIexternal\fP);
+char*      fmtperm(mode_t \fIperm\fP);
 char*      fmtre(const char* \fIpattern\fP);
 char*      fmtsignal(int \fIsig\fP);
 char*      fmttime(const char* \fIformat\fP, time_t \fItm\fP);

--- a/src/lib/libast/man/hash.3
+++ b/src/lib/libast/man/hash.3
@@ -580,7 +580,7 @@ then the hash bucket
 .I key-value
 pairs for each collision chain are also dumped.
 .TP
-.L "void hashsize(Hash_table_t* tab, int size)"
+.L "void hashsize(Hash_table_t* tab, ssize_t size)"
 Changes the size of the hash table
 .L tab
 to
@@ -591,22 +591,22 @@ must be a power of 2.
 Explicit calls to this routine are not necessary as hash tables
 are automatically resized.
 .TP
-.L "int strhash(char* name)"
+.L "size_t strhash(char* name)"
 Hashes the null-terminated character string
 .L name
 using a linear congruent pseudo-random number generator algorithm
 and returns a non-negative
-.L int
+.L size_t
 hash value.
 .TP
-.L "int memhash(char* buf, int siz)"
+.L "size_t memhash(char* buf, int siz)"
 Hashes the buffer
 .L buf
 of
 .L siz
 bytes using a linear congruent pseudo-random number generator algorithm
 and returns a non-negative
-.L int
+.L size_t
 hash value.
 .TP
 .L "long strsum(char* name, long sum)"

--- a/src/lib/libast/man/modecanon.3
+++ b/src/lib/libast/man/modecanon.3
@@ -46,8 +46,8 @@ modecanon \- canonical file mode representation
 .EX
 #include <modex.h>
 
-int    modei(int \fIexternal\fP);
-int    modex(int \fIinternal\fP);
+mode_t modei(mode_t \fIexternal\fP);
+mode_t modex(mode_t \fIinternal\fP);
 .EE
 .SH DESCRIPTION
 POSIX threw out the file type bit macros and replaced them with

--- a/src/lib/libast/man/path.3
+++ b/src/lib/libast/man/path.3
@@ -51,7 +51,7 @@ char*     pathbin(void);
 char*     pathcanon(char* \fIpath\fP, int \fIflags\fP);
 char*     pathcat(char* \fIpath\fP, const char* \fIdirs\fP, int \fIsep\fP, const char* \fIa\fP, const char* \fIb\fP);
 char*     pathcd(char* \fIpath\fP, const char* \fIhome\fP);
-int       pathgetlink(const char* \fIname\fP, char* \fIbuf\fP, int \fIsiz\fP);
+ssize_t   pathgetlink(const char* \fIname\fP, char* \fIbuf\fP, size_t \fIsiz\fP);
 int       pathicase(const char* \fIpath\fP);
 char*     pathnext(char* \fIpath\fP, char* \fIextra\fP, long* \fIvisits\fP);
 char*     pathpath(char* \fIpath\fP, const char* \fIp\fP, const char* \fIa\fP, int \fImode\fP);

--- a/src/lib/libast/man/sfio.3
+++ b/src/lib/libast/man/sfio.3
@@ -81,45 +81,45 @@ int        sfstrclose(Sfio_t* f);
 .nf
 .ft 5
 int        sfgetc(Sfio_t* f);
-int        sfputc(Sfio_t* f, int c);
+ssize_t    sfputc(Sfio_t* f, int c);
 ssize_t    sfnputc(Sfio_t* f, int c, size_t n);
 int        sfungetc(Sfio_t* f, int c);
 
 Sfulong_t  sfgetm(Sfio_t* f, Sfulong_t max);
-int        sfputm(Sfio_t* f, Sfulong_t v, Sfulong_t max);
+ssize_t    sfputm(Sfio_t* f, Sfulong_t v, Sfulong_t max);
 Sfulong_t  sfgetu(Sfio_t* f);
-int        sfputu(Sfio_t* f, Sfulong_t v);
+ssize_t    sfputu(Sfio_t* f, Sfulong_t v);
 Sflong_t   sfgetl(Sfio_t* f);
-int        sfputl(Sfio_t* f, Sflong_t v);
+ssize_t    sfputl(Sfio_t* f, Sflong_t v);
 Sfdouble_t sfgetd(Sfio_t* f);
-int        sfputd(Sfio_t* f, Sfdouble_t v);
+ssize_t    sfputd(Sfio_t* f, Sfdouble_t v);
 
-char*      sfgetr(Sfio_t* f, int rsc, int type);
-ssize_t    sfputr(Sfio_t* f, const char* s, int rsc);
-Sfoff_t    sfmove(Sfio_t* fr, Sfio_t* fw, Sfoff_t n, int rsc);
+char*     sfgetr(Sfio_t* f, int rsc, int type);
+ptrdiff_t sfputr(Sfio_t* f, const char* s, int rsc);
+Sfoff_t   sfmove(Sfio_t* fr, Sfio_t* fw, Sfoff_t n, int rsc);
 
-ssize_t    sfread(Sfio_t* f, void* buf, size_t n);
-ssize_t    sfwrite(Sfio_t* f, const void* buf, size_t n);
-Sfoff_t    sfseek(Sfio_t* f, Sfoff_t offset, int type);
-void*      sfreserve(Sfio_t* f, ssize_t n, int type);
+ssize_t   sfread(Sfio_t* f, void* buf, size_t n);
+ssize_t   sfwrite(Sfio_t* f, const void* buf, size_t n);
+Sfoff_t   sfseek(Sfio_t* f, Sfoff_t offset, int type);
+void*     sfreserve(Sfio_t* f, ssize_t n, int type);
 .ft 1
 .fi
 .Ss "DATA FORMATTING"
 .nf
 .ft 5
-int        sfscanf(Sfio_t* f, const char* format, ...);
-int        sfsscanf(const char* s, const char* format, ...);
-int        sfvsscanf(const char* s, const char* format, va_list args);
-int        sfvscanf(Sfio_t* f, const char* format, va_list args);
+int       sfscanf(Sfio_t* f, const char* format, ...);
+int       sfsscanf(const char* s, const char* format, ...);
+int       sfvsscanf(const char* s, const char* format, va_list args);
+int       sfvscanf(Sfio_t* f, const char* format, va_list args);
 
-int        sfprintf(Sfio_t* f, const char* format, ...);
-char*      sfprints(const char* format, ...);
-char*      sfvprints(const char* format, va_list args);
-ssize_t    sfaprints(char** sp, const char* format, ...);
-ssize_t    sfvaprints(char** sp, const char* format, va_list args);
-ssize_t    sfsprintf(char* s, size_t n, const char* format, ...);
-ssize_t    sfvsprintf(char* s, size_t n, const char* format, va_list args);
-int        sfvprintf(Sfio_t* f, const char* format, va_list args);
+ssize_t   sfprintf(Sfio_t* f, const char* format, ...);
+char*     sfprints(const char* format, ...);
+char*     sfvprints(const char* format, va_list args);
+ssize_t   sfaprints(char** sp, const char* format, ...);
+ssize_t   sfvaprints(char** sp, const char* format, va_list args);
+ssize_t   sfsprintf(char* s, size_t n, const char* format, ...);
+ssize_t   sfvsprintf(char* s, size_t n, const char* format, va_list args);
+ssize_t   sfvprintf(Sfio_t* f, const char* format, va_list args);
 
 Sffmt_t;
 
@@ -219,7 +219,7 @@ int        sfwalk(Sfwalk_f walkf, void* data, int type);
 .nf
 .ft 5
 ssize_t    sfmaxr(ssize_t maxr, int s);
-ssize_t    sfslen();
+ptrdiff_t  sfslen();
 int        sfulen(Sfulong_t v);
 int        sfllen(Sflong_t v);
 int        sfdlen(Sfdouble_t v);
@@ -535,7 +535,7 @@ is \f3/bin/sh\fP or \f3/bin/ksh\fP, \f3sfpopen()\fP may execute the
 command \f3cmd\fP itself if there are no shell meta-characters in \f3cmd\fP.
 .Ss "  Sfio_t* sfstropen(void)"
 Shorthand that opens a new string buffer for reading and writing;
-same as \f3sfnew(NULL,NULL,-1,-1,SFIO_READ|SFIO_WRITE|SFIO_STRING)\fP.
+same as \f3sfnew(NULL,NULL,(size_t)-1,-1,SFIO_READ|SFIO_WRITE|SFIO_STRING)\fP.
 See also
 .BR sfstruse() .
 .Ss "  Sfio_t* sftmp(size_t size)"
@@ -590,7 +590,7 @@ but intended for string buffers opened with
 .BR sfstropen() .
 .Ss "INPUT/OUTPUT OPERATIONS"
 .Ss "  int sfgetc(Sfio_t* f)"
-.Ss "  int sfputc(Sfio_t* f, int c)"
+.Ss "  ssize_t sfputc(Sfio_t* f, int c)"
 These functions read/write a byte from/to stream \f3f\fP.
 \f3sfgetc()\fP returns the byte read or \f3-1\fP on error.
 \f3sfputc()\fP returns \f3c\fP on success and \f3-1\fP on error.
@@ -608,7 +608,7 @@ buffered data will be discarded on any operation that implies
 buffer synchronization.
 \f3sfungetc()\fP returns \f3c\fP on success and \f3-1\fP on failure.
 .Ss "  Sfulong_t sfgetm(Sfio_t* f, Sfulong_t max)"
-.Ss "  int sfputm(Sfio_t* f, Sfulong_t v, Sfulong_t max)"
+.Ss "  ssize_t sfputm(Sfio_t* f, Sfulong_t v, Sfulong_t max)"
 These functions read and write \f3Sfulong_t\fP values
 encoded in a portable format given that the values are at most \f3max\fP.
 Portability across a write architecture and a read architecture
@@ -617,7 +617,7 @@ the written value is storable in an \f3Sfulong_t\fP on the read architecture.
 \f3sfgetm()\fP returns the value read or \f3-1\fP on error.
 \f3sfputm()\fP returns the number of bytes written or \f3-1\fP on error.
 .Ss "  Sfulong_t sfgetu(Sfio_t* f)"
-.Ss "  int sfputu(Sfio_t* f, Sfulong_t v)"
+.Ss "  ssize_t sfputu(Sfio_t* f, Sfulong_t v)"
 These functions read and write \f3Sfulong_t\fP values
 in a compact variable-length portable format.
 Portability across a write architecture and a read architecture
@@ -627,12 +627,12 @@ the written value is storable in an \f3Sfulong_t\fP on the read architecture.
 \f3sfputu()\fP returns the number of bytes written or \f3-1\fP on error.
 See also \f3sfulen()\fP.
 .Ss "  Sflong_t sfgetl(Sfio_t* f)"
-.Ss "  int sfputl(Sfio_t* f, Sflong_t v)"
+.Ss "  ssize_t sfputl(Sfio_t* f, Sflong_t v)"
 These functions are similar to \f3sfgetu()\fP and \f3sfputu()\fP
 but for reading and writing (signed) \f3Sflong_t\fP values.
 See also \f3sfllen()\fP.
 .Ss "  Sfdouble_t sfgetd(Sfio_t* f)"
-.Ss "  int sfputd(Sfio_t* f, Sfdouble_t v)"
+.Ss "  ssize_t sfputd(Sfio_t* f, Sfdouble_t v)"
 These functions read and write \f3Sfdouble_t\fP values.
 In this case, portability depends on the input and output architectures
 having the same floating point value representation.
@@ -662,7 +662,7 @@ a call \f3sfread(f,r,0)\fP.
 \f3SFIO_LASTR\fP:
 This should be used only after a failed \f3sfgetr()\fP to retrieve
 the last incomplete record. In this case, \f3rsc\fP is ignored.
-.Ss "  ssize_t sfputr(Sfio_t* f, const char* s, int rsc)"
+.Ss "  ptrdiff_t sfputr(Sfio_t* f, const char* s, int rsc)"
 This function writes the null-terminated string \f3s\fP to \f3f\fP.
 If \f3rsc\fP is non-negative, \f3(unsigned char)rsc\fP is
 output after the string.
@@ -878,12 +878,12 @@ which contains the following elements:
     int          fmt;    /* pattern being processed    */
     ssize_t      size;   /* object size                */
     int          flags;  /* formatting control flags   */
-    int          width;  /* width of field             */
-    int          precis; /* precision required         */
-    int          base;   /* conversion base            */
+    ptrdiff_t    width;  /* width of field             */
+    ptrdiff_t    precis; /* precision required         */
+    ptrdiff_t    base;   /* conversion base            */
 
     char*        t_str;  /* extfdata string            */
-    ssize_t      n_str;  /* length of t_str            */
+    ptrdiff_t    n_str;  /* length of t_str            */
 .ft 1
 .fi
 
@@ -1086,14 +1086,14 @@ This is useful for applications to find out
 when the format of the structure \f3Sffmt_t\fP changes.
 Note that the version number corresponds to the Sfio version number
 which is defined in the macro value \f3SFIO_VERSION\fP.
-.Ss "  int sfprintf(Sfio_t* f, const char* format, ...);"
-.Ss "  char* sfprints(const char* format, ...);"
-.Ss "  char* sfvprints(const char* format, va_list args);"
+.Ss "  ssize_t sfprintf(Sfio_t* f, const char* format, ...);"
+.Ss "  char*   sfprints(const char* format, ...);"
+.Ss "  char*   sfvprints(const char* format, va_list args);"
 .Ss "  ssize_t sfaprints(char** sp, const char* format, ...);"
 .Ss "  ssize_t sfvaprints(char** sp, const char* format, va_list args);"
 .Ss "  ssize_t sfsprintf(char* s, size_t n, const char* format, ...)"
 .Ss "  ssize_t sfvsprintf(char* s, size_t n, const char* format, va_list args);"
-.Ss "  int sfvprintf(Sfio_t* f, const char* format, va_list args);"
+.Ss "  ssize_t sfvprintf(Sfio_t* f, const char* format, va_list args);"
 These functions format output data.
 \f3sfprintf()\fP and \f3sfvprintf()\fP write to output stream \f3f\fP.
 \f3sfsprintf()\fP and \f3sfvsprintf()\fP write to buffer \f3s\fP
@@ -1950,7 +1950,7 @@ to use only about that much memory to construct a record, a non-positive bound
 allows \f3sfgetr()\fP to use as much memory as necessary.
 \f3sfmaxr()\fP sets the value only if \f3set\fP is non-zero.
 It returns the value before setting or the current value if not setting.
-.Ss "  ssize_t sfslen()"
+.Ss "  ptrdiff_t sfslen()"
 This function returns the length of a string just constructed
 by \f3sfsprintf()\fP or \f3sfprints()\fP.  See also \f3sfvalue()\fP.
 .Ss "  int sfulen(Sfulong_t v)"

--- a/src/lib/libast/man/strmatch.3
+++ b/src/lib/libast/man/strmatch.3
@@ -40,9 +40,9 @@
 .SH NAME
 strmatch \- match shell file patterns
 .SH SYNOPSIS
-.L "int strmatch(const char* s, const char* p)"
+.L "ssize_t strmatch(const char* s, const char* p)"
 .br
-.L "char* strsubmatch(const char* s, const char* p, int flags)"
+.L "char* strsubmatch(const char* s, const char* p, regflags_t flags)"
 .SH DESCRIPTION
 .I strmatch
 compares the string

--- a/src/lib/libast/man/strperm.3
+++ b/src/lib/libast/man/strperm.3
@@ -40,7 +40,7 @@
 .SH NAME
 strperm \- evaluate file permission expression
 .SH SYNOPSIS
-.L "int strperm(const char* s, char** e, int p)"
+.L "mode_t strperm(const char* s, char** e, mode_t p)"
 .SH DESCRIPTION
 .I strperm
 applies a file permission expression in the null-terminated string

--- a/src/lib/libast/path/pathgetlink.c
+++ b/src/lib/libast/path/pathgetlink.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2023 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 /*
@@ -34,13 +35,13 @@
  * the link text string length is returned
  */
 
-int
-pathgetlink(const char* name, char* buf, int siz)
+ssize_t
+pathgetlink(const char* name, char* buf, size_t siz)
 {
-	int	n;
+	ssize_t n;
 
 	if ((n = readlink(name, buf, siz)) < 0) return -1;
-	if (n >= siz)
+	if (n >= (ssize_t)siz)
 	{
 		errno = EINVAL;
 		return -1;

--- a/src/lib/libast/sfio/_sfgetl.c
+++ b/src/lib/libast/sfio/_sfgetl.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 #include	"sfhdr.h"
@@ -25,6 +26,6 @@
 extern
 Sflong_t _sfgetl(Sfio_t* f)
 {
-	sfungetc(f, (unsigned char)_SFIO_(f)->val);
+	sfungetc(f, (uchar)_SFIO_(f)->val);
 	return sfgetl(f);
 }

--- a/src/lib/libast/sfio/_sfgetu.c
+++ b/src/lib/libast/sfio/_sfgetu.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 #include	"sfhdr.h"
@@ -25,6 +26,6 @@
 extern
 Sfulong_t _sfgetu(Sfio_t* f)
 {
-	sfungetc(f, (unsigned char)_SFIO_(f)->val);
+	sfungetc(f, (uchar)_SFIO_(f)->val);
 	return sfgetu(f);
 }

--- a/src/lib/libast/sfio/_sfopen.c
+++ b/src/lib/libast/sfio/_sfopen.c
@@ -31,7 +31,8 @@ Sfio_t* _sfopen(Sfio_t*		f,		/* old stream structure */
 		const char*	file,		/* file/string to be opened */
 		const char*	mode)		/* mode of the stream */
 {
-	int	fd, oldfd, oflags, fflags, sflags;
+	int		fd, oldfd, oflags, fflags;
+	unsigned short	sflags;
 
 	/* get the control flags */
 	if((sflags = _sftype(mode,&oflags,&fflags)) == 0)
@@ -50,8 +51,8 @@ Sfio_t* _sfopen(Sfio_t*		f,		/* old stream structure */
 				else	f->bits &= ~SFIO_BOTH;
 
 				if(f->flags&SFIO_READ)
-					f->mode = (f->mode&~SFIO_WRITE)|SFIO_READ;
-				else	f->mode = (f->mode&~SFIO_READ)|SFIO_WRITE;
+					f->mode = (f->mode&(uint32_t)~SFIO_WRITE)|SFIO_READ;
+				else	f->mode = (f->mode&(uint32_t)~SFIO_READ)|SFIO_WRITE;
 			}
 		}
 		else /* make sure there is no buffered data */
@@ -127,9 +128,10 @@ Sfio_t* _sfopen(Sfio_t*		f,		/* old stream structure */
 	return f;
 }
 
-int _sftype(const char* mode, int* oflagsp, int* fflagsp)
+unsigned short _sftype(const char* mode, int* oflagsp, int* fflagsp)
 {
-	int	sflags, oflags, fflags;
+	unsigned short	sflags;
+	int		oflags, fflags;
 
 	if(!mode)
 		return 0;

--- a/src/lib/libast/sfio/_sfputc.c
+++ b/src/lib/libast/sfio/_sfputc.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2023 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,13 +14,14 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 #include	"sfhdr.h"
 
 #undef sfputc
 
-int sfputc(Sfio_t* f, int c)
+ssize_t sfputc(Sfio_t* f, int c)
 {
-	return __sf_putc(f,c);
+	return (ssize_t)__sf_putc(f,c);
 }

--- a/src/lib/libast/sfio/_sfputd.c
+++ b/src/lib/libast/sfio/_sfputd.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 #include	"sfhdr.h"
@@ -23,7 +24,7 @@
 **	Written by Kiem-Phong Vo.
 */
 
-int _sfputd(Sfio_t* f, Sfdouble_t v)
+ssize_t _sfputd(Sfio_t* f, Sfdouble_t v)
 {
 #define N_ARRAY		(16*sizeof(Sfdouble_t))
 	ssize_t		n, w;
@@ -65,7 +66,7 @@ int _sfputd(Sfio_t* f, Sfdouble_t v)
 	while(s > ends)
 	{	/* get 2^SFIO_PRECIS precision at a time */
 		n = (int)(x = ldexpl(v,SFIO_PRECIS));
-		*--s = n|SFIO_MORE;
+		*--s = (uchar)(n|SFIO_MORE);
 		v = x-n;
 		if(v <= 0.)
 			break;
@@ -76,8 +77,8 @@ int _sfputd(Sfio_t* f, Sfdouble_t v)
 	*ends &= ~SFIO_MORE;
 
 	/* write out coded bytes */
-	n = ends - s + 1;
-	w = SFWRITE(f,s,n) == n ? w+n : -1;
+	n = (ssize_t)(ends - s + 1);
+	w = SFWRITE(f,s,(size_t)n) == n ? w+n : -1;
 
 	SFOPEN(f,0);
 	return w;

--- a/src/lib/libast/sfio/_sfputl.c
+++ b/src/lib/libast/sfio/_sfputl.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -24,12 +24,13 @@
 **	Written by Kiem-Phong Vo.
 */
 
-int _sfputl(Sfio_t*	f,	/* write a portable long to this stream */
-	    Sflong_t	v)	/* the value to be written */
+ssize_t _sfputl(Sfio_t*		f,	/* write a portable long to this stream */
+		  Sflong_t	v)	/* the value to be written */
 {
 #define N_ARRAY		(2*sizeof(Sflong_t))
-	uchar	*s, *ps;
-	ssize_t	n, p;
+	uchar		*s, *ps;
+	ssize_t		n;
+	ptrdiff_t	p;
 	uchar		c[N_ARRAY];
 
 	if(!f || (f->mode != SFIO_WRITE && _sfmode(f,SFIO_WRITE,0) < 0))
@@ -49,10 +50,10 @@ int _sfputl(Sfio_t*	f,	/* write a portable long to this stream */
 	{	*--s = (uchar)(SFUVALUE(v) | SFIO_MORE);
 		v = (Sfulong_t)v >> SFIO_UBITS;
 	}
-	n = (ps-s)+1;
+	n = (ssize_t)(ps-s)+1;
 
 	if(n > 8 || SFWPEEK(f,ps,p) < n)
-		n = SFWRITE(f,s,n); /* write the hard way */
+		n = (ssize_t)SFWRITE(f,s,(size_t)n); /* write the hard way */
 	else
 	{	switch(n)
 		{

--- a/src/lib/libast/sfio/_sfputm.c
+++ b/src/lib/libast/sfio/_sfputm.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -24,13 +24,14 @@
 **	Written by Kiem-Phong Vo.
 */
 
-int _sfputm(Sfio_t*	f,	/* write a portable ulong to this stream */
-	    Sfulong_t	v,	/* the unsigned value to be written */
-	    Sfulong_t	m)	/* the max value of the range */
+ssize_t _sfputm(Sfio_t*  f,	/* write a portable ulong to this stream */
+		Sfulong_t v,	/* the unsigned value to be written */
+		Sfulong_t m)	/* the max value of the range */
 {
 #define N_ARRAY		(2*sizeof(Sfulong_t))
-	uchar	*s, *ps;
-	ssize_t	n, p;
+	uchar		*s, *ps;
+	ssize_t		n;
+	ptrdiff_t	p;
 	uchar		c[N_ARRAY];
 
 	if(!f || v > m || (f->mode != SFIO_WRITE && _sfmode(f,SFIO_WRITE,0) < 0))
@@ -44,10 +45,10 @@ int _sfputm(Sfio_t*	f,	/* write a portable ulong to this stream */
 	{	v >>= SFIO_BBITS;
 		*--s = (uchar)SFBVALUE(v);
 	}
-	n = (ps-s)+1;
+	n = (ssize_t)(ps-s)+1;
 
 	if(n > 8 || SFWPEEK(f,ps,p) < n)
-		n = SFWRITE(f,s,n); /* write the hard way */
+		n = (ssize_t)SFWRITE(f,s,(size_t)n); /* write the hard way */
 	else
 	{	switch(n)
 		{
@@ -71,5 +72,5 @@ int _sfputm(Sfio_t*	f,	/* write a portable ulong to this stream */
 	}
 
 	SFOPEN(f,0);
-	return (int)n;
+	return n;
 }

--- a/src/lib/libast/sfio/_sfputu.c
+++ b/src/lib/libast/sfio/_sfputu.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -24,12 +24,13 @@
 **	Written by Kiem-Phong Vo.
 */
 
-int _sfputu(Sfio_t*	f,	/* write a portable ulong to this stream */
-	    Sfulong_t	v)	/* the unsigned value to be written */
+ssize_t _sfputu(Sfio_t*		f,	/* write a portable ulong to this stream */
+		  Sfulong_t	v)	/* the unsigned value to be written */
 {
 #define N_ARRAY		(2*sizeof(Sfulong_t))
-	uchar	*s, *ps;
-	ssize_t	n, p;
+	uchar		*s, *ps;
+	ssize_t		n;
+	ptrdiff_t	p;
 	uchar		c[N_ARRAY];
 
 	if(!f || (f->mode != SFIO_WRITE && _sfmode(f,SFIO_WRITE,0) < 0))
@@ -41,10 +42,10 @@ int _sfputu(Sfio_t*	f,	/* write a portable ulong to this stream */
 	*s = (uchar)SFUVALUE(v);
 	while((v >>= SFIO_UBITS) )
 		*--s = (uchar)(SFUVALUE(v) | SFIO_MORE);
-	n = (ps-s)+1;
+	n = (ssize_t)(ps-s)+1;
 
 	if(n > 8 || SFWPEEK(f,ps,p) < n)
-		n = SFWRITE(f,s,n); /* write the hard way */
+		n = (ssize_t)SFWRITE(f,s,(size_t)n); /* write the hard way */
 	else
 	{	switch(n)
 		{
@@ -68,5 +69,5 @@ int _sfputu(Sfio_t*	f,	/* write a portable ulong to this stream */
 	}
 
 	SFOPEN(f,0);
-	return (int)n;
+	return n;
 }

--- a/src/lib/libast/sfio/_sfslen.c
+++ b/src/lib/libast/sfio/_sfslen.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,13 +14,14 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 #include	"sfhdr.h"
 
 #undef sfslen
 
-ssize_t sfslen(void)
+ptrdiff_t sfslen(void)
 {
 	return __sf_slen();
 }

--- a/src/lib/libast/sfio/sfclose.c
+++ b/src/lib/libast/sfio/sfclose.c
@@ -83,7 +83,7 @@ int sfclose(Sfio_t* f)
 			}
 		}
 		else
-		{	f->mode &= ~SFIO_LOCK;	/**/ASSERT(_Sfpmove);
+		{	f->mode &= (uint32_t)~SFIO_LOCK;	/**/ASSERT(_Sfpmove);
 			if((*_Sfpmove)(f,-1) < 0)
 			{	SFOPEN(f,0);
 				return -1;

--- a/src/lib/libast/sfio/sfcvt.c
+++ b/src/lib/libast/sfio/sfcvt.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2012 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2025 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -79,11 +79,11 @@ static int neg0d(double f)
 char* _sfcvt(void*	vp,		/* pointer to value to convert	*/
 	     char*	buf,		/* conversion goes here		*/
 	     size_t	size,		/* size of buf			*/
-	     int	n_digit,	/* number of digits wanted	*/
+	     ptrdiff_t	n_digit,	/* number of digits wanted	*/
 	     int*	decpt,		/* to return decimal point	*/
 	     int*	sign,		/* to return sign		*/
-	     int*	len,		/* return string length		*/
-	     int	format)		/* conversion format		*/
+	     ptrdiff_t*	len,		/* return string length		*/
+	     ptrdiff_t format)		/* conversion format		*/
 {
 	char			*sp;
 	long			n, v;
@@ -139,8 +139,8 @@ char* _sfcvt(void*	vp,		/* pointer to value to convert	*/
 		{	Sfdouble_t	g;
 			b = sp = buf;
 			ep = (format & SFFMT_UPPER) ? ux : lx;
-			if(n_digit <= 0 || n_digit >= (size - 9))
-				n_digit = size - 9;
+			if(n_digit <= 0 || (size_t)n_digit >= (size - 9))
+				n_digit = (ptrdiff_t)size - 9;
 			endsp = sp + n_digit + 1;
 
 			g = frexpl(f, &x);
@@ -236,7 +236,7 @@ char* _sfcvt(void*	vp,		/* pointer to value to convert	*/
 					goto done;
 				}
 				else if((n = (long)(f *= 10.)) < 10)
-				{	*sp++ = '0' + n;
+				{	*sp++ = (char)('0' + n);
 					f -= n;
 				}
 				else /* n == 10 */
@@ -287,8 +287,8 @@ char* _sfcvt(void*	vp,		/* pointer to value to convert	*/
 		{	double		g;
 			b = sp = buf;
 			ep = (format & SFFMT_UPPER) ? ux : lx;
-			if(n_digit <= 0 || n_digit >= (size - 9))
-				n_digit = size - 9;
+			if(n_digit <= 0 || (size_t)n_digit >= (size - 9))
+				n_digit = (ptrdiff_t)size - 9;
 			endsp = sp + n_digit + 1;
 
 			g = frexp(f, &x);
@@ -427,7 +427,7 @@ char* _sfcvt(void*	vp,		/* pointer to value to convert	*/
  done:
 	*--ep = '\0';
 	if(len)
-		*len = ep-b;
+		*len = (ep-b);
 	return b;
  around:
 	if (((m >> x) & 0xf) >= 8)

--- a/src/lib/libast/sfio/sfdisc.c
+++ b/src/lib/libast/sfio/sfdisc.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2025 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -70,14 +70,14 @@ static ssize_t _dccaread(Sfio_t* f, void* buf, size_t size, Sfdisc_t* disc)
 	if(!prev)
 		return -1;
 
-	if(size <= 0) /* nothing to do */
-		return size;
+	if((ssize_t)size <= 0) /* nothing to do */
+		return (ssize_t)size;
 
 	/* read from available data */
 	dcca = (Dccache_t*)disc;
 	if((sz = dcca->endb - dcca->data) > (ssize_t)size)
 		sz = (ssize_t)size;
-	memcpy(buf, dcca->data, sz);
+	memcpy(buf, dcca->data, (size_t)sz);
 
 	if((dcca->data += sz) >= dcca->endb) /* free empty cache */
 	{	prev->disc = disc->disc;
@@ -123,7 +123,7 @@ Sfdisc_t* sfdisc(Sfio_t* f, Sfdisc_t* disc)
 	if(!(f->flags&SFIO_STRING))
 	{	(void)SFSYNC(f); /* do a silent buffer synch */
 		if((f->mode&SFIO_READ) && (f->mode&SFIO_SYNCED) )
-		{	f->mode &= ~SFIO_SYNCED;
+		{	f->mode &= (uint32_t)~SFIO_SYNCED;
 			f->endb = f->next = f->endr = f->endw = f->data;
 		}
 
@@ -147,7 +147,7 @@ Sfdisc_t* sfdisc(Sfio_t* f, Sfdisc_t* disc)
 
 		/* trick the new discipline into processing already buffered data */
 		if((f->mode&SFIO_READ) && n > 0 && disc && disc->readf )
-		{	if(!(dcca = (Dccache_t*)malloc(sizeof(Dccache_t)+n)) )
+		{	if(!(dcca = (Dccache_t*)malloc(sizeof(Dccache_t)+(size_t)n)) )
 				goto done;
 			memclear(dcca, sizeof(Dccache_t));
 
@@ -157,7 +157,7 @@ Sfdisc_t* sfdisc(Sfio_t* f, Sfdisc_t* disc)
 			/* move buffered data into the temp discipline */
 			dcca->data = ((uchar*)dcca) + sizeof(Dccache_t);
 			dcca->endb = dcca->data + n;
-			memcpy(dcca->data, f->next, n);
+			memcpy(dcca->data, f->next, (size_t)n);
 			f->endb = f->next = f->endr = f->endw = f->data;
 		}
 	}
@@ -239,7 +239,7 @@ Sfdisc_t* sfdisc(Sfio_t* f, Sfdisc_t* disc)
 				sfsetbuf(f,NULL,0);
 			else
 			{	int	flags = f->flags;
-				sfsetbuf(f,f->data,f->size);
+				sfsetbuf(f,f->data,(size_t)f->size);
 				f->flags |= (flags&SFIO_MALLOC);
 			}
 		}

--- a/src/lib/libast/sfio/sfdlen.c
+++ b/src/lib/libast/sfio/sfdlen.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 #include	"sfhdr.h"
@@ -25,7 +26,7 @@
 
 int _sfdlen(Sfdouble_t v)
 {
-#define N_ARRAY		(16*sizeof(Sfdouble_t))
+#define N_ARRAY		((int)(16*sizeof(Sfdouble_t)))
 	int		n, w;
 	Sfdouble_t	x;
 	int		exp;

--- a/src/lib/libast/sfio/sfecvt.c
+++ b/src/lib/libast/sfio/sfecvt.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,16 +14,17 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 #include	"sfhdr.h"
 
 char* sfecvt(double	dval,		/* value to convert */
-	     int	n_digit,	/* number of digits wanted */
+	     ptrdiff_t	n_digit,	/* number of digits wanted */
 	     int*	decpt,		/* to return decimal point */
 	     int*	sign)		/* to return sign */
 {
-	int		len;
+	ptrdiff_t	len;
 	static char	buf[SFIO_MAXDIGITS];
 
 	return _sfcvt(&dval,buf,sizeof(buf),n_digit,decpt,sign,&len,SFFMT_EFORMAT);

--- a/src/lib/libast/sfio/sfexcept.c
+++ b/src/lib/libast/sfio/sfexcept.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 #include	"sfhdr.h"
@@ -75,7 +76,7 @@ int _sfexcept(Sfio_t*	f,	/* stream where the exception happened */
 			if((io -= size) <= 0)
 				io = SFIO_GRAIN;
 			size = ((size+io+SFIO_GRAIN-1)/SFIO_GRAIN)*SFIO_GRAIN;
-			if(!(data = realloc(f->data,size)))
+			if(!(data = realloc(f->data,(size_t)size)))
 				goto chk_stack;
 			f->endb = data + size;
 			f->next = data + (f->next - f->data);

--- a/src/lib/libast/sfio/sfextern.c
+++ b/src/lib/libast/sfio/sfextern.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 #include	"sfhdr.h"

--- a/src/lib/libast/sfio/sffcvt.c
+++ b/src/lib/libast/sfio/sffcvt.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,16 +14,17 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 #include	"sfhdr.h"
 
 char *sffcvt(double	dval,		/* value to convert */
-	     int	n_digit,	/* number of digits wanted */
+	     ptrdiff_t	n_digit,	/* number of digits wanted */
 	     int*	decpt,		/* to return decimal point */
 	     int*	sign)		/* to return sign */
 {
-	int		len;
+	ptrdiff_t	len;
 	static char	buf[SFIO_MAXDIGITS];
 
 	return _sfcvt(&dval,buf,sizeof(buf),n_digit,decpt,sign,&len,0);

--- a/src/lib/libast/sfio/sffilbuf.c
+++ b/src/lib/libast/sfio/sffilbuf.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 #include	"sfhdr.h"
@@ -28,11 +29,12 @@
 **	Written by Kiem-Phong Vo
 */
 
-int _sffilbuf(Sfio_t*	f,	/* fill the read buffer of this stream */
-	      int	n)	/* see above */
+ptrdiff_t _sffilbuf(Sfio_t*	f,	/* fill the read buffer of this stream */
+		    ptrdiff_t	n)	/* see above */
 {
-	ssize_t		r;
-	int		first, local, rcrv, rc, justseek;
+	ptrdiff_t	r, ret;
+	int		first, local, rc, justseek;
+	unsigned int	rcrv;
 
 	if(!f)
 		return -1;
@@ -45,7 +47,7 @@ int _sffilbuf(Sfio_t*	f,	/* fill the read buffer of this stream */
 
 	justseek = f->bits&SFIO_JUSTSEEK; f->bits &= ~SFIO_JUSTSEEK;
 
-	for(first = 1;; first = 0, (f->mode &= ~SFIO_LOCK) )
+	for(first = 1;; first = 0, (f->mode &= (uint32_t)~SFIO_LOCK) )
 	{	/* check mode */
 		if(SFMODE(f,local) != SFIO_READ && _sfmode(f,SFIO_READ,local) < 0)
 			return -1;
@@ -62,17 +64,17 @@ int _sffilbuf(Sfio_t*	f,	/* fill the read buffer of this stream */
 			/* try shifting left to make room for new data */
 			if(!(f->bits&SFIO_MMAP) && f->next > f->data &&
 			   n > (f->size - (f->endb-f->data)) )
-			{	ssize_t	s = r;
+			{	size_t	s = (size_t)r;
 
 				/* try to maintain block alignment */
-				if(f->blksz > 0 && (f->here%f->blksz) == 0 )
-				{	s = ((r + f->blksz-1)/f->blksz)*f->blksz;
-					if(s+n > f->size)
-						s = r;
+				if(f->blksz > 0 && ((unsigned)f->here%f->blksz) == 0 )
+				{	s = (((size_t)r + f->blksz-1)/f->blksz)*f->blksz;
+					if((ptrdiff_t)s+n > f->size)
+						s = (size_t)r;
 				}
 
 				memmove(f->data, f->endb-s, s);
-				f->next = f->data + (s-r);
+				f->next = f->data + (s-(size_t)r);
 				f->endb = f->data + s;
 			}
 		}
@@ -80,21 +82,21 @@ int _sffilbuf(Sfio_t*	f,	/* fill the read buffer of this stream */
 			f->next = f->endb = f->endr = f->data;
 
 		if(f->bits&SFIO_MMAP)
-			r = n > 0 ? n : f->size;
+			r = n > 0 ? n : (ptrdiff_t)f->size;
 		else if(!(f->flags&SFIO_STRING) )
 		{	r = f->size - (f->endb - f->data); /* available buffer */
 			if(n > 0)
 			{	if(r > n && f->extent < 0 && (f->flags&SFIO_SHARE) )
 					r = n;	/* read only as much as requested */
-				else if(justseek && n <= f->iosz && f->iosz <= f->size)
-					r = f->iosz;	/* limit buffer filling */
+				else if(justseek && n <= (ssize_t)f->iosz && (ssize_t)f->iosz <= f->size)
+					r = (ptrdiff_t)f->iosz;	/* limit buffer filling */
 			}
 		}
 
 		/* SFRD takes care of discipline read and stack popping */
 		f->mode |= rcrv;
 		f->getr = rc;
-		if((r = SFRD(f,f->endb,r,f->disc)) >= 0)
+		if((r = (ptrdiff_t)SFRD(f,f->endb,(size_t)r,f->disc)) >= 0)
 		{	r = f->endb - f->next;
 			break;
 		}
@@ -102,7 +104,7 @@ int _sffilbuf(Sfio_t*	f,	/* fill the read buffer of this stream */
 
 	SFOPEN(f,local);
 
-	rcrv = (n == 0) ? (r > 0 ? (int)(*f->next++) : EOF) : (int)r;
+	ret = (n == 0) ? (r > 0 ? *f->next++ : EOF) : r;
 
-	return rcrv;
+	return ret;
 }

--- a/src/lib/libast/sfio/sfflsbuf.c
+++ b/src/lib/libast/sfio/sfflsbuf.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 #include	"sfhdr.h"
@@ -24,21 +25,21 @@
 **	Written by Kiem-Phong Vo
 */
 
-int _sfflsbuf(Sfio_t*	f,	/* write out the buffered content of this stream */
-	      int	c)	/* if c>=0, c is also written out */
+ptrdiff_t _sfflsbuf(Sfio_t*	f,	/* write out the buffered content of this stream */
+		  ptrdiff_t c)		/* if c>=0, c is also written out */
 {
 	ssize_t		n, w, written;
 	uchar*		data;
 	uchar		outc;
 	int		local, isall;
-	int		inpc = c;
+	ptrdiff_t	inpc = c;
 
 	if(!f)
 		return -1;
 
 	GETLOCAL(f,local);
 
-	for(written = 0;; f->mode &= ~SFIO_LOCK)
+	for(written = 0;; f->mode &= (uint32_t)~SFIO_LOCK)
 	{	/* check stream mode */
 		if(SFMODE(f,local) != SFIO_WRITE && _sfmode(f,SFIO_WRITE,local) < 0)
 			return -1;
@@ -50,7 +51,7 @@ int _sfflsbuf(Sfio_t*	f,	/* write out the buffered content of this stream */
 		if(n == (f->endb-data) && (f->flags&SFIO_STRING))
 		{	/* call sfwr() to extend string buffer and process events */
 			w = ((f->bits&SFIO_PUTR) && f->val > 0) ? f->val : 1;
-			(void)SFWR(f, data, w, f->disc);
+			(void)SFWR(f, data, (size_t)w, f->disc);
 
 			/* !(f->flags&SFIO_STRING) is required because exception
 			   handlers may turn a string stream to a file stream */
@@ -65,7 +66,7 @@ int _sfflsbuf(Sfio_t*	f,	/* write out the buffered content of this stream */
 		if(c >= 0)
 		{	/* write into buffer */
 			if(n < (f->endb - (data = f->data)))
-			{	*f->next++ = c;
+			{	*f->next++ = (uchar)c;
 				if(c == '\n' &&
 				   (f->flags&SFIO_LINE) && !(f->flags&SFIO_STRING))
 				{	c = -1;
@@ -86,9 +87,9 @@ int _sfflsbuf(Sfio_t*	f,	/* write out the buffered content of this stream */
 			break;
 
 		isall = SFISALL(f,isall);
-		if((w = SFWR(f,data,n,f->disc)) > 0)
+		if((w = SFWR(f,data,(size_t)n,f->disc)) > 0)
 		{	if((n -= w) > 0) /* save unwritten data, then resume */
-				memmove((char*)f->data,(char*)data+w,n);
+				memmove((char*)f->data,(char*)data+w,(size_t)n);
 			written += w;
 			f->next = f->data+n;
 			if(c < 0 && (!isall || n == 0))

--- a/src/lib/libast/sfio/sfgetd.c
+++ b/src/lib/libast/sfio/sfgetd.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 #include	"sfhdr.h"
@@ -26,7 +27,8 @@
 Sfdouble_t sfgetd(Sfio_t* f)
 {
 	uchar		*s, *ends, c;
-	int		p, sign, exp;
+	int		sign, exp;
+	ptrdiff_t	p;
 	Sfdouble_t	v;
 
 	if(!f || (sign = sfgetc(f)) < 0 || (exp = (int)sfgetu(f)) < 0)

--- a/src/lib/libast/sfio/sfgetl.c
+++ b/src/lib/libast/sfio/sfgetl.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 #include	"sfhdr.h"
@@ -27,7 +28,7 @@ Sflong_t sfgetl(Sfio_t* f)
 {
 	Sflong_t	v;
 	uchar		*s, *ends, c;
-	int		p;
+	ptrdiff_t	p;
 
 	if(!f || (f->mode != SFIO_READ && _sfmode(f,SFIO_READ,0) < 0))
 		return (Sflong_t)(-1);
@@ -42,10 +43,10 @@ Sflong_t sfgetl(Sfio_t* f)
 		for(ends = s+p; s < ends;)
 		{	c = *s++;
 			if(c&SFIO_MORE)
-				v = ((Sfulong_t)v << SFIO_UBITS) | SFUVALUE(c);
+				v = (Sflong_t)(((Sfulong_t)v << SFIO_UBITS) | SFUVALUE(c));
 			else
 			{	/* special translation for this byte */
-				v = ((Sfulong_t)v << SFIO_SBITS) | SFSVALUE(c);
+				v = (Sflong_t)(((Sfulong_t)v << SFIO_SBITS) | SFSVALUE(c));
 				f->next = s;
 				v = (c&SFIO_SIGN) ? -v-1 : v;
 				goto done;

--- a/src/lib/libast/sfio/sfgetm.c
+++ b/src/lib/libast/sfio/sfgetm.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 #include	"sfhdr.h"
@@ -27,7 +28,7 @@ Sfulong_t sfgetm(Sfio_t* f, Sfulong_t m)
 {
 	Sfulong_t	v;
 	uchar		*s, *ends, c;
-	int		p;
+	ptrdiff_t	p;
 
 	if(!f || (f->mode != SFIO_READ && _sfmode(f,SFIO_READ,0) < 0))
 		return (Sfulong_t)(-1);

--- a/src/lib/libast/sfio/sfgetr.c
+++ b/src/lib/libast/sfio/sfgetr.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 #include	"sfhdr.h"
@@ -47,7 +48,7 @@ char* sfgetr(Sfio_t*	f,	/* stream to read from	*/
 	type = type < 0 ? SFIO_LASTR : type == 1 ? SFIO_STRING : type;
 
 	if(type&SFIO_LASTR) /* return the broken record */
-	{	if((f->flags&SFIO_STRING) && (un = f->endb - f->next))
+	{	if((f->flags&SFIO_STRING) && (un = (ssize_t)(f->endb - f->next)))
 		{	us = f->next;
 			f->next = f->endb;
 			found = 1;
@@ -80,7 +81,7 @@ char* sfgetr(Sfio_t*	f,	/* stream to read from	*/
 			}
 		}
 
-		if(!(s = (uchar*)memchr((char*)s,rc,n)))
+		if(!(s = (uchar*)memchr((char*)s,rc,(size_t)n)))
 			s = ends;
 	do_copy:
 		if(s < ends) /* found separator */
@@ -92,14 +93,14 @@ char* sfgetr(Sfio_t*	f,	/* stream to read from	*/
 			    ((f->flags&SFIO_STRING) && (f->bits&SFIO_BOTH) ) ) )
 			{	/* returning data in buffer */
 				us = f->next;
-				un = s - f->next;
+				un = (ssize_t)(s - f->next);
 				f->next = s;
 				goto done;
 			}
 		}
 
 		/* amount to be read */
-		n = s - f->next;
+		n = (ssize_t)(s - f->next);
 
 		if(!found && (_Sfmaxr > 0 && un+n+1 >= _Sfmaxr || (f->flags&SFIO_STRING))) /* already exceed limit */
 		{	us = NULL;
@@ -123,7 +124,7 @@ char* sfgetr(Sfio_t*	f,	/* stream to read from	*/
 		un += n;
 		ends = f->next;
 		f->next += n;
-		MEMCPY(s,ends,n);
+		MEMCPY(s,ends,(size_t)n);
 	}
 
 done:

--- a/src/lib/libast/sfio/sfgetu.c
+++ b/src/lib/libast/sfio/sfgetu.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 #include	"sfhdr.h"
@@ -27,7 +28,7 @@ Sfulong_t sfgetu(Sfio_t* f)
 {
 	Sfulong_t	v;
 	uchar		*s, *ends, c;
-	int		p;
+	ptrdiff_t	p;
 
 	if(!f || (f->mode != SFIO_READ && _sfmode(f,SFIO_READ,0) < 0))
 		return (Sfulong_t)(-1);

--- a/src/lib/libast/sfio/sfhdr.h
+++ b/src/lib/libast/sfio/sfhdr.h
@@ -268,9 +268,9 @@
 typedef struct _sfpool_s	Sfpool_t;
 struct _sfpool_s
 {	Sfpool_t*	next;
-	int		mode;		/* type of pool			*/
-	int		s_sf;		/* size of pool array		*/
-	int		n_sf;		/* number currently in pool	*/
+	uint32_t	mode;		/* type of pool			*/
+	ssize_t		s_sf;		/* size of pool array		*/
+	ssize_t		n_sf;		/* number currently in pool	*/
 	Sfio_t**	sf;		/* array of streams		*/
 	Sfio_t*		array[3];	/* start with 3			*/
 };
@@ -288,8 +288,8 @@ typedef struct _sfproc_s	Sfproc_t;
 struct _sfproc_s
 {	int		pid;	/* process ID			*/
 	uchar*		rdata;	/* read data being cached	*/
-	int		ndata;	/* size of cached data		*/
-	int		size;	/* buffer size			*/
+	ptrdiff_t	ndata;	/* size of cached data		*/
+	ptrdiff_t	size;	/* buffer size			*/
 	int		file;	/* saved file descriptor	*/
 	int		sigp;	/* sigpipe protection needed	*/
 };
@@ -334,7 +334,7 @@ struct _fmt_s
 
 	char*		oform;		/* original format string	*/
 	va_list		oargs;		/* original arg list		*/
-	int		argn;		/* number of args already used	*/
+	ptrdiff_t	argn;		/* number of args already used	*/
 	Fmtpos_t*	fp;		/* position list		*/
 
 	Sffmt_t*	ft;		/* formatting environment	*/
@@ -343,10 +343,10 @@ struct _fmt_s
 };
 
 struct _fmtpos_s
-{	Sffmt_t	ft;			/* environment			*/
-	Argv_t	argv;			/* argument value		*/
-	int	fmt;			/* original format		*/
-	int	need[FP_INDEX];		/* positions depending on	*/
+{	Sffmt_t		ft;		/* environment			*/
+	Argv_t		argv;		/* argument value		*/
+	int		fmt;		/* original format		*/
+	ptrdiff_t	need[FP_INDEX];	/* positions depending on	*/
 };
 
 #define LEFTP		'('
@@ -481,9 +481,9 @@ typedef struct _sfextern_s
 #define SFIO_ECONT	3	/* can continue normally		*/
 
 #define SETLOCAL(f)	((f)->mode |= SFIO_LOCAL)
-#define GETLOCAL(f,v)	((v) = ((f)->mode&SFIO_LOCAL), (f)->mode &= ~SFIO_LOCAL, (v))
+#define GETLOCAL(f,v)	((v) = ((f)->mode&SFIO_LOCAL), (f)->mode &= (uint32_t)~SFIO_LOCAL, (v))
 #define SFWRALL(f)	((f)->mode |= SFIO_RV)
-#define SFISALL(f,v)	((((v) = (f)->mode&SFIO_RV) ? ((f)->mode &= ~SFIO_RV) : 0), \
+#define SFISALL(f,v)	((((v) = (f)->mode&SFIO_RV) ? ((f)->mode &= (uint32_t)~SFIO_RV) : 0), \
 			 ((v) || ((f)->flags&(SFIO_SHARE|SFIO_APPENDWR|SFIO_WHOLE)) ) )
 #define SFSK(f,a,o,d)	(SETLOCAL(f),sfsk(f,(Sfoff_t)a,o,d))
 #define SFRD(f,b,n,d)	(SETLOCAL(f),sfrd(f,b,n,d))
@@ -500,7 +500,7 @@ typedef struct _sfextern_s
 #define SFRAISE(f,e,d)	(SETLOCAL(f),sfraise(f,e,d))
 
 /* lock/open a stream */
-#define SFMODE(f,l)	((f)->mode & ~(SFIO_RV|SFIO_RC|((l) ? SFIO_LOCK : 0)) )
+#define SFMODE(f,l)	((f)->mode & (uint32_t)~(SFIO_RV|SFIO_RC|((l) ? SFIO_LOCK : 0)) )
 #define SFLOCK(f,l)	(void)((f)->mode |= SFIO_LOCK, (f)->endr = (f)->endw = (f)->data)
 #define _SFOPENRD(f)	((f)->endr = (f)->endb)
 #define _SFOPENWR(f)	((f)->endw = ((f)->flags&SFIO_LINE) ? (f)->data : (f)->endb)
@@ -508,12 +508,12 @@ typedef struct _sfextern_s
 			 (f)->mode == SFIO_WRITE ? _SFOPENWR(f) : \
 			 ((f)->endw = (f)->endr = (f)->data) )
 #define SFOPEN(f,l)	(void)((l) ? 0 : \
-				((f)->mode &= ~(SFIO_LOCK|SFIO_RC|SFIO_RV), _SFOPEN(f), 0) )
+				((f)->mode &= (uint32_t)~(SFIO_LOCK|SFIO_RC|SFIO_RV), _SFOPEN(f), 0) )
 
 /* check to see if the stream can be accessed */
 #define SFFROZEN(f)	(((f)->mode&(SFIO_PUSH|SFIO_LOCK|SFIO_PEEK)) ? 1 : \
 			 !((f)->mode&SFIO_STDIO) ? 0 : \
-			 _Sfstdsync ? (*_Sfstdsync)(f) : (((f)->mode &= ~SFIO_STDIO),0) )
+			 _Sfstdsync ? (*_Sfstdsync)(f) : (((f)->mode &= (uint32_t)~SFIO_STDIO),0) )
 
 
 /* set discipline code */
@@ -544,7 +544,7 @@ typedef struct _sfextern_s
 /* fast peek of a stream */
 #define _SFAVAIL(f,s,n)	((n) = (f)->endb - ((s) = (f)->next) )
 #define SFRPEEK(f,s,n)	(_SFAVAIL(f,s,n) > 0 ? (n) : \
-				((n) = SFFILBUF(f,-1), (s) = (f)->next, (n)) )
+				((n) = (ptrdiff_t)SFFILBUF(f,-1), (s) = (f)->next, (n)) )
 #define SFWPEEK(f,s,n)	(_SFAVAIL(f,s,n) > 0 ? (n) : \
 				((n) = SFFLSBUF(f,-1), (s) = (f)->next, (n)) )
 
@@ -629,7 +629,7 @@ typedef struct _sftab_
 	int		(*sf_cvinitf)(void);	/* initialization function	*/
 	int		sf_cvinit;		/* initialization state		*/
 	Fmtpos_t*	(*sf_fmtposf)(Sfio_t*,const char*,va_list,Sffmt_t*,int);
-	char*		(*sf_fmtintf)(const char*,int*);
+	char*		(*sf_fmtintf)(const char*,ptrdiff_t*);
 	float*		sf_flt_pow10;		/* float powers of 10		*/
 	double*		sf_dbl_pow10;		/* double powers of 10		*/
 	Sfdouble_t*	sf_ldbl_pow10;		/* Sfdouble_t powers of 10	*/
@@ -717,19 +717,19 @@ typedef struct _sftab_
 #define MEMSET(s,c,n) \
 	switch(n) \
 	{ default : memset(s,(int)c,n); s += n; break; \
-	  case  7 : *s++ = c;		\
+	  case  7 : *s++ = (uchar)c;	\
 		    /* FALLTHROUGH */	\
-	  case  6 : *s++ = c;		\
+	  case  6 : *s++ = (uchar)c;	\
 		    /* FALLTHROUGH */	\
-	  case  5 : *s++ = c;		\
+	  case  5 : *s++ = (uchar)c;	\
 		    /* FALLTHROUGH */	\
-	  case  4 : *s++ = c;		\
+	  case  4 : *s++ = (uchar)c;	\
 		    /* FALLTHROUGH */	\
-	  case  3 : *s++ = c;		\
+	  case  3 : *s++ = (uchar)c;	\
 		    /* FALLTHROUGH */	\
-	  case  2 : *s++ = c;		\
+	  case  2 : *s++ = (uchar)c;	\
 		    /* FALLTHROUGH */	\
-	  case  1 : *s++ = c;		\
+	  case  1 : *s++ = (uchar)c;	\
 	}
 
 extern Sftab_t		_Sftable;
@@ -739,13 +739,13 @@ extern int		_sfpclose(Sfio_t*);
 extern int		_sfexcept(Sfio_t*, int, ssize_t, Sfdisc_t*);
 extern Sfrsrv_t*	_sfrsrv(Sfio_t*, ssize_t);
 extern int		_sfsetpool(Sfio_t*);
-extern char*		_sfcvt(void*,char*,size_t,int,int*,int*,int*,int);
+extern char*		_sfcvt(void*,char*,size_t,ptrdiff_t,int*,int*,ptrdiff_t*,ptrdiff_t);
 extern char**		_sfgetpath(char*);
 
 extern Sfextern_t	_Sfextern;
 
 extern int		_sfmode(Sfio_t*, int, int);
-extern int		_sftype(const char*, int*, int*);
+extern unsigned short	_sftype(const char*, int*, int*);
 
 #ifndef errno
 extern int		errno;

--- a/src/lib/libast/sfio/sfmode.c
+++ b/src/lib/libast/sfio/sfmode.c
@@ -59,7 +59,7 @@ static void _sfcleanup(void)
 	Sfpool_t*	p;
 	Sfio_t*		f;
 	int		n;
-	int		pool;
+	unsigned int	pool;
 
 	f = (Sfio_t*)Version; /* shut compiler warning */
 
@@ -83,7 +83,7 @@ static void _sfcleanup(void)
 
 			/* from now on, write streams are unbuffered */
 			pool = f->mode&SFIO_POOL;
-			f->mode &= ~SFIO_POOL;
+			f->mode &= (uint32_t)~SFIO_POOL;
 			if((f->flags&SFIO_WRITE) && !(f->mode&SFIO_WRITE))
 				(void)_sfmode(f,SFIO_WRITE,1);
 			if(f->data &&
@@ -102,7 +102,8 @@ int _sfsetpool(Sfio_t* f)
 {
 	Sfpool_t*	p;
 	Sfio_t**	array;
-	int		n, rv;
+	int		rv;
+	ssize_t		n;
 
 	if(!_Sfcleanup)
 	{	_Sfcleanup = _sfcleanup;
@@ -122,11 +123,11 @@ int _sfsetpool(Sfio_t* f)
 		}
 		else	/* allocate a larger array */
 		{	n = (p->sf != p->array ? p->s_sf : (p->s_sf/4 + 1)*4) + 4;
-			if(!(array = (Sfio_t**)malloc(n*sizeof(Sfio_t*))) )
+			if(!(array = (Sfio_t**)malloc((size_t)n*sizeof(Sfio_t*))) )
 				goto done;
 
 			/* move old array to new one */
-			memcpy(array,p->sf,p->n_sf*sizeof(Sfio_t*));
+			memcpy(array,p->sf,(size_t)p->n_sf*sizeof(Sfio_t*));
 			if(p->sf != p->array)
 				free(p->sf);
 
@@ -153,12 +154,12 @@ Sfrsrv_t* _sfrsrv(Sfio_t* f, ssize_t size)
 	/* make buffer if nothing yet */
 	size = ((size + SFIO_GRAIN-1)/SFIO_GRAIN)*SFIO_GRAIN;
 	if(!(rsrv = f->rsrv) || size > rsrv->size)
-	{	if(!(rs = (Sfrsrv_t*)malloc(size+sizeof(Sfrsrv_t))))
+	{	if(!(rs = (Sfrsrv_t*)malloc((size_t)size+sizeof(Sfrsrv_t))))
 			size = -1;
 		else
 		{	if(rsrv)
 			{	if(rsrv->slen > 0)
-					memcpy(rs,rsrv,sizeof(Sfrsrv_t)+rsrv->slen);
+					memcpy(rs,rsrv,sizeof(Sfrsrv_t)+(size_t)rsrv->slen);
 				free(rsrv);
 			}
 			f->rsrv = rsrv = rs;
@@ -256,7 +257,7 @@ static int _sfpmode(Sfio_t* f, int type)
 		if(p->ndata > p->size)
 		{	if(p->rdata)
 				free(p->rdata);
-			if((p->rdata = (uchar*)malloc(p->ndata)) )
+			if((p->rdata = (uchar*)malloc((size_t)p->ndata)) )
 				p->size = p->ndata;
 			else
 			{	p->size = 0;
@@ -264,15 +265,15 @@ static int _sfpmode(Sfio_t* f, int type)
 			}
 		}
 		if(p->ndata > 0)
-			memcpy(p->rdata,f->next,p->ndata);
+			memcpy(p->rdata,f->next,(size_t)p->ndata);
 		f->endb = f->data;
 	}
 	else
 	{	/* restore read data */
 		if(p->ndata > f->size)	/* may lose data!!! */
-			p->ndata = f->size;
+			p->ndata = (ptrdiff_t)f->size;
 		if(p->ndata > 0)
-		{	memcpy(f->data,p->rdata,p->ndata);
+		{	memcpy(f->data,p->rdata,(size_t)p->ndata);
 			f->endb = f->data+p->ndata;
 			p->ndata = 0;
 		}
@@ -298,10 +299,10 @@ int _sfmode(Sfio_t*	f,	/* change r/w mode and sync file pointer for this stream 
 
 
 	if(wanted&SFIO_SYNCED) /* for (SFIO_SYNCED|SFIO_READ) stream, just junk data */
-	{	wanted &= ~SFIO_SYNCED;
+	{	wanted &= (uint32_t)~SFIO_SYNCED;
 		if((f->mode&(SFIO_SYNCED|SFIO_READ)) == (SFIO_SYNCED|SFIO_READ) )
 		{	f->next = f->endb = f->endr = f->data;
-			f->mode &= ~SFIO_SYNCED;
+			f->mode &= (uint32_t)~SFIO_SYNCED;
 		}
 	}
 
@@ -327,7 +328,7 @@ int _sfmode(Sfio_t*	f,	/* change r/w mode and sync file pointer for this stream 
 	}
 
 	if(f->mode&SFIO_GETR)
-	{	f->mode &= ~SFIO_GETR;
+	{	f->mode &= (uint32_t)~SFIO_GETR;
 #ifdef MAP_TYPE
 		if(f->bits&SFIO_MMAP)
 		{
@@ -341,7 +342,7 @@ int _sfmode(Sfio_t*	f,	/* change r/w mode and sync file pointer for this stream 
 		}
 #endif
 		if(f->getr)
-		{	f->next[-1] = f->getr;
+		{	f->next[-1] = (uchar)f->getr;
 			f->getr = 0;
 		}
 	}
@@ -361,7 +362,7 @@ int _sfmode(Sfio_t*	f,	/* change r/w mode and sync file pointer for this stream 
 		{	local = 1;
 			goto err_notify;
 		}
-		f->mode &= ~SFIO_POOL;
+		f->mode &= (uint32_t)~SFIO_POOL;
 	}
 
 	SFLOCK(f,local);
@@ -382,7 +383,7 @@ int _sfmode(Sfio_t*	f,	/* change r/w mode and sync file pointer for this stream 
 			goto err_notify;
 
 		if((f->flags&SFIO_STRING) && f->size >= 0 && f->data)
-		{	f->mode &= ~SFIO_INIT;
+		{	f->mode &= (uint32_t)~SFIO_INIT;
 			f->extent = ((f->flags&SFIO_READ) || (f->bits&SFIO_BOTH)) ?
 					f->size : 0;
 			f->here = 0;
@@ -394,7 +395,7 @@ int _sfmode(Sfio_t*	f,	/* change r/w mode and sync file pointer for this stream 
 		}
 		else
 		{	n = f->flags;
-			(void)SFSETBUF(f,f->data,f->size);
+			(void)SFSETBUF(f,f->data,(size_t)f->size);
 			f->flags |= (n&SFIO_MALLOC);
 		}
 	}
@@ -480,7 +481,7 @@ int _sfmode(Sfio_t*	f,	/* change r/w mode and sync file pointer for this stream 
 
 		/* reset buffer and seek pointer */
 		if(!(f->mode&SFIO_SYNCED) )
-		{	intptr_t nn = f->endb - f->next;
+		{	ptrdiff_t nn = f->endb - f->next;
 			if(f->extent >= 0 && (nn > 0 || (f->data && (f->bits&SFIO_MMAP))) )
 			{	/* reset file pointer */
 				addr = f->here - nn;
@@ -512,7 +513,7 @@ int _sfmode(Sfio_t*	f,	/* change r/w mode and sync file pointer for this stream 
 			wanted = SFIO_READ;
 
 		/* set errno for operations that access wrong stream type */
-		if(wanted != (f->mode&SFIO_RDWR) && f->file >= 0)
+		if(wanted != (int)(f->mode&SFIO_RDWR) && f->file >= 0)
 			errno = EBADF;
 
 		if(_Sfnotify) /* notify application of the error */

--- a/src/lib/libast/sfio/sfmove.c
+++ b/src/lib/libast/sfio/sfmove.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -50,7 +50,7 @@ Sfoff_t sfmove(Sfio_t*	fr,	/* moving data from this stream */
 				n = 0;
 			else
 			{	r = sfvalue(fr);
-				if(fw && (w = SFWRITE(fw, cp, r)) != r)
+				if(fw && (w = SFWRITE(fw, cp, (size_t)r)) != r)
 				{	if(fr->extent >= 0 )
 						(void)SFSEEK(fr,(Sfoff_t)(-r),SEEK_CUR);
 					if(fw->extent >= 0 && w > 0)
@@ -133,7 +133,7 @@ Sfoff_t sfmove(Sfio_t*	fr,	/* moving data from this stream */
 					if(w >= maxw)
 						w = maxw;
 					else	w = ((w+fr->size-1)/fr->size)*fr->size;
-					if(rsize <= 0 && (rbuf = (uchar*)malloc(w)) )
+					if(rsize <= 0 && (rbuf = (uchar*)malloc((size_t)w)) )
 						rsize = w;
 					if(rbuf)
 					{	next = rbuf;
@@ -150,7 +150,7 @@ Sfoff_t sfmove(Sfio_t*	fr,	/* moving data from this stream */
 						r = (ssize_t)n;
 				}
 				else	r = -1;
-				if((r = SFFILBUF(fr,r)) <= 0)
+				if((r = (ssize_t)SFFILBUF(fr,(ptrdiff_t)r)) <= 0)
 					break;
 				next = fr->next;
 			}
@@ -159,7 +159,7 @@ Sfoff_t sfmove(Sfio_t*	fr,	/* moving data from this stream */
 				if(n > 0 && n < w)
 					w = (ssize_t)n;
 
-				if((r = SFRD(fr,next,w,fr->disc)) > 0)
+				if((r = SFRD(fr,next,(size_t)w,fr->disc)) > 0)
 					fr->next = fr->endb = fr->endr = fr->data;
 				else if(r == 0)
 					break;		/* eof */
@@ -183,7 +183,7 @@ Sfoff_t sfmove(Sfio_t*	fr,	/* moving data from this stream */
 		{	/* move leftover to read stream */
 			if(w > fr->size)
 				w = fr->size;
-			memmove(fr->data,cp,w);
+			memmove(fr->data,cp,(size_t)w);
 			fr->endb = fr->data+w;
 			if((w = endb - (cp+w)) > 0)
 				(void)SFSK(fr,(Sfoff_t)(-w),SEEK_CUR,fr->disc);
@@ -193,10 +193,10 @@ Sfoff_t sfmove(Sfio_t*	fr,	/* moving data from this stream */
 		{	if(direct == SFIO_WRITE)
 				fw->next += r;
 			else if(r <= (fw->endb-fw->next) )
-			{	memmove(fw->next,next,r);
+			{	memmove(fw->next,next,(size_t)r);
 				fw->next += r;
 			}
-			else if((w = SFWRITE(fw,next,r)) != r)
+			else if((w = SFWRITE(fw,next,(size_t)r)) != r)
 			{	/* a write error happened */
 				if(w > 0)
 				{	r -= w;

--- a/src/lib/libast/sfio/sfnew.c
+++ b/src/lib/libast/sfio/sfnew.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 #include	"sfhdr.h"
@@ -25,14 +26,14 @@
 **	Written by Kiem-Phong Vo.
 */
 
-Sfio_t* sfnew(Sfio_t*	oldf,	/* old stream to be reused */
-	      void*	buf,	/* a buffer to read/write, if NULL, will be allocated */
-	      size_t	size,	/* buffer size if buf is given or desired buffer size */
-	      int	file,	/* file descriptor to read/write from */
-	      int	flags)	/* type of file stream */
+Sfio_t* sfnew(Sfio_t*		oldf,	/* old stream to be reused */
+	      void*		buf,	/* a buffer to read/write, if NULL, will be allocated */
+	      size_t		size,	/* buffer size if buf is given or desired buffer size */
+	      int		file,	/* file descriptor to read/write from */
+	      unsigned short	flags)	/* type of file stream */
 {
 	Sfio_t*		f;
-	int		sflags;
+	unsigned short	sflags;
 
 
 	if(!(flags&SFIO_RDWR))
@@ -99,8 +100,8 @@ Sfio_t* sfnew(Sfio_t*	oldf,	/* old stream to be reused */
 
 	f->mode |= SFIO_INIT;
 	if(size != (size_t)SFIO_UNBOUND)
-	{	f->size = size;
-		f->data = size <= 0 ? NULL : (uchar*)buf;
+	{	f->size = (ssize_t)size;
+		f->data = size == (size_t)-1 ? NULL : (uchar*)buf;
 	}
 	f->endb = f->endr = f->endw = f->next = f->data;
 

--- a/src/lib/libast/sfio/sfnputc.c
+++ b/src/lib/libast/sfio/sfnputc.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 #include	"sfhdr.h"
@@ -45,11 +46,11 @@ ssize_t sfnputc(Sfio_t*		f,	/* file to write */
 	if((size_t)(p = (f->endb-(ps = f->next))) < n)
 		{ ps = buf; p = sizeof(buf); }
 	if((size_t)p > n)
-		p = n;
-	MEMSET(ps,c,p);
+		p = (ssize_t)n;
+	MEMSET(ps,c,(size_t)p);
 	ps -= p;
 
-	w = n;
+	w = (ssize_t)n;
 	if(ps == f->next)
 	{	/* simple sfwrite */
 		f->next += p;
@@ -60,12 +61,12 @@ ssize_t sfnputc(Sfio_t*		f,	/* file to write */
 
 	for(;;)
 	{	/* hard write of data */
-		if((p = SFWRITE(f,ps,p)) <= 0 || (n -= p) <= 0)
-		{	w -= n;
+		if((p = SFWRITE(f,ps,(size_t)p)) <= 0 || (ssize_t)(n -= (size_t)p) <= 0)
+		{	w -= (ssize_t)n;
 			goto done;
 		}
-		if((size_t)p > n)
-			p = n;
+		if(p > (ssize_t)n)
+			p = (ssize_t)n;
 	}
 done :
 	SFOPEN(f,local);

--- a/src/lib/libast/sfio/sfpeek.c
+++ b/src/lib/libast/sfio/sfpeek.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 #include	"sfhdr.h"
@@ -31,7 +32,7 @@ extern ssize_t sfpeek(Sfio_t*	f,	/* file to peek */
 	int	mode;
 
 	/* query for the extent of the remainder of the buffer */
-	if((sz = size) == 0 || !bp)
+	if((sz = (ssize_t)size) == 0 || !bp)
 	{	if(f->mode&SFIO_INIT)
 			(void)_sfmode(f,0,0);
 

--- a/src/lib/libast/sfio/sfpkrd.c
+++ b/src/lib/libast/sfio/sfpkrd.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2012 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -53,7 +53,7 @@ ssize_t sfpkrd(int	fd,	/* file descriptor */
 				   =2: same as >0, but always use select(2)
 				*/
 {
-	ssize_t		r;
+	ssize_t		r, q;
 	int		ntry, t;
 	char		*buf = (char*)argbuf, *endbuf;
 
@@ -78,7 +78,7 @@ ssize_t sfpkrd(int	fd,	/* file descriptor */
 			pbuf.ctlbuf.maxlen = -1;
 			pbuf.ctlbuf.len = 0;
 			pbuf.ctlbuf.buf = NULL;
-			pbuf.databuf.maxlen = n;
+			pbuf.databuf.maxlen = (int)n;
 			pbuf.databuf.buf = buf;
 			pbuf.databuf.len = 0;
 
@@ -187,17 +187,17 @@ ssize_t sfpkrd(int	fd,	/* file descriptor */
 		else /* get here means: tm < 0 && action <= 0 && rc >= 0 */
 		{	/* number of records read at a time */
 			if((action = action ? -action : 1) > (int)n)
-				action = n;
+				action = (int)n;
 			r = 0;
-			while((t = read(fd,buf,action)) > 0)
-			{	r += t;
-				for(endbuf = buf+t; buf < endbuf;)
+			while((q = read(fd,buf,(size_t)action)) > 0)
+			{	r += q;
+				for(endbuf = buf+q; buf < endbuf;)
 					if(*buf++ == rc)
 						action -= 1;
-				if(action == 0 || (int)(n-r) < action)
+				if(action == 0 || ((int)n-(int)r) < action)
 					break;
 			}
-			return r == 0 ? t : r;
+			return r == 0 ? q : r;
 		}
 	}
 
@@ -215,7 +215,7 @@ ssize_t sfpkrd(int	fd,	/* file descriptor */
 
 	/* advance */
 	if(action <= 0)
-		r = read(fd,buf,r);
+		r = read(fd,buf,(size_t)r);
 
 	return r;
 }

--- a/src/lib/libast/sfio/sfpoll.c
+++ b/src/lib/libast/sfio/sfpoll.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -37,7 +37,7 @@ int sfpoll(Sfio_t** fa,	/* array of streams to poll		*/
 	if(n <= 0 || !fa)
 		return -1;
 
-	if(!(status = (int*)malloc(2*n*sizeof(int))) )
+	if(!(status = (int*)malloc(2*(size_t)n*sizeof(int))) )
 		return -1;
 	check = status+n; /* streams that need polling */
 

--- a/src/lib/libast/sfio/sfpool.c
+++ b/src/lib/libast/sfio/sfpool.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -76,7 +76,7 @@ static Sfpool_t* newpool(int mode)
 /* move a stream to head */
 static int _sfphead(Sfpool_t*	p,	/* the pool			*/
 		    Sfio_t*	f,	/* the stream			*/
-		    int		n)	/* current position in pool	*/
+		    ssize_t	n)	/* current position in pool	*/
 {
 	Sfio_t*		head;
 	ssize_t		k, w, v;
@@ -106,12 +106,12 @@ static int _sfphead(Sfpool_t*	p,	/* the pool			*/
 		if((k = v - (f->endb-f->data)) <= 0)
 			k = 0;
 		else	/* try to write out amount exceeding f's capacity */
-		{	if((w = SFWR(head,head->data,k,head->disc)) == k)
+		{	if((w = SFWR(head,head->data,(size_t)k,head->disc)) == k)
 				v -= k;
 			else	/* write failed, recover buffer then quit */
 			{	if(w > 0)
 				{	v -= w;
-					memmove(head->data,(head->data+w),v);
+					memmove(head->data,(head->data+w),(size_t)v);
 				}
 				head->next = head->data+v;
 				goto done;
@@ -120,11 +120,11 @@ static int _sfphead(Sfpool_t*	p,	/* the pool			*/
 
 		/* move data from head to f */
 		if((head->data+k) != f->data )
-			memmove(f->data,(head->data+k),v);
+			memmove(f->data,(head->data+k),(size_t)v);
 		f->next = f->data+v;
 	}
 
-	f->mode &= ~SFIO_POOL;
+	f->mode &= (uint32_t)~SFIO_POOL;
 	head->mode |= SFIO_POOL;
 	head->next = head->endr = head->endw = head->data; /* clear write buffer */
 
@@ -133,7 +133,7 @@ static int _sfphead(Sfpool_t*	p,	/* the pool			*/
 	rv = 0;
 
 done:
-	head->mode &= ~SFIO_LOCK; /* partially unlock because it's no longer head */
+	head->mode &= (uint32_t)~SFIO_LOCK; /* partially unlock because it's no longer head */
 
 	return rv;
 }
@@ -141,7 +141,7 @@ done:
 /* delete a stream from its pool */
 static int _sfpdelete(Sfpool_t*	p,	/* the pool		*/
 		      Sfio_t*	f,	/* the stream		*/
-		      int	n)	/* position in pool	*/
+		      ssize_t	n)	/* position in pool	*/
 {
 
 	p->n_sf -= 1;
@@ -149,7 +149,7 @@ static int _sfpdelete(Sfpool_t*	p,	/* the pool		*/
 		p->sf[n] = p->sf[n+1];
 
 	f->pool = NULL;
-	f->mode &= ~SFIO_POOL;
+	f->mode &= (uint32_t)~SFIO_POOL;
 
 	if(p->n_sf == 0 || p == &_Sfpool)
 	{	if(p != &_Sfpool)
@@ -169,7 +169,7 @@ static int _sfpdelete(Sfpool_t*	p,	/* the pool		*/
 
 	/* head stream has SFIO_POOL off */
 	f = p->sf[0];
-	f->mode &= ~SFIO_POOL;
+	f->mode &= (uint32_t)~SFIO_POOL;
 	if(!SFFROZEN(f))
 		_SFOPEN(f);
 
@@ -184,10 +184,10 @@ done:
 }
 
 static int _sfpmove(Sfio_t*	f,
-		    int	type)	/* <0 : deleting, 0: move-to-front, >0: inserting */
+		    int		type)	/* <0 : deleting, 0: move-to-front, >0: inserting */
 {
 	Sfpool_t*	p;
-	int		n;
+	ssize_t		n;
 
 	if(type > 0)
 		return _sfsetpool(f);
@@ -263,7 +263,7 @@ Sfio_t* sfpool(Sfio_t* f, Sfio_t* pf, int mode)
 	}
 
 	if(pf->pool && pf->pool != &_Sfpool) /* always use current mode */
-		mode = pf->pool->mode;
+		mode = (signed)pf->pool->mode;
 
 	if(mode&SFIO_SHARE) /* can only have write streams */
 	{	if(SFMODE(f,1) != SFIO_WRITE && _sfmode(f,SFIO_WRITE,1) < 0)

--- a/src/lib/libast/sfio/sfpopen.c
+++ b/src/lib/libast/sfio/sfpopen.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2012 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -30,8 +30,8 @@ Sfio_t*	sfpopen(Sfio_t*		f,
 		const char*	mode)		/* mode of the stream */
 {
 	Proc_t*		proc;
-	int		sflags;
-	long		flags;
+	unsigned short	sflags;
+	int		flags;
 	int		pflags;
 	char*		av[4];
 

--- a/src/lib/libast/sfio/sfprintf.c
+++ b/src/lib/libast/sfio/sfprintf.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2012 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 #include	"sfhdr.h"
@@ -23,10 +24,10 @@
 **	Written by Kiem-Phong Vo.
 */
 
-int sfprintf(Sfio_t* f, const char* form, ...)
+ssize_t sfprintf(Sfio_t* f, const char* form, ...)
 {
 	va_list	args;
-	int	rv;
+	ssize_t rv;
 	va_start(args,form);
 	rv = sfvprintf(f,form,args);
 	va_end(args);
@@ -49,10 +50,10 @@ ssize_t sfvsprintf(char* s, size_t n, const char* form, va_list args)
 	if((rv = sfvprintf(f,form,args)) < 0 )
 		return -1;
 	if(s && n > 0)
-	{	if((rv+1) >= n)
+	{	if((size_t)(rv+1) >= n)
 			n--;
 		else
-			n = rv;
+			n = (size_t)rv;
 		memcpy(s, f->data, n);
 		s[n] = 0;
 	}
@@ -67,7 +68,7 @@ ssize_t sfvsprintf(char* s, size_t n, const char* form, va_list args)
 ssize_t sfsprintf(char* s, size_t n, const char* form, ...)
 {
 	va_list	args;
-	ssize_t	rv;
+	ssize_t rv;
 	va_start(args,form);
 	rv = sfvsprintf(s,n,form,args);
 	va_end(args);

--- a/src/lib/libast/sfio/sfprints.c
+++ b/src/lib/libast/sfio/sfprints.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2012 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 #include	"sfhdr.h"
@@ -27,7 +28,7 @@
 
 char* sfvprints(const char* form, va_list args)
 {
-	int		rv;
+	ssize_t		rv;
 	Sfnotify_f	notify = _Sfnotify;
 	static Sfio_t*	f;
 
@@ -45,7 +46,7 @@ char* sfvprints(const char* form, va_list args)
 	if(rv < 0 || sfputc(f,'\0') < 0)
 		return NULL;
 
-	_Sfi = (f->next - f->data) - 1;
+	_Sfi = (ssize_t)(f->next - f->data) - 1;
 	return (char*)f->data;
 }
 
@@ -62,7 +63,7 @@ char* sfprints(const char* form, ...)
 ssize_t sfvaprints(char** sp, const char* form, va_list args)
 {
 	char	*s;
-	ssize_t	n;
+	size_t	n;
 
 	if(!sp || !(s = sfvprints(form,args)) )
 		return -1;
@@ -70,13 +71,13 @@ ssize_t sfvaprints(char** sp, const char* form, va_list args)
 	{	if(!(*sp = (char*)malloc(n = strlen(s)+1)) )
 			return -1;
 		memcpy(*sp, s, n);
-		return n-1;
+		return (ssize_t)n-1;
 	}
 }
 
 ssize_t sfaprints(char** sp, const char* form, ...)
 {
-	ssize_t	n;
+	ssize_t n;
 	va_list	args;
 	va_start(args,form);
 	n = sfvaprints(sp, form, args);

--- a/src/lib/libast/sfio/sfpurge.c
+++ b/src/lib/libast/sfio/sfpurge.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -56,7 +56,7 @@ int sfpurge(Sfio_t* f)
 	}
 #endif
 
-	switch(f->mode&~SFIO_LOCK)
+	switch(f->mode&(uint32_t)~SFIO_LOCK)
 	{
 	default :
 		SFOPEN(f,0);

--- a/src/lib/libast/sfio/sfputd.c
+++ b/src/lib/libast/sfio/sfputd.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2023 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,13 +14,14 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 #include	"sfhdr.h"
 
 #undef sfputd
 
-int sfputd(Sfio_t* f, Sfdouble_t d)
+ssize_t sfputd(Sfio_t* f, Sfdouble_t d)
 {
 	return __sf_putd(f,d);
 }

--- a/src/lib/libast/sfio/sfputl.c
+++ b/src/lib/libast/sfio/sfputl.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2023 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,13 +14,14 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 #include	"sfhdr.h"
 
 #undef sfputl
 
-int sfputl(Sfio_t* f, Sflong_t l)
+ssize_t sfputl(Sfio_t* f, Sflong_t l)
 {
 	return __sf_putl(f,l);
 }

--- a/src/lib/libast/sfio/sfputm.c
+++ b/src/lib/libast/sfio/sfputm.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,13 +14,14 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 #include	"sfhdr.h"
 
 #undef sfputm
 
-int sfputm(Sfio_t* f, Sfulong_t u, Sfulong_t m)
+ssize_t sfputm(Sfio_t* f, Sfulong_t u, Sfulong_t m)
 {
 	return __sf_putm(f, u, m);
 }

--- a/src/lib/libast/sfio/sfputr.c
+++ b/src/lib/libast/sfio/sfputr.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 #include	"sfhdr.h"
@@ -22,11 +23,11 @@
 **
 **	Written by Kiem-Phong Vo.
 */
-ssize_t sfputr(Sfio_t*		f,	/* write to this stream	*/
-	       const char*	s,	/* string to write	*/
-	       int		rc)	/* record separator 	*/
+ptrdiff_t sfputr(Sfio_t*		f,	/* write to this stream	*/
+	         const char*		s,	/* string to write	*/
+	         int			rc)	/* record separator 	*/
 {
-	ssize_t		p, n, w, sn;
+	ptrdiff_t	p, n, w, sn;
 	uchar		*ps;
 	char		*ss;
 
@@ -39,9 +40,9 @@ ssize_t sfputr(Sfio_t*		f,	/* write to this stream	*/
 	for(w = 0; (*s || rc >= 0); )
 	{	/* need to communicate string size to exception handler */
 		if((f->flags&SFIO_STRING) && f->next >= f->endb )
-		{	sn = sn < 0 ? strlen(s) : (sn - (s-ss));
+		{	sn = sn < 0 ? (ptrdiff_t)strlen(s) : (sn - (s-ss));
 			ss = (char*)s; /* save current checkpoint */
-			f->val = sn + (rc >= 0 ? 1 : 0); /* space requirement */
+			f->val = (ssize_t)sn + (rc >= 0 ? 1 : 0); /* space requirement */
 			f->bits |= SFIO_PUTR; /* tell sfflsbuf to use f->val */
 		}
 
@@ -52,16 +53,16 @@ ssize_t sfputr(Sfio_t*		f,	/* write to this stream	*/
 			break;
 
 		if(p == 0 || (f->flags&SFIO_WHOLE) )
-		{	n = sn < 0 ? strlen(s) : sn - (s-ss);
+		{	n = sn < 0 ? (ptrdiff_t)strlen(s) : sn - (s-ss);
 			if(p >= (n + (rc < 0 ? 0 : 1)) )
 			{	/* buffer can hold everything */
 				if(n > 0)
-				{	memcpy(ps, s, n);
+				{	memcpy(ps, s, (size_t)n);
 					ps += n;
 					w += n;
 				}
 				if(rc >= 0)
-				{	*ps++ = rc;
+				{	*ps++ = (uchar)rc;
 					w += 1;
 				}
 				f->next = ps;
@@ -71,14 +72,14 @@ ssize_t sfputr(Sfio_t*		f,	/* write to this stream	*/
 				Sfrsrv_t*	rsrv;
 
 				p = n + (rc >= 0 ? 1 : 0);
-				if(!(rsrv = _sfrsrv(f, p)) )
+				if(!(rsrv = _sfrsrv(f, (ssize_t)p)) )
 					n = 0;
 				else
 				{	if(n > 0)
-						memcpy(rsrv->data, s, n);
+						memcpy(rsrv->data, s, (size_t)n);
 					if(rc >= 0)
-						rsrv->data[n] = rc;
-					if((n = SFWRITE(f,rsrv->data,p)) < 0 )
+						rsrv->data[n] = (uchar)rc;
+					if((n = (ptrdiff_t)SFWRITE(f,rsrv->data,(size_t)p)) < 0 )
 						n = 0;
 				}
 
@@ -88,7 +89,7 @@ ssize_t sfputr(Sfio_t*		f,	/* write to this stream	*/
 		}
 
 		if(*s == 0)
-		{	*ps++ = rc;
+		{	*ps++ = (uchar)rc;
 			f->next = ps;
 			w += 1;
 			break;
@@ -100,7 +101,7 @@ ssize_t sfputr(Sfio_t*		f,	/* write to this stream	*/
 		 * same buffer. See: https://github.com/att/ast/issues/78
 		 */
 		for(; p > 0; --p, ++ps, ++s)
-			if((*ps = *s) == 0)
+			if((*ps = (uchar)*s) == 0)
 				break;
 
 		w += ps - f->next;
@@ -116,7 +117,7 @@ ssize_t sfputr(Sfio_t*		f,	/* write to this stream	*/
 	{	if(n > w)
 			n = w;
 		f->next -= n;
-		(void)SFWRITE(f,f->next,n);
+		(void)SFWRITE(f,f->next,(size_t)n);
 	}
 
 	SFOPEN(f,0);

--- a/src/lib/libast/sfio/sfputu.c
+++ b/src/lib/libast/sfio/sfputu.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2023 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,13 +14,14 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 #include	"sfhdr.h"
 
 #undef sfputu
 
-int sfputu(Sfio_t* f, Sfulong_t u)
+ssize_t sfputu(Sfio_t* f, Sfulong_t u)
 {
 	return __sf_putu(f,u);
 }

--- a/src/lib/libast/sfio/sfrd.c
+++ b/src/lib/libast/sfio/sfrd.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -55,14 +55,15 @@ ssize_t sfrd(Sfio_t* f, void* buf, size_t n, Sfdisc_t* disc)
 {
 	Sfoff_t		r;
 	Sfdisc_t*	dc;
-	int		local, rcrv, dosync, oerrno;
+	int		local, dosync, oerrno;
+	uint32_t	rcrv;
 
 	if(!f)
 		return -1;
 
 	GETLOCAL(f,local);
 	if((rcrv = f->mode & (SFIO_RC|SFIO_RV)) )
-		f->mode &= ~(SFIO_RC|SFIO_RV);
+		f->mode &= (uint32_t)~(SFIO_RC|SFIO_RV);
 	f->bits &= ~SFIO_JUSTSEEK;
 
 	if(f->mode&SFIO_PKRD)
@@ -76,7 +77,7 @@ ssize_t sfrd(Sfio_t* f, void* buf, size_t n, Sfdisc_t* disc)
 				return -1;
 			if((f->mode&(SFIO_SYNCED|SFIO_READ)) == (SFIO_SYNCED|SFIO_READ) )
 			{	f->endb = f->next = f->endr = f->data;
-				f->mode &= ~SFIO_SYNCED;
+				f->mode &= (uint32_t)~SFIO_SYNCED;
 			}
 #ifdef MAP_TYPE
 			if((f->bits&SFIO_MMAP) && f->data)
@@ -107,11 +108,11 @@ ssize_t sfrd(Sfio_t* f, void* buf, size_t n, Sfdisc_t* disc)
 		/* warn that a read is about to happen */
 		SFDISC(f,dc,readf);
 		if(dc && dc->exceptf && (f->flags&SFIO_IOCHECK) )
-		{	int	rv;
+		{	ssize_t	rv;
 			if(local)
 				SETLOCAL(f);
-			if((rv = _sfexcept(f,SFIO_READ,n,dc)) > 0)
-				n = rv;
+			if((rv = _sfexcept(f,SFIO_READ,(ssize_t)n,dc)) > 0)
+				n = (size_t)rv;
 			else if(rv < 0)
 			{	f->flags |= SFIO_ERROR;
 				return (ssize_t)rv;
@@ -125,7 +126,7 @@ ssize_t sfrd(Sfio_t* f, void* buf, size_t n, Sfdisc_t* disc)
 
 			/* determine if we have to copy data to buffer */
 			if((uchar*)buf >= f->data && (uchar*)buf <= f->endb)
-			{	n += f->endb - f->next;
+			{	n += (size_t)(f->endb - f->next);
 				buf = NULL;
 			}
 
@@ -146,13 +147,13 @@ ssize_t sfrd(Sfio_t* f, void* buf, size_t n, Sfdisc_t* disc)
 			}
 
 			/* make sure current position is page aligned */
-			if((a = (size_t)(f->here%_Sfpage)) != 0)
+			if((a = (ssize_t)(f->here%_Sfpage)) != 0)
 			{	f->here -= a;
 				r += a;
 			}
 
 			/* map minimal requirement */
-			if(r > (round = (1 + (n+a)/f->size)*f->size) )
+			if(r > (round = (ssize_t)(1 + ((ssize_t)n+a)/f->size)*f->size) )
 				r = round;
 
 			if(f->data)
@@ -186,13 +187,13 @@ ssize_t sfrd(Sfio_t* f, void* buf, size_t n, Sfdisc_t* disc)
 
 				if(buf)
 				{	if(n > (size_t)(r-a))
-						n = (ssize_t)(r-a);
+						n = (size_t)(r-a);
 					memmove(buf,f->next,n);
 					f->next += n;
 				}
-				else	n = f->endb - f->next;
+				else	n = (size_t)(f->endb - f->next);
 
-				return n;
+				return (ssize_t)n;
 			}
 			else
 			{	r = -1;
@@ -206,7 +207,7 @@ ssize_t sfrd(Sfio_t* f, void* buf, size_t n, Sfdisc_t* disc)
 
 				if(!buf)
 				{	buf = f->data;
-					n = f->size;
+					n = (size_t)f->size;
 				}
 			}
 		}
@@ -284,8 +285,8 @@ ssize_t sfrd(Sfio_t* f, void* buf, size_t n, Sfdisc_t* disc)
 		case SFIO_ECONT :
 			goto do_continue;
 		case SFIO_EDONE :
-			n = local ? 0 : (ssize_t)r;
-			return n;
+			n = local ? 0 : (size_t)r;
+			return (ssize_t)n;
 		case SFIO_EDISC :
 			if(!local && !(f->flags&SFIO_STRING))
 				goto do_continue;

--- a/src/lib/libast/sfio/sfread.c
+++ b/src/lib/libast/sfio/sfread.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 #include	"sfhdr.h"
@@ -32,49 +33,49 @@ ssize_t sfread(Sfio_t*	f,	/* read from this stream. 	*/
 	int		local, justseek;
 
 	if(!f)
-		return (ssize_t)(-1);
+		return -1;
 
 	GETLOCAL(f,local);
 	justseek = f->bits&SFIO_JUSTSEEK; f->bits &= ~SFIO_JUSTSEEK;
 
 	if(!buf)
-		return (ssize_t)(n == 0 ? 0 : -1) ;
+		return n == 0 ? 0 : -1;
 
 	/* release peek lock */
 	if(f->mode&SFIO_PEEK)
 	{	if(!(f->mode&SFIO_READ) )
-			return (ssize_t)(-1);
+			return -1;
 
 		if(f->mode&SFIO_GETR)
 		{	if(((uchar*)buf + f->val) != f->next &&
 			   (!f->rsrv || f->rsrv->data != (uchar*)buf) )
-				return (ssize_t)(-1);
-			f->mode &= ~SFIO_PEEK;
+				return -1;
+			f->mode &= (uint32_t)~SFIO_PEEK;
 			return 0;
 		}
 		else
 		{	if((uchar*)buf != f->next)
-				return (ssize_t)(-1);
-			f->mode &= ~SFIO_PEEK;
+				return -1;
+			f->mode &= (uint32_t)~SFIO_PEEK;
 			if(f->mode&SFIO_PKRD)
 			{	/* actually read the data now */
-				f->mode &= ~SFIO_PKRD;
+				f->mode &= (uint32_t)~SFIO_PKRD;
 				if(n > 0)
-					n = (r = read(f->file,f->data,n)) < 0 ? 0 : r;
+					n = (r = read(f->file,f->data,n)) < 0 ? 0 : (size_t)r;
 				f->endb = f->data+n;
 				f->here += n;
 			}
 			f->next += n;
 			f->endr = f->endb;
-			return n;
+			return (ssize_t)n;
 		}
 	}
 
 	s = begs = (uchar*)buf;
-	for(;; f->mode &= ~SFIO_LOCK)
+	for(;; f->mode &= (uint32_t)~SFIO_LOCK)
 	{	/* check stream mode */
 		if(SFMODE(f,local) != SFIO_READ && _sfmode(f,SFIO_READ,local) < 0)
-		{	n = s > begs ? s-begs : (size_t)(-1);
+		{	n = s > begs ? (size_t)(s-begs) : (size_t)(-1);
 			return (ssize_t)n;
 		}
 
@@ -84,13 +85,13 @@ ssize_t sfread(Sfio_t*	f,	/* read from this stream. 	*/
 		{	if(r > (ssize_t)n)
 				r = (ssize_t)n;
 			if(s != f->next)
-				memmove(s, f->next, r);
+				memmove(s, f->next, (size_t)r);
 			f->next += r;
 			s += r;
-			n -= r;
+			n -= (size_t)r;
 		}
 
-		if(n <= 0)	/* all done */
+		if((ssize_t)n <= 0)	/* all done */
 			break;
 
 		if(!(f->flags&SFIO_STRING) && !(f->bits&SFIO_MMAP) )
@@ -100,8 +101,8 @@ ssize_t sfread(Sfio_t*	f,	/* read from this stream. 	*/
 			if(SFDIRECT(f,n) ||
 			   ((f->flags&SFIO_SHARE) && f->extent < 0) )
 				r = (ssize_t)n;
-			else if(justseek && n <= f->iosz && f->iosz <= f->size)
-				r = f->iosz;	/* limit buffering */
+			else if(justseek && n <= f->iosz && f->iosz <= (size_t)f->size)
+				r = (ssize_t)f->iosz;	/* limit buffering */
 			else	r = f->size;	/* full buffering */
 
 			/* if read almost full size, then just do it direct */
@@ -109,9 +110,9 @@ ssize_t sfread(Sfio_t*	f,	/* read from this stream. 	*/
 				r = (ssize_t)n;
 
 			/* read directly to user's buffer */
-			if(r == (ssize_t)n && (r = SFRD(f,s,r,f->disc)) >= 0)
+			if(r == (ssize_t)n && (r = SFRD(f,s,(size_t)r,f->disc)) >= 0)
 			{	s += r;
-				n -= r;
+				n -= (size_t)r;
 				if(r == 0 || n == 0) /* eof or eob */
 					break;
 			}

--- a/src/lib/libast/sfio/sfreserve.c
+++ b/src/lib/libast/sfio/sfreserve.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 #include	"sfhdr.h"
@@ -118,16 +119,16 @@ void* sfreserve(Sfio_t*	f,	/* file to peek */
 		/* do a buffer refill or flush */
 		now = n;
 		if(f->mode&SFIO_WRITE)
-			(void)SFFLSBUF(f, iosz);
+			(void)SFFLSBUF(f, (ptrdiff_t)iosz);
 		else if(type == SFIO_LOCKR && f->extent < 0 && (f->flags&SFIO_SHARE) )
 		{	if(n == 0) /* peek-read only if there is no buffered data */
 			{	f->mode |= SFIO_RV;
-				(void)SFFILBUF(f, iosz );
+				(void)SFFILBUF(f, (ptrdiff_t)iosz );
 			}
 			if((n = f->endb - f->next) < sz)
 			{	if(f->mode&SFIO_PKRD)
 				{	f->endb = f->endr = f->next;
-					f->mode &= ~SFIO_PKRD;
+					f->mode &= (uint32_t)~SFIO_PKRD;
 				}
 				break;
 			}
@@ -137,7 +138,7 @@ void* sfreserve(Sfio_t*	f,	/* file to peek */
 			if(size == 0 && type == 0)
 				f->mode |= SFIO_RV;
 
-			(void)SFFILBUF(f, iosz );
+			(void)SFFILBUF(f, (ptrdiff_t)iosz );
 		}
 
 		if((n = f->endb - f->next) <= 0)
@@ -166,7 +167,7 @@ done:	/* compute the buffer to be returned */
 		data = f->next;
 	else if(f->flags&SFIO_STRING) /* try extending string buffer */
 	{	if((f->mode&SFIO_WRITE) && (f->flags&SFIO_MALLOC) )
-		{	(void)SFWR(f,f->next,sz,f->disc);
+		{	(void)SFWR(f,f->next,(size_t)sz,f->disc);
 			if((n = f->endb - f->next) >= sz )
 				data = f->next;
 		}
@@ -176,7 +177,7 @@ done:	/* compute the buffer to be returned */
 			data = rsrv->data;
 	}
 	else if(type != SFIO_LOCKR && sz > f->size && (rsrv = _sfrsrv(f,sz)) )
-	{	if((n = SFREAD(f,rsrv->data,sz)) >= sz) /* read side buffer */
+	{	if((n = SFREAD(f,rsrv->data,(size_t)sz)) >= sz) /* read side buffer */
 			data = rsrv->data;
 		else	rsrv->slen = -n;
 	}

--- a/src/lib/libast/sfio/sfresize.c
+++ b/src/lib/libast/sfio/sfresize.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 #include	"sfhdr.h"
@@ -36,20 +37,20 @@ int sfresize(Sfio_t* f, Sfoff_t size)
 
 		if(f->extent >= size)
 		{	if((f->flags&SFIO_MALLOC) && (f->next - f->data) <= size)
-			{	size_t	s = (((size_t)size + 1023)/1024)*1024;
+			{	size_t	s = ((size_t)(size + 1023)/1024)*1024;
 				void*	d;
-				if(s < f->size && (d = realloc(f->data, s)) )
+				if(s < (size_t)f->size && (d = realloc(f->data, s)) )
 				{	f->data = d;
-					f->size = s;
-					f->extent = s;
+					f->size = (ssize_t)s;
+					f->extent = (ssize_t)s;
 				}
 			}
-			memclear((char*)(f->data+size), (int)(f->extent-size));
+			memclear((char*)(f->data+size), (size_t)(f->extent-size));
 		}
 		else
 		{	if(SFSK(f, size, SEEK_SET, f->disc) != size)
 				return -1;
-			memclear((char*)(f->data+f->extent), (int)(size-f->extent));
+			memclear((char*)(f->data+f->extent), (size_t)(size-f->extent));
 		}
 	}
 	else

--- a/src/lib/libast/sfio/sfscanf.c
+++ b/src/lib/libast/sfio/sfscanf.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 #include	"sfhdr.h"
@@ -45,7 +46,7 @@ int sfvsscanf(const char* s, const char* form, va_list args)
 	f.flags = SFIO_STRING|SFIO_READ;
 	f.bits = SFIO_PRIVATE;
 	f.mode = SFIO_READ;
-	f.size = strlen((char*)s);
+	f.size = (ssize_t)strlen((char*)s);
 	f.data = f.next = f.endw = (uchar*)s;
 	f.endb = f.endr = f.data+f.size;
 

--- a/src/lib/libast/sfio/sfseek.c
+++ b/src/lib/libast/sfio/sfseek.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -61,7 +61,7 @@ Sfoff_t sfseek(Sfio_t*	f,	/* seek to a new location in this stream */
 
 	/* set and initialize the stream to a definite mode */
 	if((int)SFMODE(f,local) != (mode = f->mode&SFIO_RDWR))
-	{	int	flags = f->flags;
+	{	unsigned short	flags = f->flags;
 
 		if(hardseek&SFIO_PUBLIC) /* seek ptr must follow file descriptor */
 			f->flags |= SFIO_SHARE|SFIO_PUBLIC;
@@ -112,7 +112,7 @@ Sfoff_t sfseek(Sfio_t*	f,	/* seek to a new location in this stream */
 			f->next = f->data ? f->data + p : NULL;
 			f->here = p;
 			if(p > f->extent)
-				memclear((char*)(f->data+f->extent),(int)(p-f->extent));
+				memclear((char*)(f->data+f->extent),(size_t)(p-f->extent));
 			goto done;
 		}
 
@@ -207,23 +207,22 @@ Sfoff_t sfseek(Sfio_t*	f,	/* seek to a new location in this stream */
 
 	if(f->endb > f->next)
 	{	/* reduce wastage in future buffer fillings */
-		f->iosz = (f->next - f->data) + (f->endb - f->next)/2;
 		f->iosz = ((f->iosz + f->blksz-1)/f->blksz)*f->blksz;
 	}
-	if(f->iosz >= f->size)
+	if(f->iosz >= (size_t)f->size)
 		f->iosz = 0;
 
 	/* buffer is now considered empty */
 	f->next = f->endr = f->endb = f->data;
 
 	/* small backseeks often come in bunches, so seek back as far as possible */
-	if(p < f->lpos && f->size > f->blksz && (p + f->blksz) > s)
+	if(p < f->lpos && (size_t)f->size > f->blksz && ((size_t)p + f->blksz) > (size_t)s)
 	{	if((r = s - f->size) < 0)
 			r = 0;
 	}
 	/* try to align buffer to block boundary to enhance I/O speed */
-	else if(f->blksz > 0 && f->size >= 2*f->blksz)
-		r = p - (p%f->blksz);
+	else if(f->blksz > 0 && (size_t)f->size >= 2*f->blksz)
+		r = p - (p%(Sflong_t)f->blksz);
 	else
 	{	r = p;
 
@@ -241,7 +240,7 @@ Sfoff_t sfseek(Sfio_t*	f,	/* seek to a new location in this stream */
 	}
 
 	if(r < p) /* read to cover p */
-	{	(void)SFRD(f, f->data, f->size, f->disc);
+	{	(void)SFRD(f, f->data, (size_t)f->size, f->disc);
 		if(p <= f->here && p >= (f->here - (f->endb - f->data)) )
 			f->next = f->endb - (size_t)(f->here-p);
 		else /* recover from read failure by just seeking to p */

--- a/src/lib/libast/sfio/sfsetbuf.c
+++ b/src/lib/libast/sfio/sfsetbuf.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -68,13 +68,13 @@ static int sfsetlinemode(void)
 					++astsfio;
 				for(endw = astsfio; *endw && !ISSEPAR(*endw); ++endw)
 					;
-				if((endw-astsfio) > (sizeof(sf_line)-1) &&
+				if((endw-astsfio) > ((ssize_t)sizeof(sf_line)-1) &&
 				   strncmp(astsfio,sf_line,sizeof(sf_line)-1) == 0)
 					modes |= SFIO_LINE;
-				else if((endw-astsfio) > (sizeof(sf_maxr)-1) &&
+				else if((endw-astsfio) > ((ssize_t)sizeof(sf_maxr)-1) &&
 				   strncmp(astsfio,sf_maxr,sizeof(sf_maxr)-1) == 0)
 					_Sfmaxr = (ssize_t)strtonll(astsfio+sizeof(sf_maxr)-1,NULL,NULL,0);
-				else if((endw-astsfio) > (sizeof(sf_wcwidth)-1) &&
+				else if((endw-astsfio) > ((ssize_t)sizeof(sf_wcwidth)-1) &&
 				   strncmp(astsfio,sf_wcwidth,sizeof(sf_wcwidth)-1) == 0)
 					modes |= SFIO_WCWIDTH;
 			}
@@ -89,7 +89,8 @@ void* sfsetbuf(Sfio_t*	f,	/* stream to be buffered */
 	       void*	buf,	/* new buffer */
 	       size_t	size)	/* buffer size, -1 for default size */
 {
-	int		sf_malloc, oflags, init, local;
+	int		oflags, init, local;
+	unsigned short	sf_malloc;
 	ssize_t		bufsize, blksz;
 	Sfdisc_t*	disc;
 	struct stat	st;
@@ -139,7 +140,7 @@ void* sfsetbuf(Sfio_t*	f,	/* stream to be buffered */
 			return NULL;
 
 		/* turn off the SFIO_SYNCED bit because buffer is changing */
-		f->mode &= ~SFIO_SYNCED;
+		f->mode &= (uint32_t)~SFIO_SYNCED;
 	}
 
 	SFLOCK(f,local);
@@ -242,7 +243,7 @@ void* sfsetbuf(Sfio_t*	f,	/* stream to be buffered */
 		if(_Sfpage <= 0)
 		{
 #if _lib_getpagesize
-			if((_Sfpage = (size_t)getpagesize()) <= 0)
+			if((_Sfpage = (ssize_t)getpagesize()) <= 0)
 #endif
 				_Sfpage = SFIO_PAGE;
 		}
@@ -276,17 +277,20 @@ void* sfsetbuf(Sfio_t*	f,	/* stream to be buffered */
 						f->flags |= SFIO_LINE|SFIO_WCWIDTH;
 #if _sys_stat
 					else	/* special case /dev/null */
-					{	int	dev, ino;
-						static int null_checked, null_dev, null_ino;
-						dev = (int)st.st_dev;
-						ino = (int)st.st_ino;
+					{	dev_t		dev;
+						ino_t		ino;
+						static int	null_checked;
+						static dev_t	null_dev;
+						static ino_t	null_ino;
+						dev = st.st_dev;
+						ino = st.st_ino;
 						if(!null_checked)
 						{	if(stat(DEVNULL,&st) < 0)
 								null_checked = -1;
 							else
 							{	null_checked = 1;
-								null_dev = (int)st.st_dev;
-								null_ino = (int)st.st_ino;
+								null_dev = st.st_dev;
+								null_ino = st.st_ino;
 							}
 						}
 						if(null_checked >= 0 && dev == null_dev && ino == null_ino)
@@ -314,8 +318,8 @@ void* sfsetbuf(Sfio_t*	f,	/* stream to be buffered */
 		{	f->bits |= SFIO_MMAP;
 			if(size == (size_t)SFIO_UNBOUND)
 			{	if(bufsize > _Sfpage)
-					size = bufsize * SFIO_NMAP;
-				else	size = _Sfpage * SFIO_NMAP;
+					size = (size_t)bufsize * SFIO_NMAP;
+				else	size = (size_t)_Sfpage * SFIO_NMAP;
 				if(size > 256*1024)
 					size = 256*1024;
 			}
@@ -328,7 +332,7 @@ setbuf:
 	if(size == (size_t)SFIO_UNBOUND)
 	{	/* define a default size suitable for block transfer */
 		if(init && osize > 0)
-			size = osize;
+			size = (size_t)osize;
 		else if(f == sfstderr && (f->mode&SFIO_WRITE))
 			size = 0;
 		else if(f->flags&SFIO_STRING )
@@ -336,8 +340,8 @@ setbuf:
 		else if((f->flags&SFIO_READ) && !(f->bits&SFIO_BOTH) &&
 			f->extent > 0 && f->extent < (Sfoff_t)_Sfpage )
 			size = (((size_t)f->extent + SFIO_GRAIN-1)/SFIO_GRAIN)*SFIO_GRAIN;
-		else if((ssize_t)(size = _Sfpage) < bufsize)
-			size = bufsize;
+		else if((ssize_t)(size = (size_t)_Sfpage) < bufsize)
+			size = (size_t)bufsize;
 
 		buf = NULL;
 	}
@@ -369,13 +373,13 @@ setbuf:
 	}
 
 	/* set up new buffer */
-	f->size = size;
+	f->size = (ssize_t)size;
 	f->next = f->data = f->endr = f->endw = (uchar*)buf;
 	f->endb = buf ? ((f->mode&SFIO_READ) ? f->data : f->data+size) : NULL;
 	if(f->flags&SFIO_STRING)
 	{	/* these fields are used to test actual size - see sfseek() */
 		f->extent = (!sf_malloc &&
-			     ((f->flags&SFIO_READ) || (f->bits&SFIO_BOTH)) ) ? size : 0;
+			     ((f->flags&SFIO_READ) || (f->bits&SFIO_BOTH)) ) ? (Sflong_t)size : 0;
 		f->here = 0;
 
 		/* read+string stream should have all data available */
@@ -402,7 +406,7 @@ done:
 		blksz = SFIO_GRAIN;
 	while(blksz > f->size/2)
 		blksz /= 2;
-	f->blksz = blksz;
+	f->blksz = (size_t)blksz;
 
 	SFOPEN(f,local);
 

--- a/src/lib/libast/sfio/sfstack.c
+++ b/src/lib/libast/sfio/sfstack.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 #include	"sfhdr.h"
@@ -44,7 +45,7 @@ Sfio_t* sfstack(Sfio_t*	f1,	/* base of stack	*/
 	if(f2 == SFIO_POPSTACK)
 	{	if(!(f2 = f1->push))
 			return NULL;
-		f2->mode &= ~SFIO_PUSH;
+		f2->mode &= (uint32_t)~SFIO_PUSH;
 	}
 	else
 	{	if(f2->push)
@@ -81,7 +82,7 @@ Sfio_t* sfstack(Sfio_t*	f1,	/* base of stack	*/
 	}
 	else
 	{	/* unfreeze the just exposed stream */
-		f1->mode &= ~SFIO_PUSH;
+		f1->mode &= (uint32_t)~SFIO_PUSH;
 		f2->push = NULL;
 		rf = f2;
 	}

--- a/src/lib/libast/sfio/sfstrtod.c
+++ b/src/lib/libast/sfio/sfstrtod.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2023 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 #include	"sfhdr.h"
@@ -24,10 +25,10 @@
 **	Written by Kiem-Phong Vo.
 */
 
-#define BATCH	(2*sizeof(int))	/* accumulate this many digits at a time */
-#define IPART		0	/* doing integer part */
-#define FPART		1	/* doing fractional part */
-#define EPART		2	/* doing exponent part */
+#define BATCH	((int)(2*sizeof(int)))	/* accumulate this many digits at a time */
+#define IPART		0		/* doing integer part */
+#define FPART		1		/* doing fractional part */
+#define EPART		2		/* doing exponent part */
 
 static Sfdouble_t sfpow10(int n)
 {

--- a/src/lib/libast/sfio/sfstrtof.h
+++ b/src/lib/libast/sfio/sfstrtof.h
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2025 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 /*
@@ -162,19 +163,19 @@ S2F_function(const char* str, char** end)
 #endif
 {
 #if !S2F_scan
-	unsigned char*	s = (unsigned char*)str;
+	uchar*		s = (uchar*)str;
 #if S2F_size
-	unsigned char*	z = s + size;
+	uchar*		z = s + size;
 	int		back = 1;
 	int		b;
 #endif
-	unsigned char*		t;
+	uchar*		t;
 #endif
 	S2F_batch	n;
 	int		c;
 	int		digits;
 	int		m;
-	unsigned char*	cv;
+	uchar*		cv;
 	int		negative;
 	int		enegative;
 	int		fraction;
@@ -366,8 +367,8 @@ S2F_function(const char* str, char** end)
 		if (c >= '0' && c <= '9')
 		{
 			digits++;
-			n = (n << 3) + (n << 1) + (c - '0');
-			if (n >= ((~((S2F_batch)0)) / 10) && part < elementsof(parts))
+			n = (n << 3) + (n << 1) + (S2F_batch)(c - '0');
+			if (n >= ((~((S2F_batch)0)) / 10) && part < (ssize_t)elementsof(parts))
 			{
 				parts[part].batch = n;
 				n = 0;
@@ -410,7 +411,7 @@ S2F_function(const char* str, char** end)
 	 * don't forget the last part
 	 */
 
-	if (n && part < elementsof(parts))
+	if (n && part < (ssize_t)elementsof(parts))
 	{
 		parts[part].batch = n;
 		parts[part].digits = digits;
@@ -431,7 +432,7 @@ S2F_function(const char* str, char** end)
 		n = 0;
 		while (c >= '0' && c <= '9')
 		{
-			n = (n << 3) + (n << 1) + (c - '0');
+			n = (n << 3) + (n << 1) + (S2F_batch)(c - '0');
 			c = GET(s);
 		}
 		if (enegative)

--- a/src/lib/libast/sfio/sfswap.c
+++ b/src/lib/libast/sfio/sfswap.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -30,7 +30,8 @@
 Sfio_t* sfswap(Sfio_t* f1, Sfio_t* f2)
 {
 	Sfio_t		tmp;
-	int		f1pool, f2pool, f1flags, f2flags;
+	ssize_t		f1pool, f2pool;
+	int		f1flags, f2flags;
 	unsigned int	f1mode, f2mode;
 
 	if(!f1 || (f1->mode&SFIO_AVAIL) || (SFFROZEN(f1) && (f1->mode&SFIO_PUSH)) )

--- a/src/lib/libast/sfio/sfsync.c
+++ b/src/lib/libast/sfio/sfsync.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -75,7 +75,8 @@ static int _sfall(void)
 
 int sfsync(Sfio_t* f)
 {
-	int	local, rv, lock;
+	int		local, rv;
+	uint32_t	lock;
 	Sfio_t*	origf;
 
 	if(!(origf = f) )
@@ -110,7 +111,7 @@ int sfsync(Sfio_t* f)
 
 		/* pretend that this stream is not on a stack */
 		mode = f->mode&SFIO_PUSH;
-		f->mode &= ~SFIO_PUSH;
+		f->mode &= (uint32_t)~SFIO_PUSH;
 
 		/* these streams do not need synchronization */
 		if((f->flags&SFIO_STRING) || (f->mode&SFIO_SYNCED))
@@ -119,7 +120,7 @@ int sfsync(Sfio_t* f)
 		if((f->mode&SFIO_WRITE) && (f->next > f->data || (f->bits&SFIO_HOLE)) )
 		{	/* sync the buffer, make sure pool doesn't move */
 			unsigned int pool = f->mode&SFIO_POOL;
-			f->mode &= ~SFIO_POOL;
+			f->mode &= (uint32_t)~SFIO_POOL;
 			if(f->next > f->data && (SFWRALL(f), SFFLSBUF(f,-1)) < 0)
 				rv = -1;
 			if(!SFISNULL(f) && (f->bits&SFIO_HOLE) )
@@ -142,7 +143,7 @@ int sfsync(Sfio_t* f)
 			if((f->flags&SFIO_SHARE) && !(f->flags&SFIO_PUBLIC) &&
 			   !(f->bits&SFIO_MMAP) )
 			{	f->endb = f->next = f->data;
-				f->mode &= ~SFIO_SYNCED;
+				f->mode &= (uint32_t)~SFIO_SYNCED;
 			}
 		}
 

--- a/src/lib/libast/sfio/sftable.c
+++ b/src/lib/libast/sfio/sftable.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2012 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2025 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -26,7 +26,7 @@
 **	Written by Kiem-Phong Vo.
 */
 
-static char* sffmtint(const char* str, int* v)
+static char* sffmtint(const char* str, ptrdiff_t* v)
 {
 	for(*v = 0; isdigit(*str); ++str)
 		*v = *v * 10 + (*str - '0');
@@ -37,16 +37,17 @@ static char* sffmtint(const char* str, int* v)
 /* type>0: scanf, type==0: printf, type==-1: internal */
 static Fmtpos_t* sffmtpos(Sfio_t* f,const char* form,va_list args,Sffmt_t* ft,int type)
 {
-	int		base, fmt, flags, dot, width, precis;
-	ssize_t		n_str, size = 0;
+	int		fmt, flags, dot;
+	ptrdiff_t	n, n_str, argp, base, precis, size = 0, v, width;
 	char		*t_str, *sp;
-	int		v, n, skip, dollar, decimal, thousand;
+	int		skip, dollar, decimal, thousand;
 	Sffmt_t		savft;
 	Fmtpos_t*	fp;	/* position array of arguments	*/
-	int		argp, maxp, need[FP_INDEX];
-	int		nargs;	/* the argv[] index of the last seen sequential % format (% or *) */
-	int		xargs;	/* highest (max) argv[] index see in an indexed format (%x$ *x$)  */
-	int		nextarg = 0;
+	ptrdiff_t	maxp;
+	ptrdiff_t	need[FP_INDEX];
+	ptrdiff_t	nargs;	/* the argv[] index of the last seen sequential % format (% or *) */
+	ptrdiff_t	xargs;	/* highest (max) argv[] index see in an indexed format (%x$ *x$)  */
+	ptrdiff_t	nextarg = 0;
 	SFMBDCL(fmbs)
 
 	if(type < 0)
@@ -209,7 +210,7 @@ static Fmtpos_t* sffmtpos(Sfio_t* f,const char* form,va_list args,Sffmt_t* ft,in
 		case 'I' : /* object length */
 			size = -1; flags = (flags & ~SFFMT_TYPES) | SFFMT_IFLAG;
 			if(isdigit(*form) )
-			{	for(size = 0, n = *form; isdigit(n); n = *++form)
+			{	for(size = 0, n = *form; isdigit((int)n); n = *++form)
 					size = size*10 + (n - '0');
 			}
 			else if(*form == '*')
@@ -328,7 +329,7 @@ static Fmtpos_t* sffmtpos(Sfio_t* f,const char* form,va_list args,Sffmt_t* ft,in
 
 	maxp = nargs > xargs ? nargs : xargs;
 	if(!fp) /* constructing position array only */
-	{	if(!dollar || !(fp = (Fmtpos_t*)malloc((maxp+1)*sizeof(Fmtpos_t))) )
+	{	if(!dollar || !(fp = (Fmtpos_t*)malloc((size_t)(maxp+1)*sizeof(Fmtpos_t))) )
 			return NULL;
 		for(n = 0; n <= maxp; ++n)
 			fp[n].ft.fmt = 0;
@@ -405,7 +406,7 @@ static Fmtpos_t* sffmtpos(Sfio_t* f,const char* form,va_list args,Sffmt_t* ft,in
 		{ arg_list:
 			if(fp[n].ft.fmt == LEFTP)
 			{	fp[n].argv.s = va_arg(args, char*);
-				fp[n].ft.size = strlen(fp[n].argv.s);
+				fp[n].ft.size = (ptrdiff_t)strlen(fp[n].argv.s);
 			}
 			else if(fp[n].ft.fmt == '.' || fp[n].ft.fmt == 'I')
 				fp[n].argv.i = va_arg(args, int);
@@ -482,26 +483,26 @@ static int sfcvinit(void)
 
 	/* [0-9] */
 	for(d = 0; d < 10; ++d)
-	{	_Sfcv36[(uchar)_Sfdigits[d]] = d;
-		_Sfcv64[(uchar)_Sfdigits[d]] = d;
+	{	_Sfcv36[(uchar)_Sfdigits[d]] = (uchar)d;
+		_Sfcv64[(uchar)_Sfdigits[d]] = (uchar)d;
 	}
 
 	/* [a-z] */
 	for(; d < 36; ++d)
-	{	_Sfcv36[(uchar)_Sfdigits[d]] = d;
-		_Sfcv64[(uchar)_Sfdigits[d]] = d;
+	{	_Sfcv36[(uchar)_Sfdigits[d]] = (uchar)d;
+		_Sfcv64[(uchar)_Sfdigits[d]] = (uchar)d;
 	}
 
 	/* [A-Z] */
 	for(l = 10; d < 62; ++l, ++d)
-	{	_Sfcv36[(uchar)_Sfdigits[d]] = l;
-		_Sfcv64[(uchar)_Sfdigits[d]] = d;
+	{	_Sfcv36[(uchar)_Sfdigits[d]] = (uchar)l;
+		_Sfcv64[(uchar)_Sfdigits[d]] = (uchar)d;
 	}
 
 	/* remaining digits */
 	for(; d < SFIO_RADIX; ++d)
-	{	_Sfcv36[(uchar)_Sfdigits[d]] = d;
-		_Sfcv64[(uchar)_Sfdigits[d]] = d;
+	{	_Sfcv36[(uchar)_Sfdigits[d]] = (uchar)d;
+		_Sfcv64[(uchar)_Sfdigits[d]] = (uchar)d;
 	}
 
 	_Sftype['d'] = _Sftype['i'] = SFFMT_INT;

--- a/src/lib/libast/sfio/sftmp.c
+++ b/src/lib/libast/sfio/sftmp.c
@@ -207,7 +207,7 @@ static int _tmpexcept(Sfio_t* f, int type, void* val, Sfdisc_t* disc)
 	if(savf.data)
 	{	SFSTRSIZE(&savf);
 		if(!(savf.flags&SFIO_MALLOC) )
-			(void)sfsetbuf(f,savf.data,savf.size);
+			(void)sfsetbuf(f,savf.data,(size_t)savf.size);
 		if(savf.extent > 0)
 			(void)sfwrite(f,savf.data,(size_t)savf.extent);
 		(void)sfseek(f,(Sfoff_t)(savf.next - savf.data),SEEK_SET);

--- a/src/lib/libast/sfio/sfungetc.c
+++ b/src/lib/libast/sfio/sfungetc.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -70,13 +70,13 @@ int sfungetc(Sfio_t*	f,	/* push back one byte to this stream */
 	{	uchar*	data;
 		if(f->size < 0)
 			f->size = 0;
-		if(!(data = (uchar*)malloc(f->size+16)))
+		if(!(data = (uchar*)malloc((size_t)(f->size+16))))
 		{	c = -1;
 			goto done;
 		}
 		f->flags |= SFIO_MALLOC;
 		if(f->data)
-			memcpy((char*)(data+16),(char*)f->data,f->size);
+			memcpy((char*)(data+16),(char*)f->data,(size_t)f->size);
 		f->size += 16;
 		f->data  = data;
 		f->next  = data+16;

--- a/src/lib/libast/sfio/sfvprintf.c
+++ b/src/lib/libast/sfio/sfvprintf.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2012 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -40,7 +40,7 @@
 
 #include <ccode.h>
 
-static int chr2str(char* buf, int v)
+static int chr2str(char* buf, char v)
 {
 	if(isprint(v) && v != '\\')
 	{	*buf++ = v;
@@ -74,21 +74,22 @@ static int chr2str(char* buf, int v)
 #define _sffmt_small	1
 #endif
 
-int sfvprintf(Sfio_t*		f,		/* file to print to	*/
-	      const char*	form,		/* format to use	*/
-	      va_list		args)		/* arg list if !argf	*/
+ssize_t sfvprintf(Sfio_t*		f,		/* file to print to	*/
+		    const char*		form,		/* format to use	*/
+		    va_list		args)		/* arg list if !argf	*/
 {
-	int		n, v=0, w, k, n_s, base, fmt, flags;
+	int		fmt, flags;
 	Sflong_t	lv;
 	char		*sp, *ssp, *endsp, *ep, *endep;
-	int		dot, width, precis, sign, decpt;
-	int		scale;
-	ssize_t		size;
+	int		dot, sign, decpt;
+	unsigned int	scale;
+	ptrdiff_t	base, k, n, n_s, q, precis, size, v, w, width;
+	ssize_t		n_w;
 	Sfdouble_t	dval;
 	void*		valp;
 	char		*tls[2], **ls;	/* for %..[separ]s		*/
 	char*		t_str;		/* stuff between ()		*/
-	ssize_t		n_str;		/* its length			*/
+	ptrdiff_t	n_str;		/* its length			*/
 
 	Argv_t		argv;		/* for extf to return value	*/
 	Sffmt_t		*ft;		/* format environment		*/
@@ -97,9 +98,10 @@ int sfvprintf(Sfio_t*		f,		/* file to print to	*/
 	char*		oform;		/* original format string	*/
 	va_list		oargs;		/* original arg list		*/
 	Fmtpos_t*	fp;		/* arg position list		*/
-	int		argp, argn;	/* arg position and number	*/
-	int		nargs;		/* the argv[] index of the last seen sequential % format (% or *) */
-	int		xargs;		/* highest (max) argv[] index see in an indexed format (%x$ *x$)  */
+	ptrdiff_t	argn;		/* arg number			*/
+	ptrdiff_t	argp;		/* arg position			*/
+	ptrdiff_t	nargs;		/* the argv[] index of the last seen sequential % format (% or *) */
+	ptrdiff_t	xargs;		/* highest (max) argv[] index see in an indexed format (%x$ *x$)  */
 
 #define SLACK		1024
 	char		buf[SFIO_MAXDIGITS+SLACK], tmp[SFIO_MAXDIGITS+1], data[SFIO_GRAIN];
@@ -110,19 +112,19 @@ int sfvprintf(Sfio_t*		f,		/* file to print to	*/
 	SFMBDCL(fmbs)			/* state of format string	*/
 	SFMBDCL(mbs)			/* state of some string		*/
 	char*		osp;
-	int		n_w, wc;
+	int		wc;
 #endif
 
 	/* local io system */
-	int		o, n_output;
-#define SMputc(f,c)	{ if((o = SFFLSBUF(f,c)) >= 0 ) n_output += 1; \
+	ssize_t		o, n_output;
+#define SMputc(f,c)	{ if((o = (ssize_t)SFFLSBUF(f,c)) >= 0 ) n_output += 1; \
 			  else		{ SFBUF(f); goto done; } \
 			}
-#define SMnputc(f,c,n)	{ if((o = SFNPUTC(f,c,n)) > 0 ) n_output += 1; \
-			  if(o != n)	{ SFBUF(f); goto done; } \
+#define SMnputc(f,c,n)	{ if((o = (ssize_t)SFNPUTC(f,c,(size_t)(n))) > 0 ) n_output += 1; \
+			  if(o != (ssize_t)(n))	{ SFBUF(f); goto done; } \
 			}
-#define SMwrite(f,s,n)	{ if((o = SFWRITE(f,s,n)) > 0 ) n_output += o; \
-			  if(o != n)	{ SFBUF(f); goto done; } \
+#define SMwrite(f,s,n)	{ if((o = (ssize_t)SFWRITE(f,s,(size_t)(n))) > 0 ) n_output += o; \
+			  if(o != (ssize_t)(n))	{ SFBUF(f); goto done; } \
 			}
 #if _sffmt_small /* these macros are made smaller at some performance cost */
 #define SFBUF(f)
@@ -140,10 +142,10 @@ int sfvprintf(Sfio_t*		f,		/* file to print to	*/
 	  		  else		  { SFEND(f); SMputc(f,c); SFBUF(f); } \
 	  		}
 #define SFnputc(f,c,n)	{ if(d+n <= endd) { while(n--) *d++ = (uchar)(c); } \
-			  else		  { SFEND(f); SMnputc(f,c,n); SFBUF(f); } \
+			  else		  { SFEND(f); SMnputc(f,c,(size_t)(n)); SFBUF(f); } \
 			}
 #define SFwrite(f,s,n)	{ if(d+n <= endd) { while(n--) *d++ = (uchar)(*s++); } \
-			  else 		  { SFEND(f); SMwrite(f,s,n); SFBUF(f); } \
+			  else 		  { SFEND(f); SMwrite(f,s,(size_t)(n)); SFBUF(f); } \
 			}
 #endif /* _sffmt_small */
 
@@ -189,8 +191,8 @@ loop_fmt :
 				}
 			} while(*(form += n) && *form != '%');
 
-			n = form-sp;
-			SFwrite(f,sp,n);
+			q = form-sp;
+			SFwrite(f,sp,q);
 			continue;
 		}
 		else	form += 1;
@@ -261,13 +263,13 @@ loop_fmt :
 							if(!(ft->flags&SFFMT_VALUE) )
 								goto t_arg;
 							if((t_str = argv.s) &&
-							   (n_str = (int)ft->size) < 0)
-								n_str = strlen(t_str);
+							   (n_str = ft->size) < 0)
+								n_str = (ptrdiff_t)strlen(t_str);
 						}
 						else
 						{ t_arg:
 							if((t_str = va_arg(args,char*)) )
-								n_str = strlen(t_str);
+								n_str = (ptrdiff_t)strlen(t_str);
 						}
 					}
 					goto loop_flags;
@@ -438,7 +440,7 @@ loop_fmt :
 			else if (fmt == 'z')
 				flags = (flags&~SFFMT_TYPES) | SFFMT_ZFLAG;
 			else if(isdigit(*form) )
-			{	for(size = 0, n = *form; isdigit(n); n = *++form)
+			{	for(size = 0, n = *form; isdigit((int)n); n = *++form)
 					size = size*10 + (n - '0');
 			}
 			goto loop_flags;
@@ -529,7 +531,7 @@ loop_fmt :
 				}
 				else	/* reload ft on type mismatch */
 				{	FMTSET(ft, form, args, fmt, size, flags, width, precis, base, t_str, n_str);
-					(*ft->reloadf)(argp, fmt, &argv, ft);
+					(*ft->reloadf)(argp, (char)fmt, &argv, ft);
 					FMTGET(ft, form, args, fmt, size, flags, width, precis, base);
 				}
 			}
@@ -701,7 +703,7 @@ loop_fmt :
 					{	if((size >= 0 && n >= size) ||
 						   (size <  0 && *wsp == 0) )
 							break;
-						if((n_s = wcrtomb(buf, *wsp, &mbs)) <= 0)
+						if((n_s = (ptrdiff_t)wcrtomb(buf, *wsp, &mbs)) <= 0)
 							break;
 						if(wc)
 						{	n_w = mbwidth(*wsp);
@@ -730,7 +732,7 @@ loop_fmt :
 						osp = ssp;
 						if((n = mbchar(osp)) == 0)
 							break;
-						if(n > 0 && (n_w = mbwidth(n)) > 0)
+						if(n > 0 && (n_w = mbwidth((wchar_t)n)) > 0)
 						{
 							if(precis >= 0 && (w+n_w) > precis)
 								break;
@@ -767,7 +769,7 @@ loop_fmt :
 						wsp = (wchar_t*)sp;
 						while(n < 0)
 						{
-							int	wd;
+							ssize_t wd;
 							if ((wd = mbwidth(*wsp)) > 0)
 								n += wd;
 							wsp++;
@@ -779,13 +781,13 @@ loop_fmt :
 					{	SFMBCLR(&mbs);
 						osp = sp;
 						while(n < 0)
-						{	int	wd;
+						{	ssize_t wd;
 							ssp = sp;
 							if ((k = mbchar(sp)) <= 0)
 							{	sp = ssp;
 								break;
 							}
-							if ((wd = mbwidth(k)) > 0)
+							if ((wd = mbwidth((wchar_t)k)) > 0)
 								n += wd;
 						}
 						v -= (sp - osp);
@@ -801,7 +803,7 @@ loop_fmt :
 				if(flags & SFFMT_LONG)
 				{	SFMBCLR(&mbs);
 					for(wsp = (wchar_t*)sp; w > 0; ++wsp, --w)
-					{	if((n_s = wcrtomb(buf, *wsp, &mbs)) <= 0)
+					{	if((n_s = (ptrdiff_t)wcrtomb(buf, *wsp, &mbs)) <= 0)
 							break;
 						sp = buf; SFwrite(f, sp, n_s);
 					}
@@ -846,7 +848,7 @@ loop_fmt :
 			{	if(base >= 0)
 				{	if(!(sp = argv.s) )
 						continue;
-					size = strlen(sp);
+					size = (ptrdiff_t)strlen(sp);
 				}
 				else
 				{	argv.c = (char)(argv.i);
@@ -860,7 +862,7 @@ loop_fmt :
 #if _has_multibyte
 				if(flags&SFFMT_LONG)
 				{	SFMBCLR(&mbs);
-					if((n_s = wcrtomb(buf, *wsp++, &mbs)) <= 0)
+					if((n_s = (ptrdiff_t)wcrtomb(buf, *wsp++, &mbs)) <= 0)
 						break;
 					if(wc)
 					{
@@ -940,7 +942,7 @@ loop_fmt :
 			lv = (Sflong_t)((Sfulong_t)argv.vp);
 			goto long_cvt;
 #else
-			v = (int)((uint)argv.vp);
+			v = (ptrdiff_t)((size_t)argv.vp);
 			goto int_cvt;
 #endif
 		case 'o':
@@ -993,7 +995,7 @@ loop_fmt :
 				else	lv = (Sflong_t)argv.ul;
 			long_cvt:
 				if(scale)
-				{	sp = fmtscale(lv, scale);
+				{	sp = fmtscale((Sfulong_t)lv, scale);
 #if _has_multibyte
 					wc = 0;
 #endif
@@ -1003,10 +1005,10 @@ loop_fmt :
 					break;
 				if(lv < 0 && fmt == 'd' )
 				{	flags |= SFFMT_MINUS;
-					if(lv == HIGHBITL) /* avoid overflow */
-					{	lv = (Sflong_t)(HIGHBITL/base);
+					if((Sfulong_t)lv == HIGHBITL) /* avoid overflow */
+					{	lv = (Sflong_t)(HIGHBITL/(Sfulong_t)base);
 						*--sp = _Sfdigits[HIGHBITL -
-								  ((Sfulong_t)lv)*base];
+								  ((Sfulong_t)lv)*(Sfulong_t)base];
 					}
 					else	lv = -lv;
 				}
@@ -1017,32 +1019,32 @@ loop_fmt :
 				else if(n_s > 0) /* base power-of-2 */
 				{	do
 					{	*--sp = ssp[lv&n_s];
-					} while((lv = ((Sfulong_t)lv) >> n) );
+					} while((lv = (Sflong_t)((Sfulong_t)lv) >> n) );
 				}
 				else		/* general base */
 				{	do
-					{	*--sp = ssp[((Sfulong_t)lv)%base];
-					} while((lv = ((Sfulong_t)lv)/base) );
+					{	*--sp = ssp[((Sfulong_t)lv)%(Sfulong_t)base];
+					} while(lv = (Sflong_t)(lv/base) );
 				}
 			} else
 #endif
 			if(sizeof(short) < sizeof(int) && size == sizeof(short) )
 			{	if(fmt == 'd')
-					v = (int)((short)argv.i);
-				else	v = (int)((ushort)argv.i);
+					v = (ptrdiff_t)((short)argv.i);
+				else	v = (ptrdiff_t)((ushort)argv.i);
 				goto int_cvt;
 			}
 			else if(size == sizeof(char))
 			{	if(fmt != 'd')
-					v = (int)((uchar)argv.i);
+					v = (ptrdiff_t)((uchar)argv.i);
 				else
 				{
 #if _key_signed
-					v = (int)((signed char)argv.i);
+					v = (ptrdiff_t)((signed char)argv.i);
 #else
 					if(argv.i < 0)
-						v = -((int)((char)(-argv.i)));
-					else	v =  ((int)((char)( argv.i)));
+						v = -((ptrdiff_t)((char)(-argv.i)));
+					else	v =  ((ptrdiff_t)((char)( argv.i)));
 #endif
 				}
 				goto int_cvt;
@@ -1051,7 +1053,7 @@ loop_fmt :
 			{	v = argv.i;
 			int_cvt:
 				if(scale)
-				{	sp = fmtscale(v, scale);
+				{	sp = fmtscale((Sfulong_t)v, scale);
 #if _has_multibyte
 					wc = 0;
 #endif
@@ -1061,10 +1063,10 @@ loop_fmt :
 					break;
 				if(v < 0 && fmt == 'd' )
 				{	flags |= SFFMT_MINUS;
-					if(v == HIGHBITI) /* avoid overflow */
-					{	v = (int)(HIGHBITI/base);
+					if((uint)v == HIGHBITI) /* avoid overflow */
+					{	v = (int)(HIGHBITI/(uint)base);
 						*--sp = _Sfdigits[HIGHBITI -
-								  ((uint)v)*base];
+								  (uint)v*(uint)base];
 					}
 					else	v = -v;
 				}
@@ -1073,13 +1075,13 @@ loop_fmt :
 				}
 				else if(n_s > 0) /* base power-of-2 */
 				{	do
-					{	*--sp = ssp[v&n_s];
-					} while((v = ((uint)v) >> n) );
+					{	*--sp = ssp[(uint)v&(uint)n_s];
+					} while((v = (ptrdiff_t)(((uint)v) >> n)) );
 				}
 				else /* n_s == 0, general base */
 				{	do
-					{	*--sp = ssp[((uint)v)%base];
-					} while((v = ((uint)v)/base) );
+					{	*--sp = ssp[((uint)v)%(uint)base];
+					} while((v = (ptrdiff_t)(((uint)v)/(uint)base)) );
 				}
 			}
 
@@ -1092,7 +1094,7 @@ loop_fmt :
 					if(sp == endsp)
 						break;
 					if(sp <= endsp-3)
-						*ep++ = thousand;
+						*ep++ = (char)thousand;
 					endep = ep+3;
 				}
 				sp = buf+SLACK;
@@ -1133,8 +1135,8 @@ loop_fmt :
 						if(base < 10)
 							*--sp = (char)('0'+base);
 						else
-						{	*--sp = _Sfdec[(base <<= 1)+1];
-							*--sp = _Sfdec[base];
+						{	*--sp = (char)_Sfdec[(base <<= 1)+1];
+							*--sp = (char)_Sfdec[base];
 						}
 					}
 				}
@@ -1235,7 +1237,7 @@ loop_fmt :
 
 			SFSETLOCALE(&decimal,&thousand);
 			if(precis > 0 || (flags&SFFMT_ALTER))
-				*endsp++ = decimal;
+				*endsp++ = (char)decimal;
 			ssp = endsp;
 			endep = ep+precis;
 			while((*endsp++ = *ep++) && ep <= endep)
@@ -1283,7 +1285,7 @@ loop_fmt :
 					n = 3;
 				while(ep < endep && (*endsp++ = *ep++) )
 				{	if(--n == 0 && (ep <= endep-3) )
-					{	*endsp++ = thousand;
+					{	*endsp++ = (char)thousand;
 						n = 3;
 					}
 				}
@@ -1296,7 +1298,7 @@ loop_fmt :
 				*endsp++ = '0';
 
 			if(precis > 0 || (flags&SFFMT_ALTER))
-				*endsp++ = decimal;
+				*endsp++ = (char)decimal;
 
 			if((n = -decpt) > 0)
 			{	/* output zeros for negative exponent */
@@ -1333,7 +1335,7 @@ loop_fmt :
 		{	if(flags&SFFMT_LEFT)
 				v = -v;
 			else if(flags&SFFMT_PREFIX) /* blank padding, output prefix now */
-			{	*--sp = fmt;
+			{	*--sp = (char)fmt;
 				flags &= ~SFFMT_PREFIX;
 			}
 		}
@@ -1346,7 +1348,7 @@ loop_fmt :
 
 		if((n = v) > 0) /* left padding */
 		{	v = (flags&SFFMT_ZERO) ? '0' : ' ';
-			SFnputc(f,v,n);
+			SFnputc(f,(int)v,n);
 		}
 
 		if((n = precis) > 0 && !(flags&SFFMT_FLOAT))
@@ -1356,7 +1358,7 @@ loop_fmt :
 		}
 
 	do_output:
-		if((n = endsp-sp) > 0)
+		if((n = (endsp-sp)) > 0)
 			SFwrite(f,sp,n);
 
 		if(flags&(SFFMT_FLOAT|SFFMT_LEFT))
@@ -1365,7 +1367,7 @@ loop_fmt :
 				SFnputc(f,'0',n);
 
 			/* SFFMT_FLOAT: the exponent of %eE */
-			if((n = endep - (sp = ep)) > 0)
+			if((n = (endep - (sp = ep))) > 0)
 				SFwrite(f,sp,n);
 
 			/* SFFMT_LEFT: right padding */
@@ -1419,15 +1421,15 @@ done:
 
 	SFEND(f);
 
-	n = f->next - f->data;
+	q = f->next - f->data;
 	if((sp = (char*)f->data) == data)
 		f->endw = f->endr = f->endb = f->data = NULL;
 	f->next = f->data;
 
 	if((((flags = f->flags)&SFIO_SHARE) && !(flags&SFIO_PUBLIC) ) ||
-	   (n > 0 && (sp == data || (flags&SFIO_LINE) ) ) )
-		(void)SFWRITE(f,sp,n);
-	else	f->next += n;
+	   (q > 0 && (sp == data || (flags&SFIO_LINE) ) ) )
+		(void)SFWRITE(f,sp,(size_t)q);
+	else	f->next += q;
 
 	SFOPEN(f,0);
 	return n_output;

--- a/src/lib/libast/sfio/sfvscanf.c
+++ b/src/lib/libast/sfio/sfvscanf.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2012 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -51,13 +51,13 @@ static void _sfbuf(Sfio_t* f, int* peek)
 /* buffer used during scanning of a double value or a multi-byte
    character. the fields mirror certain local variables in sfvscanf. */
 typedef struct _scan_s
-{	int	error;	/* get set by _sfdscan if no value specified	*/
-	int	inp;	/* last input character read			*/
-	int	width;	/* field width					*/
-	Sfio_t	*f;	/* stream being scanned				*/
-	uchar	*d, *endd, *data;	/* local buffering system	*/
-	int	peek;	/* != 0 if unseekable/share stream		*/
-	int	n_input;/* number of input bytes processed		*/
+{	int		error;			/* get set by _sfdscan if no value specified	*/
+	int		inp;			/* last input character read			*/
+	ptrdiff_t	width;			/* field width					*/
+	Sfio_t		*f;			/* stream being scanned				*/
+	uchar		*d, *endd, *data;	/* local buffering system	*/
+	int		peek;			/* != 0 if unseekable/share stream		*/
+	ssize_t		n_input;		/* number of input bytes processed		*/
 } Scan_t;
 
 /* ds != 0 for scanning double values */
@@ -88,7 +88,7 @@ static int _scgetc(void* arg, int flag)
 	if(sc->d >= sc->endd) /* refresh local buffer */
 	{	sc->n_input += sc->d - sc->data;
 		if(sc->peek)
-			SFREAD(sc->f, sc->data, sc->d - sc->data);
+			SFREAD(sc->f, sc->data, (size_t)(sc->d - sc->data));
 		else	sc->f->next = sc->d;
 
 		_sfbuf(sc->f, &sc->peek);
@@ -108,15 +108,15 @@ static int _scgetc(void* arg, int flag)
 
 /* structure to match characters in a character class */
 typedef struct _accept_s
-{	char	ok[SFIO_MAXCHAR+1];
+{	uchar	ok[SFIO_MAXCHAR+1];
 	int	yes;
-	char	*form, *endf;
+	uchar	*form, *endf;
 #if _has_multibyte
 	wchar_t	wc;
 #endif
 } Accept_t;
 
-static char* _sfsetclass(const char*	form,	/* format string			*/
+static uchar* _sfsetclass(uchar*	form,	/* format string			*/
 			 Accept_t*	ac,	/* values of accepted characters	*/
 			 int		flags)	/* SFFMT_LONG for wchar_t		*/
 {
@@ -133,10 +133,10 @@ static char* _sfsetclass(const char*	form,	/* format string			*/
 		ac->ok[c] = !ac->yes;
 
 	if(*form == ']' || *form == '-') /* special first char */
-	{	ac->ok[*((unsigned char*)form)] = ac->yes;
+	{	ac->ok[*form] = (uchar)ac->yes;
 		form += 1;
 	}
-	ac->form = (char*)form;
+	ac->form = form;
 
 	if(flags&SFFMT_LONG)
 		SFMBCLR(&mbs);
@@ -151,7 +151,7 @@ static char* _sfsetclass(const char*	form,	/* format string			*/
 				goto one_char;
 #endif
 			for(; c <= endc; ++c)
-				ac->ok[c] = ac->yes;
+				ac->ok[c] = (uchar)ac->yes;
 			n = 3;
 		}
 		else
@@ -161,36 +161,37 @@ static char* _sfsetclass(const char*	form,	/* format string			*/
 				return NULL;
 			if(n == 1)
 #endif
-				ac->ok[c] = ac->yes;
+				ac->ok[c] = (uchar)ac->yes;
 		}
 	}
 
-	ac->endf = (char*)form;
-	return (char*)(form+1);
+	ac->endf = form;
+	return form+1;
 }
 
 #if _has_multibyte
 static int _sfwaccept(wchar_t wc, Accept_t* ac)
 {
-	int		endc, c, n;
-	wchar_t		fwc;
-	char		*form = ac->form;
+	int	endc, c;
+	size_t	n;
+	wchar_t	fwc;
+	uchar	*form = ac->form;
 	SFMBDCL(mbs)
 
 	SFMBCLR(&mbs);
 	for(n = 1; *form != ']'; form += n)
-	{	if((c = *((uchar*)form)) == 0)
+	{	if((c = *form) == 0)
 			return 0;
 
 		if(*(form+1) == '-')
-		{	endc = *((uchar*)(form+2));
+		{	endc = *(form+2);
 			if(c >= 128 || endc >= 128 ) /* range must be ASCII */
 				goto one_char;
 			n = 3;
 		}
 		else
 		{ one_char:
-			if((n = mbrtowc(&fwc, form, ac->endf-form, &mbs)) > 1 &&
+			if((n = mbrtowc(&fwc, (const char*)form, (size_t)(ac->endf-form), &mbs)) > 1 &&
 			   wc == fwc )
 				return ac->yes;
 		}
@@ -211,12 +212,13 @@ static int _sfgetwc(Scan_t*	sc,	/* the scanning handle		*/
 		    Accept_t*	ac,	/* accept handle for %[		*/
 		    void*	mbs)	/* multibyte parsing state	*/
 {
-	int		n, v;
-	unsigned char	b[16];		/* assuming that SFMBMAX <= 16! */
+	size_t	n;
+	int	v;
+	uchar	b[16];		/* assuming that SFMBMAX <= 16! */
 
 	/* shift left data so that there will be more room to back up on error.
 	   this won't help streams with small buffers - c'est la vie! */
-	if(sc->d > sc->f->data && (n = sc->endd - sc->d) > 0 && n < SFMBMAX)
+	if(sc->d > sc->f->data && (n = (size_t)(sc->endd - sc->d)) > 0 && n < SFMBMAX)
 	{	memmove(sc->f->data, sc->d, n);
 		if(sc->f->endr == sc->f->endb)
 			sc->f->endr = sc->f->data+n;
@@ -231,7 +233,7 @@ static int _sfgetwc(Scan_t*	sc,	/* the scanning handle		*/
 	for(n = 0; n < SFMBMAX; )
 	{	if((v = _scgetc(sc, 0)) <= 0)
 			goto no_match;
-		else	b[n++] = v;
+		else	b[n++] = (uchar)v;
 
 		if(mbrtowc(wc, (char*)b, n, (mbstate_t*)mbs) == (size_t)(-1))
 			goto no_match;  /* malformed multi-byte char */
@@ -270,9 +272,10 @@ int sfvscanf(Sfio_t*		f,		/* file to be scanned */
 	     const char*	form,		/* scanning format */
 	     va_list		args)
 {
-	int		inp, shift, base, width;
-	ssize_t		size;
-	int		fmt, flags, dot, n_assign, v, n, n_input;
+	int		inp, shift;
+	ssize_t		n_input;
+	ptrdiff_t	base, size, width;
+	int		fmt, flags, dot, n_assign, v;
 	char		*sp;
 
 	Accept_t	acc;
@@ -284,7 +287,7 @@ int sfvscanf(Sfio_t*		f,		/* file to be scanned */
 	Fmtpos_t*	fp;
 	char		*oform;
 	va_list		oargs;
-	int		argp, argn;
+	ptrdiff_t	argp, argn;
 
 	int		decimal = 0, thousand = 0;
 
@@ -296,7 +299,7 @@ int sfvscanf(Sfio_t*		f,		/* file to be scanned */
 
 	void*		value;	/* location to assign scanned value */
 	char*		t_str;
-	ssize_t		n_str;
+	ptrdiff_t	n, n_str;
 
 	/* local buffering system */
 	Scan_t		scd;
@@ -306,7 +309,7 @@ int sfvscanf(Sfio_t*		f,		/* file to be scanned */
 #define SFlen(f)	(d - data)
 #define SFinit(f)	((peek = f->extent < 0 && (f->flags&SFIO_SHARE)), SFbuf(f) )
 #define SFend(f)	((n_input += SFlen(f)), \
-			 (peek ? SFREAD(f,data,SFlen(f)) : ((f->next = d),0)) )
+			 (peek ? SFREAD(f,data,(size_t)SFlen(f)) : ((f->next = d),0)) )
 #define SFgetc(f,c)	((c) = (d < endd || (SFend(f), SFbuf(f), d < endd)) ? \
 				(int)(*d++) : -1 )
 #define SFungetc(f,c)	(d -= 1)
@@ -443,13 +446,13 @@ loop_fmt:
 							if(!(ft->flags&SFFMT_VALUE) )
 								goto t_arg;
 							if((t_str = argv.s) &&
-							   (n_str = (int)ft->size) < 0)
-								n_str = strlen(t_str);
+							   (n_str = (ptrdiff_t)ft->size) < 0)
+								n_str = (ptrdiff_t)strlen(t_str);
 						}
 						else
 						{ t_arg:
 							if((t_str = va_arg(args,char*)) )
-								n_str = strlen(t_str);
+								n_str = (ptrdiff_t)strlen(t_str);
 						}
 					}
 					goto loop_flags;
@@ -546,7 +549,7 @@ loop_fmt:
 			else if (fmt == 'z')
 				flags = (flags&~SFFMT_TYPES) | SFFMT_ZFLAG;
 			else if(isdigit(*form))
-				for(size = 0, n = *form; isdigit(n); n = *++form)
+				for(size = 0, n = *form; isdigit((int)n); n = *++form)
 					size = size*10 + (n - '0');
 			goto loop_flags;
 
@@ -643,7 +646,7 @@ loop_fmt:
 			else	flags |= SFFMT_SKIP;
 		}
 		else if(ft && ft->extf)
-		{	FMTSET(ft, form,args, fmt, size,flags, width,0,base, t_str,n_str);
+		{	FMTSET(ft, form,args, fmt, size, flags, width,0,base, t_str,n_str);
 			SFend(f); SFOPEN(f,0);
 			v = (*ft->extf)(f, &argv, ft);
 			SFLOCK(f,0); SFbuf(f);
@@ -829,7 +832,7 @@ loop_fmt:
 				{	/* fast base 10 conversion */
 #define TEN(x) (((x) << 3) + ((x) << 1) )
 					if (inp >= '0' && inp <= '9')
-					{	argv.lu = TEN(argv.lu) + (inp-'0');
+					{	argv.lu = TEN(argv.lu) + (Sfulong_t)(inp-'0');
 						n += 1;
 					}
 					else if(inp == thousand)
@@ -847,7 +850,7 @@ loop_fmt:
 				}
 
 				if(fmt == 'i' && inp == '#' && !(flags&SFFMT_ALTER) )
-				{	base = (int)argv.lu;
+				{	base = (ptrdiff_t)argv.lu;
 					if(base < 2 || base > SFIO_RADIX)
 						goto pop_fmt;
 					argv.lu = 0;
@@ -874,13 +877,13 @@ loop_fmt:
 					else	shift = base < 64 ? 5 : 6;
 
 			base_shift:	do
-					{ argv.lu = (argv.lu << shift) + sp[inp];
+					{ argv.lu = (argv.lu << shift) + (Sfulong_t)sp[inp];
 					} while(--width > 0 &&
 					        SFgetc(f,inp) >= 0 && sp[inp] < base);
 				}
 				else
 				{	do
-					{ argv.lu = (argv.lu * base) + sp[inp];
+					{ argv.lu = (argv.lu * (Sfulong_t)base) + (Sfulong_t)sp[inp];
 					} while(--width > 0 &&
 						SFgetc(f,inp) >= 0 && sp[inp] < base);
 				}
@@ -945,7 +948,7 @@ loop_fmt:
 			}
 			else	size = 0;
 
-			if(fmt == '[' && !(form = _sfsetclass(form,&acc,flags)) )
+			if(fmt == '[' && !(form = (const char*)_sfsetclass((uchar*)form,&acc,flags)) )
 			{	SFungetc(f,inp);
 				goto pop_fmt;
 			}
@@ -970,13 +973,13 @@ loop_fmt:
 				{	if(isspace(inp))
 						break;
 					if((n += 1) <= size)
-						*argv.s++ = inp;
+						*argv.s++ = (char)inp;
 				} while(--width > 0 && SFgetc(f,inp) >= 0);
 			}
 			else if(fmt == 'c')
 			{	do
 			 	{	if((n += 1) <= size)
-						*argv.s++ = inp;
+						*argv.s++ = (char)inp;
 				} while(--width > 0 && SFgetc(f,inp) >= 0);
 			}
 			else /* if(fmt == '[') */
@@ -990,7 +993,7 @@ loop_fmt:
 						}
 					}
 					if((n += 1) <= size)
-						*argv.s++ = inp;
+						*argv.s++ = (char)inp;
 				} while(--width > 0 && SFgetc(f,inp) >= 0);
 			}
 

--- a/src/lib/libast/sfio/sfwr.c
+++ b/src/lib/libast/sfio/sfwr.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -74,7 +74,7 @@ static ssize_t sfoutput(Sfio_t* f, char* buf, size_t n)
 				break;
 
 			/* skip a dirty page */
-			n -= _Sfpage;
+			n -= (size_t)_Sfpage;
 			buf += _Sfpage;
 		}
 
@@ -84,7 +84,7 @@ static ssize_t sfoutput(Sfio_t* f, char* buf, size_t n)
 			{	buf = endbuf;
 				n = s = 0;
 			}
-			if((wr = write(f->file,wbuf,buf-wbuf)) > 0)
+			if((wr = write(f->file,wbuf,(size_t)(buf-wbuf))) > 0)
 			{	w += wr;
 				f->bits &= ~SFIO_HOLE;
 			}
@@ -99,7 +99,7 @@ static ssize_t sfoutput(Sfio_t* f, char* buf, size_t n)
 			if(SFSK(f,(Sfoff_t)s,SEEK_CUR,NULL) < 0)
 				break;
 			w += s;
-			n -= s;
+			n -= (size_t)s;
 			wbuf = (buf += s);
 			f->bits |= SFIO_HOLE;
 
@@ -107,7 +107,7 @@ static ssize_t sfoutput(Sfio_t* f, char* buf, size_t n)
 			{	/* next page must be dirty */
 				s = (ssize_t)n <= _Sfpage ? 1 : _Sfpage;
 				buf += s;
-				n -= s;
+				n -= (size_t)s;
 			}
 		}
 	}
@@ -122,14 +122,14 @@ ssize_t sfwr(Sfio_t* f, const void* buf, size_t n, Sfdisc_t* disc)
 	int		local, oerrno;
 
 	if(!f)
-		return (ssize_t)(-1);
+		return -1;
 
 	GETLOCAL(f,local);
 	if(!local && !(f->bits&SFIO_DCDOWN)) /* an external user's call */
 	{	if(f->mode != SFIO_WRITE && _sfmode(f,SFIO_WRITE,0) < 0 )
-			return (ssize_t)(-1);
+			return -1;
 		if(f->next > f->data && SFSYNC(f) < 0 )
-			return (ssize_t)(-1);
+			return -1;
 	}
 
 	for(;;)
@@ -142,16 +142,16 @@ ssize_t sfwr(Sfio_t* f, const void* buf, size_t n, Sfdisc_t* disc)
 
 		dc = disc;
 		if(f->flags&SFIO_STRING)	/* just asking to extend buffer */
-			w = n + (f->next - f->data);
+			w = (ssize_t)n + (f->next - f->data);
 		else
 		{	/* warn that a write is about to happen */
 			SFDISC(f,dc,writef);
 			if(dc && dc->exceptf && (f->flags&SFIO_IOCHECK) )
-			{	int	rv;
+			{	ssize_t	rv;
 				if(local)
 					SETLOCAL(f);
-				if((rv = _sfexcept(f,SFIO_WRITE,n,dc)) > 0)
-					n = rv;
+				if((rv = _sfexcept(f,SFIO_WRITE,(ssize_t)n,dc)) > 0)
+					n = (size_t)rv;
 				else if(rv < 0)
 				{	f->flags |= SFIO_ERROR;
 					return rv;
@@ -177,7 +177,7 @@ ssize_t sfwr(Sfio_t* f, const void* buf, size_t n, Sfdisc_t* disc)
 			{	SFDCWR(f,buf,n,dc,w);
 			}
 			else if(SFISNULL(f))
-				w = n;
+				w = (ssize_t)n;
 			else if(f->flags&SFIO_WHOLE)
 				goto do_write;
 			else if((ssize_t)n >= _Sfpage &&
@@ -223,7 +223,7 @@ ssize_t sfwr(Sfio_t* f, const void* buf, size_t n, Sfdisc_t* disc)
 				goto do_continue;
 			/* FALLTHROUGH */
 		case SFIO_ESTACK :
-			return (ssize_t)(-1);
+			return -1;
 		}
 
 	do_continue:

--- a/src/lib/libast/sfio/sfwrite.c
+++ b/src/lib/libast/sfio/sfwrite.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2012 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 #include	"sfhdr.h"
@@ -32,7 +33,7 @@ ssize_t sfwrite(Sfio_t*		f,	/* write to this stream. 	*/
 	int		local;
 
 	if(!f)
-		return (ssize_t)(-1);
+		return -1;
 
 	GETLOCAL(f,local);
 
@@ -42,30 +43,30 @@ ssize_t sfwrite(Sfio_t*		f,	/* write to this stream. 	*/
 	/* release peek lock */
 	if(f->mode&SFIO_PEEK)
 	{	if(!(f->mode&SFIO_WRITE) && (f->flags&SFIO_RDWR) != SFIO_RDWR)
-			return (ssize_t)(-1);
+			return -1;
 
 		if((uchar*)buf != f->next &&
 		   (!f->rsrv || f->rsrv->data != (uchar*)buf) )
-			return (ssize_t)(-1);
+			return -1;
 
-		f->mode &= ~SFIO_PEEK;
+		f->mode &= (uint32_t)~SFIO_PEEK;
 
 		if(f->mode&SFIO_PKRD)
 		{	/* read past peeked data */
 			char		buf[16];
 			ssize_t	r;
 
-			for(w = n; w > 0; )
-			{	if((r = w) > sizeof(buf))
+			for(w = (ssize_t)n; w > 0; )
+			{	if((r = w) > (ssize_t)sizeof(buf))
 					r = sizeof(buf);
-				if((r = read(f->file,buf,r)) <= 0)
-				{	n -= w;
+				if((r = read(f->file,buf,(size_t)r)) <= 0)
+				{	n -= (size_t)w;
 					break;
 				}
 				else	w -= r;
 			}
 
-			f->mode &= ~SFIO_PKRD;
+			f->mode &= (uint32_t)~SFIO_PKRD;
 			f->endb = f->data + n;
 			f->here += n;
 		}
@@ -75,7 +76,7 @@ ssize_t sfwrite(Sfio_t*		f,	/* write to this stream. 	*/
 	}
 
 	s = begs = (uchar*)buf;
-	for(;; f->mode &= ~SFIO_LOCK)
+	for(;; f->mode &= (uint32_t)~SFIO_LOCK)
 	{	/* check stream mode */
 		if(SFMODE(f,local) != SFIO_WRITE && _sfmode(f,SFIO_WRITE,local) < 0 )
 		{	w = s > begs ? s-begs : -1;
@@ -90,14 +91,14 @@ ssize_t sfwrite(Sfio_t*		f,	/* write to this stream. 	*/
 		{	if(w > (ssize_t)n)
 				w = (ssize_t)n;
 			f->next = (s += w);
-			n -= w;
+			n -= (size_t)w;
 			break;
 		}
 
 		/* attempt to create space in buffer */
 		if(w == 0 || ((f->flags&SFIO_WHOLE) && w < (ssize_t)n) )
 		{	if(f->flags&SFIO_STRING) /* extend buffer */
-			{	(void)SFWR(f, s, n-w, f->disc);
+			{	(void)SFWR(f, s, n-(size_t)w, f->disc);
 				if((w = f->endb - f->next) < (ssize_t)n)
 				{	if(!(f->flags&SFIO_STRING)) /* maybe sftmp */
 					{	if(f->next > f->data)
@@ -117,7 +118,7 @@ ssize_t sfwrite(Sfio_t*		f,	/* write to this stream. 	*/
 		}
 
 		if(!(f->flags&SFIO_STRING) && f->next == f->data &&
-		   (((f->flags&SFIO_WHOLE) && w <= n) || SFDIRECT(f,n)) )
+		   (((f->flags&SFIO_WHOLE) && w <= (ssize_t)n) || SFDIRECT(f,n)) )
 		{	/* bypass buffering */
 			if((w = SFWR(f,s,n,f->disc)) <= 0 )
 				break;
@@ -127,12 +128,13 @@ ssize_t sfwrite(Sfio_t*		f,	/* write to this stream. 	*/
 				w = (ssize_t)n;
 			if(w <= 0) /* no forward progress possible */
 				break;
-			memmove(f->next, s, w);
+			memmove(f->next, s, (size_t)w);
 			f->next += w;
 		}
 
 		s += w;
-		if((n -= w) <= 0)
+		n -= (size_t)w;
+		if((ssize_t)n <= 0)
 			break;
 	}
 
@@ -142,8 +144,8 @@ ssize_t sfwrite(Sfio_t*		f,	/* write to this stream. 	*/
 
 	/* check to see if buffer should be flushed */
 	else if(n == 0 && (f->flags&SFIO_LINE) && !(f->flags&SFIO_STRING))
-	{	if((ssize_t)(n = f->next-f->data) > (w = s-begs))
-			n = w;
+	{	if((ssize_t)(n = (size_t)(f->next-f->data)) > (w = s-begs))
+			n = (size_t)w;
 		if(n > 0 && n < HIFORLINE)
 		{	for(next = f->next-1; n > 0; --n, --next)
 			{	if(*next == '\n')

--- a/src/lib/libast/stdio/_doprnt.c
+++ b/src/lib/libast/stdio/_doprnt.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 
@@ -22,5 +23,5 @@
 int
 _doprnt(const char* fmt, va_list args, Sfio_t* f)
 {
-	return sfvprintf(f, fmt, args);
+	return (int)sfvprintf(f, fmt, args);
 }

--- a/src/lib/libast/stdio/_filbuf.c
+++ b/src/lib/libast/stdio/_filbuf.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 
@@ -22,5 +23,5 @@
 extern int
 _filbuf(Sfio_t* f)
 {
-	return _sffilbuf(f, 0);
+	return (int)_sffilbuf(f, 0);
 }

--- a/src/lib/libast/stdio/fdopen.c
+++ b/src/lib/libast/stdio/fdopen.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2012 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 
@@ -22,7 +23,7 @@
 Sfio_t*
 fdopen(int fd, const char* mode)
 {
-	int	flags;
+	unsigned short	flags;
 
 	if (fd < 0 || !(flags = _sftype(mode, NULL, NULL)))
 		return NULL;

--- a/src/lib/libast/stdio/fgets.c
+++ b/src/lib/libast/stdio/fgets.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,15 +14,16 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 
 #include "stdhdr.h"
 
 extern char*
-_stdgets(Sfio_t* f, char* us, int n, int isgets)
+_stdgets(Sfio_t* f, char* us, ptrdiff_t n, int isgets)
 {
-	int		p;
+	ptrdiff_t	p;
 	unsigned char*	is;
 	unsigned char*	ps;
 
@@ -46,7 +47,7 @@ _stdgets(Sfio_t* f, char* us, int n, int isgets)
 		if(p > n)
 			p = n;
 
-		if((ps = (uchar*)memccpy((char*)is,(char*)ps,'\n',p)) != NULL)
+		if((ps = (uchar*)memccpy((char*)is,(char*)ps,'\n',(size_t)p)) != NULL)
 			p = ps-is;
 		is += p;
 		ps  = f->next+p;
@@ -59,7 +60,7 @@ _stdgets(Sfio_t* f, char* us, int n, int isgets)
 			n -= p;
 	}
 
-	if((_Sfi = is - ((uchar*)us)) <= 0)
+	if((_Sfi = (ssize_t)(is - ((uchar*)us))) <= 0)
 		us = NULL;
 	else if(isgets && is[-1] == '\n')
 	{	is[-1] = '\0';

--- a/src/lib/libast/stdio/fgetwc.c
+++ b/src/lib/libast/stdio/fgetwc.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 
@@ -31,7 +32,7 @@ fgetwc(Sfio_t* f)
 	wchar_t	c;
 
 	FWIDE(f, WEOF);
-	return (sfread(f, &c, sizeof(c)) == sizeof(c)) ? c : WEOF;
+	return (sfread(f, &c, sizeof(c)) == sizeof(c)) ? (wint_t)c : WEOF;
 }
 
 #endif /* !_has_multibyte */

--- a/src/lib/libast/stdio/fgetws.c
+++ b/src/lib/libast/stdio/fgetws.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2023 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 
@@ -32,8 +33,8 @@ fgetws(wchar_t* s, int n, Sfio_t* f)
 	wchar_t*	e = s + n - 1;
 	wint_t		c;
 
-	FWIDE(f, 0);
-	while (p < e && (c = fgetwc(f)) != WEOF && (*p++ = c) != '\n');
+	FWIDE(f, NULL);
+	while (p < e && (c = fgetwc(f)) != WEOF && (*p++ = (wchar_t)c) != '\n');
 	*p = 0;
 	return s;
 }
@@ -45,8 +46,8 @@ getws(wchar_t* s)
 	wchar_t*	e = s + BUFSIZ - 1;
 	wint_t		c;
 
-	FWIDE(sfstdin, 0);
-	while (p < e && (c = fgetwc(sfstdin)) != WEOF && (*p++ = c) != '\n');
+	FWIDE(sfstdin, NULL);
+	while (p < e && (c = fgetwc(sfstdin)) != WEOF && (*p++ = (wchar_t)c) != '\n');
 	*p = 0;
 	return s;
 }

--- a/src/lib/libast/stdio/fprintf.c
+++ b/src/lib/libast/stdio/fprintf.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 
@@ -27,7 +28,7 @@ fprintf(Sfio_t* f, const char* fmt, ...)
 
 	va_start(args, fmt);
 
-	v = sfvprintf(f, fmt, args);
+	v = (int)sfvprintf(f, fmt, args);
 	va_end(args);
 	return v;
 }

--- a/src/lib/libast/stdio/fputs.c
+++ b/src/lib/libast/stdio/fputs.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 
@@ -22,5 +23,5 @@
 int
 fputs(const char* s, Sfio_t* f)
 {
-	return sfputr(f, s, -1);
+	return (int)sfputr(f, s, -1);
 }

--- a/src/lib/libast/stdio/fputwc.c
+++ b/src/lib/libast/stdio/fputwc.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 
@@ -29,7 +30,7 @@ wint_t
 fputwc(wchar_t c, Sfio_t* f)
 {
 	FWIDE(f, WEOF);
-	return (sfwrite(f, &c, sizeof(c)) == sizeof(c)) ? c : WEOF;
+	return (sfwrite(f, &c, sizeof(c)) == sizeof(c)) ? (wint_t)c : WEOF;
 }
 
 #endif /* !_has_multibyte */

--- a/src/lib/libast/stdio/fputws.c
+++ b/src/lib/libast/stdio/fputws.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 
@@ -30,9 +31,9 @@ fputws(const wchar_t* s, Sfio_t* f)
 {
 	size_t	n;
 
-	FWIDE(f, WEOF);
+	FWIDE(f, -1);
 	n = wcslen(s) * sizeof(wchar_t);
-	return (sfwrite(f, s, n) == n) ? 0 : -1;
+	return (sfwrite(f, s, n) == (ssize_t)n) ? 0 : -1;
 }
 
 #endif /* !_has_multibyte */

--- a/src/lib/libast/stdio/fread.c
+++ b/src/lib/libast/stdio/fread.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 
@@ -24,5 +25,5 @@ fread(void* p, size_t s, size_t n, Sfio_t* f)
 {
 	ssize_t	v;
 
-	return ((v = sfread(f, p, s * n)) <= 0) ? 0 : (v / s);
+	return ((v = sfread(f, p, s * n)) <= 0) ? 0 : ((size_t)v / s);
 }

--- a/src/lib/libast/stdio/fwrite.c
+++ b/src/lib/libast/stdio/fwrite.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 
@@ -24,5 +25,5 @@ fwrite(const void* p, size_t s, size_t n, Sfio_t* f)
 {
 	ssize_t	v;
 
-	return ((v = sfwrite(f, p, s * n)) <= 0) ? 0 : (v / s);
+	return ((v = sfwrite(f, p, s * n)) <= 0) ? 0 : ((size_t)v / s);
 }

--- a/src/lib/libast/stdio/getdelim.c
+++ b/src/lib/libast/stdio/getdelim.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 
@@ -37,7 +38,7 @@ getdelim(char** sp, size_t* np, int delim, Sfio_t* f)
 
 	SFLOCK(f,0);
 
-	if(!(s = (uchar*)(*sp)) || (n = *np) < 0)
+	if(!(s = (uchar*)(*sp)) || (n = (ssize_t)*np) < 0)
 		{ s = NULL; n = 0; }
 	for(m = 0;; )
 	{	/* read new data */
@@ -59,15 +60,15 @@ getdelim(char** sp, size_t* np, int delim, Sfio_t* f)
 
 		if((m+k+1) >= n ) /* make sure there is space */
 		{	n = ((m+k+15)/8)*8;
-			if(!(s = (uchar*)realloc(s, n)) )
+			if(!(s = (uchar*)realloc(s, (size_t)n)) )
 			{	*sp = 0; *np = 0;
 				m = -1;
 				break;
 			}
-			*sp = (char*)s; *np = n;
+			*sp = (char*)s; *np = (size_t)n;
 		}
 
-		memcpy(s+m, ps, k); m += k;
+		memcpy(s+m, ps, (size_t)k); m += k;
 		f->next = ps+k; /* skip copied data in buffer */
 
 		if(s[m-1] == delim)

--- a/src/lib/libast/stdio/printf.c
+++ b/src/lib/libast/stdio/printf.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 
@@ -26,7 +27,7 @@ printf(const char* fmt, ...)
 	int	v;
 
 	va_start(args, fmt);
-	v = sfvprintf(sfstdout, fmt, args);
+	v = (int)sfvprintf(sfstdout, fmt, args);
 	va_end(args);
 	return v;
 }

--- a/src/lib/libast/stdio/puts.c
+++ b/src/lib/libast/stdio/puts.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 
@@ -22,5 +23,5 @@
 int
 puts(const char* s)
 {
-	return sfputr(sfstdout, s, '\n');
+	return (int)sfputr(sfstdout, s, '\n');
 }

--- a/src/lib/libast/stdio/setbuffer.c
+++ b/src/lib/libast/stdio/setbuffer.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 
@@ -22,5 +23,5 @@
 int
 setbuffer(Sfio_t* f, char* b, int n)
 {
-	return sfsetbuf(f, b, n) ? 0 : -1;
+	return sfsetbuf(f, b, (size_t)n) ? 0 : -1;
 }

--- a/src/lib/libast/stdio/snprintf.c
+++ b/src/lib/libast/stdio/snprintf.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,19 +14,20 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 
 #include "stdhdr.h"
 
 int
-snprintf(char* s, int n, const char* fmt, ...)
+snprintf(char* s, size_t n, const char* fmt, ...)
 {
 	va_list	args;
 	int	v;
 
 	va_start(args, fmt);
-	v = sfvsprintf(s, n, fmt, args);
+	v = (int)sfvsprintf(s, n, fmt, args);
 	va_end(args);
 	return v;
 }

--- a/src/lib/libast/stdio/sprintf.c
+++ b/src/lib/libast/stdio/sprintf.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 
@@ -26,7 +27,7 @@ sprintf(char* s, const char* fmt, ...)
 	int	v;
 
 	va_start(args, fmt);
-	v = s ? sfvsprintf(s, INT_MAX, fmt, args) : -1;
+	v = s ? (int)sfvsprintf(s, INT_MAX, fmt, args) : -1;
 	va_end(args);
 	return v;
 }

--- a/src/lib/libast/stdio/vasprintf.c
+++ b/src/lib/libast/stdio/vasprintf.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 
@@ -27,7 +28,7 @@ vasprintf(char** s, const char* fmt, va_list args)
 
 	if (f = sfstropen())
 	{
-		v = sfvprintf(f, fmt, args);
+		v = (int)sfvprintf(f, fmt, args);
 		if (!(*s = strdup(sfstruse(f))))
 			v = -1;
 		sfstrclose(f);

--- a/src/lib/libast/stdio/vfprintf.c
+++ b/src/lib/libast/stdio/vfprintf.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 
@@ -22,5 +23,5 @@
 int
 vfprintf(Sfio_t* f, const char* fmt, va_list args)
 {
-	return sfvprintf(f, fmt, args);
+	return (int)sfvprintf(f, fmt, args);
 }

--- a/src/lib/libast/stdio/vfwprintf.c
+++ b/src/lib/libast/stdio/vfwprintf.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2023 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 
@@ -35,7 +36,7 @@ vfwprintf(Sfio_t* f, const wchar_t* fmt, va_list args)
 	int	v;
 	Sfio_t*	t;
 
-	FWIDE(f, WEOF);
+	FWIDE(f, -1);
 	n = wcstombs(NULL, fmt, 0);
 	if (m = malloc(n + 1))
 	{
@@ -49,8 +50,8 @@ vfwprintf(Sfio_t* f, const wchar_t* fmt, va_list args)
 			else
 			{
 				n = mbstowcs(NULL, x, 0);
-				if (w = (wchar_t*)sfreserve(f, n * sizeof(wchar_t) + 1, 0))
-					v = mbstowcs(w, x, n + 1);
+				if (w = (wchar_t*)sfreserve(f, (ssize_t)(n * sizeof(wchar_t) + 1), 0))
+					v = (int)mbstowcs(w, x, n + 1);
 				else
 					v = -1;
 			}

--- a/src/lib/libast/stdio/vfwscanf.c
+++ b/src/lib/libast/stdio/vfwscanf.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2025 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -77,7 +77,7 @@ wideread(Sfio_t* f, void* buf, size_t size, Sfdisc_t* dp)
 	if (r != sizeof(wuf[0]))
 		return -1;
 	wuf[1] = 0;
-	r = wcstombs(buf, wuf, size);
+	r = (ssize_t)wcstombs(buf, wuf, size);
 	return r;
 }
 
@@ -90,7 +90,7 @@ vfwscanf(Sfio_t* f, const wchar_t* fmt, va_list args)
 	Wide_t*	w;
 	char	buf[1024];
 
-	FWIDE(f, WEOF);
+	FWIDE(f, EOF);
 	n = wcstombs(NULL, fmt, 0);
 	if (w = newof(0, Wide_t, 1, n))
 	{

--- a/src/lib/libast/stdio/vprintf.c
+++ b/src/lib/libast/stdio/vprintf.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 
@@ -22,5 +23,5 @@
 int
 vprintf(const char* fmt, va_list args)
 {
-	return sfvprintf(sfstdout, fmt, args);
+	return (int)sfvprintf(sfstdout, fmt, args);
 }

--- a/src/lib/libast/stdio/vsnprintf.c
+++ b/src/lib/libast/stdio/vsnprintf.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,28 +14,29 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 
 #include "stdhdr.h"
 
 int
-vsnprintf(char* s, int n, const char* form, va_list args)
+vsnprintf(char* s, size_t n, const char* form, va_list args)
 {
 	Sfio_t*	f;
-	ssize_t	rv;
+	int rv;
 
 	/* make a temp stream */
 	if(!(f = sfnew(NULL,NULL,(size_t)SFIO_UNBOUND,
 			-1,SFIO_WRITE|SFIO_STRING)) )
 		return -1;
 
-	if((rv = sfvprintf(f,form,args)) >= 0 )
+	if((rv = (int)sfvprintf(f,form,args)) >= 0 )
 	{	if(s && n > 0)
-		{	if((rv+1) >= n)
+		{	if((rv+1) >= (int)n)
 				n--;
 			else
-				n = rv;
+				n = (size_t)rv;
 			memcpy(s, f->data, n);
 			s[n] = 0;
 		}

--- a/src/lib/libast/stdio/vswprintf.c
+++ b/src/lib/libast/stdio/vswprintf.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 
@@ -42,7 +43,7 @@ vswprintf(wchar_t* s, size_t n, const wchar_t* fmt, va_list args)
 	f.flags = SFIO_STRING|SFIO_WRITE;
 	f.bits = SFIO_PRIVATE;
 	f.mode = SFIO_WRITE;
-	f.size = n - 1;
+	f.size = (ssize_t)n - 1;
 	f.data = f.next = f.endr = (uchar*)s;
 	f.endb = f.endw = f.data + f.size;
 
@@ -52,7 +53,7 @@ vswprintf(wchar_t* s, size_t n, const wchar_t* fmt, va_list args)
 
 	v = vfwprintf(&f, fmt, args);
 	*f.next = 0;
-	_Sfi = f.next - f.data;
+	_Sfi = (ssize_t)(f.next - f.data);
 	return v;
 }
 

--- a/src/lib/libast/stdio/vswscanf.c
+++ b/src/lib/libast/stdio/vswscanf.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 
@@ -41,7 +42,7 @@ vswscanf(const wchar_t* s, const wchar_t* fmt, va_list args)
 	f.flags = SFIO_STRING|SFIO_READ;
 	f.bits = SFIO_PRIVATE;
 	f.mode = SFIO_READ;
-	f.size = wcslen(s) * sizeof(wchar_t);
+	f.size = (ssize_t)(wcslen(s) * sizeof(wchar_t));
 	f.data = f.next = f.endw = (uchar*)s;
 	f.endb = f.endr = f.data + f.size;
 

--- a/src/lib/libast/string/fmtelapsed.c
+++ b/src/lib/libast/string/fmtelapsed.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2023 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 /*
@@ -25,15 +26,15 @@
 #include <ast.h>
 
 char*
-fmtelapsed(unsigned long u, int n)
+fmtelapsed(unsigned long u, unsigned long n)
 {
 	unsigned long	t;
 	char*		buf;
-	int		z;
+	size_t		z;
 
-	if (u == 0L)
+	if (u == 0UL)
 		return "0";
-	if (u == ~0L)
+	if (u == ~0UL)
 		return "%";
 	buf = fmtbuf(z = 8);
 	t = u / n;

--- a/src/lib/libast/string/fmtmode.c
+++ b/src/lib/libast/string/fmtmode.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2023 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 /*
@@ -27,11 +28,11 @@
 #include "modelib.h"
 
 char*
-fmtmode(int mode, int external)
+fmtmode(mode_t mode, int external)
 {
 	char*		s;
 	struct modeop*	p;
-	char*			buf;
+	char*		buf;
 
 	if (!external)
 		mode = modex(mode);

--- a/src/lib/libast/string/fmtperm.c
+++ b/src/lib/libast/string/fmtperm.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2023 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 /*
@@ -27,7 +28,7 @@
 #include <ls.h>
 
 char*
-fmtperm(int perm)
+fmtperm(mode_t perm)
 {
 	char*	s;
 	char*		buf;

--- a/src/lib/libast/string/fmtscale.c
+++ b/src/lib/libast/string/fmtscale.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2023 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 /*
@@ -28,11 +29,11 @@
 #include <lclib.h>
 
 char*
-fmtscale(Sfulong_t n, int k)
+fmtscale(Sfulong_t n, unsigned int k)
 {
 	Sfulong_t		m;
-	int			r;
-	int			z;
+	Sflong_t		r;
+	size_t			z;
 	const char*		u;
 	char			suf[3];
 	char*			s;
@@ -53,7 +54,7 @@ fmtscale(Sfulong_t n, int k)
 			n /= k;
 			u++;
 		}
-		if ((r = (10 * (m % k) + (k / 2)) / k) > 9)
+		if ((r = (Sflong_t)(10 * (m % k) + (k / 2)) / (signed)k) > 9)
 		{
 			r = 0;
 			n++;
@@ -79,7 +80,7 @@ fmtscale(Sfulong_t n, int k)
 	}
 	*s = 0;
 	if (n > 0 && n < 10)
-		sfsprintf(buf, z, "%I*u%c%d%s", sizeof(n), n, p->decimal >= 0 ? p->decimal : '.', r, suf);
+		sfsprintf(buf, z, "%I*u%c%jd%s", sizeof(n), n, p->decimal >= 0 ? p->decimal : '.', r, suf);
 	else
 	{
 		if (r >= 5)

--- a/src/lib/libast/string/modedata.c
+++ b/src/lib/libast/string/modedata.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 /*
@@ -48,7 +49,7 @@ struct modeop	modetab[MODELEN] =
 #endif
 };
 
-int	permmap[PERMLEN] =
+mode_t	permmap[PERMLEN] =
 {
 	S_ISUID, X_ISUID,
 	S_ISGID, X_ISGID,

--- a/src/lib/libast/string/modei.c
+++ b/src/lib/libast/string/modei.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2023 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 /*
@@ -33,14 +34,14 @@
 
 #undef	modei
 
-int
-modei(int x)
+mode_t
+modei(mode_t x)
 {
 #if _S_IDPERM
 	return x & X_IPERM;
 #else
-	int	i;
-	int	c;
+	mode_t	i;
+	mode_t	c;
 
 	i = 0;
 	for (c = 0; c < PERMLEN; c += 2)

--- a/src/lib/libast/string/modelib.h
+++ b/src/lib/libast/string/modelib.h
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2022 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 /*
@@ -38,14 +39,14 @@
 
 struct modeop			/* ops for each char in mode string	*/
 {
-	int	mask1;		/* first mask				*/
-	int	shift1;		/* first shift count			*/
-	int	mask2;		/* second mask				*/
-	int	shift2;		/* second shift count			*/
+	mode_t	mask1;		/* first mask				*/
+	mode_t	shift1;		/* first shift count			*/
+	mode_t	mask2;		/* second mask				*/
+	mode_t	shift2;		/* second shift count			*/
 	char*	name;		/* mode char using mask/shift as index	*/
 };
 
 extern struct modeop	modetab[];
-extern int		permmap[];
+extern mode_t		permmap[];
 
 #endif

--- a/src/lib/libast/string/modex.c
+++ b/src/lib/libast/string/modex.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2023 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 /*
@@ -31,14 +32,14 @@
 
 #undef	modex
 
-int
-modex(int i)
+mode_t
+modex(mode_t i)
 {
 #if _S_IDPERM && _S_IDTYPE
 	return i;
 #else
-	int	x;
-	int	c;
+	mode_t	x;
+	mode_t	c;
 
 	x = 0;
 #if _S_IDPERM

--- a/src/lib/libast/string/strmatch.c
+++ b/src/lib/libast/string/strmatch.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2012 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -58,7 +58,7 @@
 static struct State_s
 {
 	regmatch_t*	match;
-	int		nmatch;
+	ssize_t		nmatch;
 } matchstate;
 
 /*
@@ -71,12 +71,12 @@ static struct State_s
  * including s+sub[1]
  */
 
-int
-strngrpmatch(const char* b, size_t z, const char* p, ssize_t* sub, int n, int flags)
+ssize_t
+strngrpmatch(const char* b, size_t z, const char* p, ssize_t* sub, ssize_t n, regflags_t flags)
 {
 	regex_t*	re;
 	ssize_t*	end;
-	int		i;
+	ssize_t		i;
 	regflags_t	reflags;
 
 	/*
@@ -92,16 +92,7 @@ strngrpmatch(const char* b, size_t z, const char* p, ssize_t* sub, int n, int fl
 	if (!*p)
 	{
 		if (sub && n > 0)
-		{
-			if (flags & STR_INT)
-			{
-				int*	subi = (int*)sub;
-
-				subi[0] = subi[1] = 0;
-			}
-			else
-				sub[0] = sub[1] = 0;
-		}
+			sub[0] = sub[1] = 0;
 		return *b == 0;
 	}
 
@@ -131,34 +122,20 @@ strngrpmatch(const char* b, size_t z, const char* p, ssize_t* sub, int n, int fl
 		return 0;
 	if (n > matchstate.nmatch)
 	{
-		if (!(matchstate.match = newof(matchstate.match, regmatch_t, n, 0)))
+		if (!(matchstate.match = newof(matchstate.match, regmatch_t, (size_t)n, 0)))
 			return 0;
 		matchstate.nmatch = n;
 	}
-	if (regnexec(re, b, z, n, matchstate.match, reflags & ~(REG_MINIMAL|REG_SHELL_GROUP|REG_LEFT|REG_RIGHT|REG_ICASE)))
+	if (regnexec(re, b, z, (size_t)n, matchstate.match, reflags & ~(REG_MINIMAL|REG_SHELL_GROUP|REG_LEFT|REG_RIGHT|REG_ICASE)))
 		return 0;
 	if (!sub || n <= 0)
 		return 1;
-	i = re->re_nsub;
-	if (flags & STR_INT)
+	i = (ssize_t)re->re_nsub;
+	end = sub + n * 2;
+	for (n = 0; sub < end && n <= i; n++)
 	{
-		int*	subi = (int*)sub;
-		int*	endi = subi + n * 2;
-
-		for (n = 0; subi < endi && n <= i; n++)
-		{
-			*subi++ = matchstate.match[n].rm_so;
-			*subi++ = matchstate.match[n].rm_eo;
-		}
-	}
-	else
-	{
-		end = sub + n * 2;
-		for (n = 0; sub < end && n <= i; n++)
-		{
-			*sub++ = matchstate.match[n].rm_so;
-			*sub++ = matchstate.match[n].rm_eo;
-		}
+		*sub++ = matchstate.match[n].rm_so;
+		*sub++ = matchstate.match[n].rm_eo;
 	}
 	return i + 1;
 }
@@ -168,7 +145,7 @@ strngrpmatch(const char* b, size_t z, const char* p, ssize_t* sub, int n, int fl
  * returns 1 for match 0 otherwise
  */
 
-int
+ssize_t
 strmatch(const char* s, const char* p)
 {
 	return strngrpmatch(s, s ? strlen(s) : 0, p, NULL, 0, STR_MAXIMAL|STR_LEFT|STR_RIGHT);
@@ -183,15 +160,15 @@ strmatch(const char* s, const char* p)
  */
 
 char*
-strsubmatch(const char* s, const char* p, int flags)
+strsubmatch(const char* s, const char* p, regflags_t flags)
 {
 	ssize_t	match[2];
 
 	return strngrpmatch(s, s ? strlen(s) : 0, p, match, 1, (flags ? STR_MAXIMAL : 0)|STR_LEFT) ? (char*)s + match[1] : NULL;
 }
 
-int
-strgrpmatch(const char* b, const char* p, ssize_t* sub, int n, int flags)
+ssize_t
+strgrpmatch(const char* b, const char* p, ssize_t* sub, ssize_t n, regflags_t flags)
 {
 	return strngrpmatch(b, b ? strlen(b) : 0, p, sub, n, flags);
 }

--- a/src/lib/libast/string/strmode.c
+++ b/src/lib/libast/string/strmode.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2023 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -14,6 +14,7 @@
 *                  David Korn <dgk@research.att.com>                   *
 *                   Phong Vo <kpv@research.att.com>                    *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 /*
@@ -26,21 +27,21 @@
 
 #include "modelib.h"
 
-int
+mode_t
 strmode(const char* s)
 {
 	int		c;
 	char*		t;
 	struct modeop*	p;
-	int		mode;
+	mode_t		mode;
 
 	mode = 0;
 	for (p = modetab; (c = *s++) && p < &modetab[MODELEN]; p++)
 		for (t = p->name; *t; t++)
 			if (*t == c)
 			{
-				c = t - p->name;
-				mode |= (p->mask1 & (c << p->shift1)) | (p->mask2 & (c << p->shift2));
+				c = (int)(t - p->name);
+				mode |= (p->mask1 & ((mode_t)c << p->shift1)) | (p->mask2 & ((mode_t)c << p->shift2));
 				break;
 			}
 	return mode;

--- a/src/lib/libast/string/strperm.c
+++ b/src/lib/libast/string/strperm.c
@@ -52,7 +52,7 @@ strperm(const char* aexpr, char** e, mode_t perm)
 	{
 		perm = 0;
 		masked = 1;
-		mask = ~0U;
+		mask = (mode_t)~0;
 	}
 	else
 		masked = 0;

--- a/src/lib/libast/string/strperm.c
+++ b/src/lib/libast/string/strperm.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1985-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2023 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -36,23 +36,23 @@
 #include <ls.h>
 #include <modex.h>
 
-int
-strperm(const char* aexpr, char** e, int perm)
+mode_t
+strperm(const char* aexpr, char** e, mode_t perm)
 {
 	char*	expr = (char*)aexpr;
 	int	c;
-	int	typ;
-	int	who;
+	mode_t	typ;
+	mode_t	who;
+	mode_t	mask;
 	int	num;
 	int	op;
-	int	mask;
 	int	masked;
 
-	if (perm == -1)
+	if (perm == (mode_t)-1)
 	{
 		perm = 0;
 		masked = 1;
-		mask = ~0;
+		mask = ~0U;
 	}
 	else
 		masked = 0;


### PR DESCRIPTION
This is the second part of the thickfold patch series, which enables ksh93 to operate within a 64-bit address space. This part of the patch series includes everything affected by changes to `<ast.h>`. Despite being the second part of the patch series, it's also the largest one individually.

The parts of ksh93 affected by this commit are:
- SFIO and the associated stdio wrapper. The `sfvprintf` and `sfvscanf` functions are notable for bearing the brunt of the substantial code changes.
  - Nearly all of the code is de novo, though towards the latter end of development I used some graphviz commits for cross-reference:
    - https://gitlab.com/graphviz/graphviz/-/commit/6451a669
    - https://gitlab.com/graphviz/graphviz/-/commit/153a8f87
    - Improved multibyte handling in `sfvscanf` via use of `unsigned char*`; ported from graphviz: https://gitlab.com/graphviz/graphviz/-/commit/cb9b35d1 (I'm aware this function is unused, but after some manual testing it works well AFAICT. A bit odd that ksh93 never uses it once.)
  - `sfseek()`: Removed a wasteful double assignment for `f->iosz`. This error was introduced in 2003-06-21 ksh93o+, and likely would have gone unnoticed if not for the thickfold project. (In practice this line was virtually always optimized out by the compiler, so it was dead code.)
- 64-bit modernization for the AST hash library.
- Transitioned `pathgetlink()` to return `ssize_t`.
- Updated the code in print.c for compatibility with the SFIO 64-bit modernization.
- Transitioned the `strgrpmatch()` family to use `regflags_t` to appease some `-Wsign-conversion` warnings (the type is now located in ast.h).
  - The now unused `STR_INT` flag backported from ksh93v- has been removed to avoid bitrot.
- Removed the unused nonstandard `ssizeof()` macro from ast.h.
- Made the `snprintf` and `vsnprintf` wrappers standards compliant with the C standard.
- Various other changes to fix type mismatches.

Change in the number of warnings on Linux when compiling with clang using `-Wsign-compare -Wshorten-64-to-32 -Wsign-conversion -Wimplicit-int-conversion`: 3,849 => 3,178 => 61 (progression from part 1 => part 2 => part 13)

Progresses https://github.com/ksh93/ksh/issues/592