### PR TITLE
Improve assert() failure output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Checkout sources
       uses: actions/checkout@main
     - name: Build
-      run: bin/package make -j5
+      run: bin/package make -j5 CCFLAGS=-Og LDFLAGS=-g
     - name: Regression tests
       run: |
         PS4="$PS4[ci.yml] "
@@ -30,13 +30,13 @@ jobs:
         sed --regexp-extended --in-place=.orig \
           '/^SHOPT (AUDIT|BGX|BRACEPAT|DEVFD|DYNAMIC|EDPREDICT|ESH|FIXEDARRAY|HISTEXPAND|MULTIBYTE|NAMESPACE|OPTIMIZE|SPAWN|STATS|SUID_EXEC|VSH)=/ s/=1?/=0/' \
           src/cmd/ksh93/SHOPT.sh &&
-        bin/package make -j5 &&
+        bin/package make -j5 CCFLAGS=-Og LDFLAGS=-g &&
         : default regression tests with SHOPTs disabled &&
         script -q -e -c "bin/shtests" &&
         : enable SHOPT_SCRIPTONLY, rebuild ksh &&
         sed --regexp-extended --in-place=.orig \
           '/^SHOPT SCRIPTONLY=/ s/=0?/=1/' \
           src/cmd/ksh93/SHOPT.sh &&
-        bin/package make -j5 &&
+        bin/package make -j5 CCFLAGS=-Og LDFLAGS=-g &&
         : default regression tests with SHOPT_SCRIPTONLY enabled &&
         script -q -e -c "bin/shtests"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Checkout sources
       uses: actions/checkout@main
     - name: Build
-      run: bin/package make -j5 CCFLAGS=-Og LDFLAGS=-g
+      run: bin/package make -j5 CCFLAGS=-Og
     - name: Regression tests
       run: |
         PS4="$PS4[ci.yml] "
@@ -30,13 +30,13 @@ jobs:
         sed --regexp-extended --in-place=.orig \
           '/^SHOPT (AUDIT|BGX|BRACEPAT|DEVFD|DYNAMIC|EDPREDICT|ESH|FIXEDARRAY|HISTEXPAND|MULTIBYTE|NAMESPACE|OPTIMIZE|SPAWN|STATS|SUID_EXEC|VSH)=/ s/=1?/=0/' \
           src/cmd/ksh93/SHOPT.sh &&
-        bin/package make -j5 CCFLAGS=-Og LDFLAGS=-g &&
+        bin/package make -j5 CCFLAGS=-Og &&
         : default regression tests with SHOPTs disabled &&
         script -q -e -c "bin/shtests" &&
         : enable SHOPT_SCRIPTONLY, rebuild ksh &&
         sed --regexp-extended --in-place=.orig \
           '/^SHOPT SCRIPTONLY=/ s/=0?/=1/' \
           src/cmd/ksh93/SHOPT.sh &&
-        bin/package make -j5 CCFLAGS=-Og LDFLAGS=-g &&
+        bin/package make -j5 CCFLAGS=-Og &&
         : default regression tests with SHOPT_SCRIPTONLY enabled &&
         script -q -e -c "bin/shtests"

--- a/src/cmd/builtin/Mamfile
+++ b/src/cmd/builtin/Mamfile
@@ -9,7 +9,7 @@ setv INSTALLROOT ../../..
 setv CC cc
 setv mam_cc_FLAGS %{mam_cc_TARGET} %{mam_cc_DLL} %{-debug-symbols?1?%{mam_cc_DEBUG} -D_BLD_DEBUG?%{mam_cc_OPTIMIZE}?}
 setv CCFLAGS
-setv CCLDFLAGS %{-strip-symbols?1?%{mam_cc_LD_STRIP}??}
+setv CCLDFLAGS %{-strip-symbols?1?%{mam_cc_LD_STRIP}??} %{mam_cc_EXPORT_DYNAMIC}
 setv IFFEFLAGS
 setv LDFLAGS
 

--- a/src/cmd/ksh93/Mamfile
+++ b/src/cmd/ksh93/Mamfile
@@ -8,7 +8,7 @@ setv INSTALLROOT ../../..
 setv CC cc
 setv mam_cc_FLAGS %{mam_cc_TARGET} %{mam_cc_DLL} -D_BLD_ksh %{-debug-symbols?1?%{mam_cc_DEBUG} -D_BLD_DEBUG?%{mam_cc_OPTIMIZE}?}
 setv CCFLAGS
-setv CCLDFLAGS %{-strip-symbols?1?%{mam_cc_LD_STRIP}??}
+setv CCLDFLAGS %{-strip-symbols?1?%{mam_cc_LD_STRIP}??} %{mam_cc_EXPORT_DYNAMIC}
 setv IFFEFLAGS
 setv LDFLAGS
 setv SH_DICT \"libshell\"

--- a/src/cmd/ksh93/sh/array.c
+++ b/src/cmd/ksh93/sh/array.c
@@ -1483,6 +1483,8 @@ char *nv_endsubscript(Namval_t *np, char *cp, int mode)
 {
 	int count=1, quoted=0, c;
 	char *sp = cp+1;
+	if(*cp!='[')
+		errormsg(SH_DICT, ERROR_exit(0), "Failure: *cp == %c, cp == '%s'", *cp, cp);
 	assert(*cp=='[');
 	/* first find matching ']' */
 	while(count>0 && (c= *++cp))

--- a/src/lib/libast/Mamfile
+++ b/src/lib/libast/Mamfile
@@ -10,7 +10,7 @@ setv INCLUDE_AST %{INSTALLROOT}/include/ast
 setv CC cc
 setv mam_cc_FLAGS %{mam_cc_TARGET} %{mam_cc_DLL} -D_BLD_ast %{-debug-symbols?1?%{mam_cc_DEBUG} -D_BLD_DEBUG?%{mam_cc_OPTIMIZE}?}
 setv CCFLAGS
-setv CCLDFLAGS %{-strip-symbols?1?%{mam_cc_LD_STRIP}??}
+setv CCLDFLAGS %{-strip-symbols?1?%{mam_cc_LD_STRIP}??} %{mam_cc_EXPORT_DYNAMIC}
 setv IFFEFLAGS
 setv LDFLAGS
 setv DYLIB_PRE %{mam_cc_SUFFIX_DYNAMIC?*?%{mam_cc_PREFIX_DYNAMIC}?%{mam_cc_PREFIX_SHARED}?}

--- a/src/lib/libast/comp/assert.c
+++ b/src/lib/libast/comp/assert.c
@@ -16,6 +16,10 @@
 
 #include <ast.h>
 
+#if _hdr_execinfo
+#include <execinfo.h>
+#endif
+
 noreturn void _ast_assertfail(const char *a, const char *fun, const char *file, int line)
 {
 #if _has___func__ || _has___FUNCTION__
@@ -23,6 +27,16 @@ noreturn void _ast_assertfail(const char *a, const char *fun, const char *file, 
 #else
 	NOT_USED(fun);
 	sfprintf(sfstderr,"\n*** assertion %s failed in %s:%d\n", a, file, line);
+#endif
+#if _lib_backtrace && _lib_backtrace_symbols
+	{
+		void* callstack[200];
+		int i, frames = backtrace(callstack, 200);
+		char** strs = backtrace_symbols(callstack, frames);
+		for (i = 0; i < frames; ++i)
+			sfprintf(sfstderr, "%s\n", strs[i]);
+		free(strs);
+	}
 #endif
 	sfsync(NULL);
 	abort();

--- a/src/lib/libast/comp/assert.c
+++ b/src/lib/libast/comp/assert.c
@@ -33,9 +33,14 @@ noreturn void _ast_assertfail(const char *a, const char *fun, const char *file, 
 		void* callstack[200];
 		int i, frames = backtrace(callstack, 200);
 		char** strs = backtrace_symbols(callstack, frames);
-		for (i = 0; i < frames; ++i)
-			sfprintf(sfstderr, "%s\n", strs[i]);
-		free(strs);
+		if(strs)
+		{
+			for (i = 0; i < frames; ++i)
+				sfprintf(sfstderr, "%s\n", strs[i]);
+			free(strs);
+		}
+		else
+			sfprintf(sfstderr, "Could not obtain a backtrace (%s)\n", strerror(errno));
 	}
 #endif
 	sfsync(NULL);

--- a/src/lib/libast/features/lib
+++ b/src/lib/libast/features/lib
@@ -4,7 +4,7 @@ cmd	universe
 
 sys	mman
 hdr	fcntl,dirent,direntry,filio,fnmatch,jioctl,libgen,limits
-hdr	locale,ndir,nl_types,process,spawn,utime
+hdr	execinfo,locale,ndir,nl_types,process,spawn,utime
 hdr	linux/fs,linux/msdos_fs
 hdr	wctype
 hdr	wchar note{ <wchar.h> and isw*() really work }end execute{
@@ -24,7 +24,7 @@ dat	_tzname,tzname
 
 lib	BSDsetpgrp
 lib	_cleanup
-lib	bcopy,bzero,confstr,dirread
+lib	backtrace,backtrace_symbols,bcopy,bzero,confstr,dirread
 lib	fchmod,fcntl,fnmatch,fork,fsync
 lib	getconf,getdents,getdirentries,getdtablesize
 lib	gethostname,getpagesize,getrlimit,getuniverse

--- a/src/lib/libcmd/Mamfile
+++ b/src/lib/libcmd/Mamfile
@@ -10,7 +10,7 @@ setv mam_cc_FLAGS %{mam_cc_TARGET} %{mam_cc_DLL} %{-debug-symbols?1?%{mam_cc_DEB
 setv CCFLAGS
 setv IFFEFLAGS
 setv LDFLAGS
-setv CCLDFLAGS
+setv CCLDFLAGS %{mam_cc_EXPORT_DYNAMIC}
 setv DYLIB_PRE %{mam_cc_SUFFIX_DYNAMIC?*?%{mam_cc_PREFIX_DYNAMIC}?%{mam_cc_PREFIX_SHARED}?}
 setv DYLIB_SUF %{mam_cc_SUFFIX_DYNAMIC-%{mam_cc_SUFFIX_SHARED}}
 setv DYLIB_VERSION 4.0

--- a/src/lib/libdll/Mamfile
+++ b/src/lib/libdll/Mamfile
@@ -10,7 +10,7 @@ setv mam_cc_FLAGS %{mam_cc_TARGET} %{mam_cc_DLL} %{-debug-symbols?1?%{mam_cc_DEB
 setv CCFLAGS
 setv IFFEFLAGS
 setv LDFLAGS
-setv CCLDFLAGS
+setv CCLDFLAGS %{mam_cc_EXPORT_DYNAMIC}
 setv DYLIB_PRE %{mam_cc_SUFFIX_DYNAMIC?*?%{mam_cc_PREFIX_DYNAMIC}?%{mam_cc_PREFIX_SHARED}?}
 setv DYLIB_SUF %{mam_cc_SUFFIX_DYNAMIC-%{mam_cc_SUFFIX_SHARED}}
 setv DYLIB_VERSION 4.0


### PR DESCRIPTION
Changes:
- `_ast_assertfail()`: Use glibc's `backtrace()` and `backtrace_symbols()` to produce a backtrace after a failed assertion.
  - Link with `-rdynamic` or `-Wl,-export-dynamic` when available. Glibc's `backtrace_symbols` function will fail to print readable function names if this is not included in the linker's flags, resulting in significantly worse backtraces. (This flag should've been part of https://github.com/ksh93/ksh/pull/357; see also https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=821806.)
- `nv_endsubscript()`: Add an error message prior to calling `assert` to hopefully make the [intermittent crashing bug](https://github.com/ksh93/ksh/actions/runs/23748197763/job/69182510328) easier to trace. (I can't trigger it manually at all, so hopefully the next CI crash produces more useful output.)
- ci.yml: Compile CI builds with `CCFLAGS=-Og` (`-g` is required alongside `-rdynamic` for useful backtraces).