### PR TITLE
64-bit transition part 8: ancillary AST suite components

### DIFF
--- a/src/cmd/INIT/mamake.c
+++ b/src/cmd/INIT/mamake.c
@@ -293,13 +293,13 @@ static struct				/* program state		*/
 	int		force;		/* all targets out of date	*/
 	int		ignore;		/* ignore command errors	*/
 	int		indent;		/* debug indent			*/
-	int		installrootlen;	/* strlen of %{INSTALLROOT}	*/
-	int		packagerootlen;	/* strlen of %{PACKAGEROOT}	*/
 	int		keepgoing;	/* do siblings on error		*/
 	int		never;		/* never execute		*/
 	int		probed;		/* probe already done		*/
 	int		verified;	/* don't bother with verify()	*/
 	int		jobs, maxjobs;	/* for parallel sh execution	*/
+	size_t		installrootlen;	/* strlen of %{INSTALLROOT}	*/
+	size_t		packagerootlen;	/* strlen of %{PACKAGEROOT}	*/
 
 	Stream_t	streams[4];	/* input file stream stack	*/
 	Stream_t	*sp;		/* input stream stack pointer	*/
@@ -501,8 +501,8 @@ static char *appendn(Buf_t *buf, char *str, size_t n)
 
 	if ((n + 1) >= (size_t)(buf->end - buf->nxt))
 	{
-		i = buf->nxt - buf->buf;
-		m = (((buf->end - buf->buf) + n + CHUNK + 1) / CHUNK) * CHUNK;
+		i = (size_t)(buf->nxt - buf->buf);
+		m = (((size_t)(buf->end - buf->buf) + n + CHUNK + 1) / CHUNK) * CHUNK;
 		if (!(buf->buf = realloc(buf->buf, m)))
 			out_of_memory();
 		buf->end = buf->buf + m;
@@ -881,7 +881,7 @@ static void view(void)
 				zp = zp->next = vp;
 			if (!c)
 				break;
-			*t++ = c;
+			*t++ = (char)c;
 			s = t;
 		}
 	}
@@ -972,7 +972,7 @@ static void substitute(Buf_t *buf, char *s)
 			if (c == '[')
 			{
 				append(buf, b);
-				*vnterm = c;
+				*vnterm = (char)c;
 				continue;
 			}
 
@@ -992,7 +992,7 @@ static void substitute(Buf_t *buf, char *s)
 			if ((c == ':' || c == '=') && (state.strict >= 2 || !v || c == ':' && !*v))
 			{
 				append(buf, b);
-				*vnterm = c;
+				*vnterm = (char)c;
 				continue;
 			}
 
@@ -1003,7 +1003,7 @@ static void substitute(Buf_t *buf, char *s)
 
 			/* Un-terminate the variable name */
 
-			*vnterm = c;
+			*vnterm = (char)c;
 
 			/* Find the ending '}', dealing with nesting */
 
@@ -1027,7 +1027,7 @@ static void substitute(Buf_t *buf, char *s)
 				q = cond(t - 1);
 				if (v)
 				{
-					if (((q - t) != 1 || *t != '*') && strncmp(v, t, q - t))
+					if (((q - t) != 1 || *t != '*') && strncmp(v, t, (size_t)(q - t)))
 						v = 0;
 				}
 				else if (q == t)
@@ -1040,7 +1040,7 @@ static void substitute(Buf_t *buf, char *s)
 						c = *t;
 						*t = 0;
 						substitute(buf, q + 1);
-						*t = c;
+						*t = (char)c;
 					}
 				}
 				else
@@ -1051,7 +1051,7 @@ static void substitute(Buf_t *buf, char *s)
 						c = *q;
 						*q = 0;
 						substitute(buf, t + 1);
-						*q = c;
+						*q = (char)c;
 					}
 				}
 				break;
@@ -1072,9 +1072,9 @@ static void substitute(Buf_t *buf, char *s)
 							q++;
 						n++;
 						c = *q, *q = 0;  /* terminate for duplicate() */
-						if (!(argv = realloc(argv, (n+1)*sizeof(char*))) || !(argv[n-1] = duplicate(a)))
+						if (!(argv = realloc(argv, (size_t)(n+1)*sizeof(char*))) || !(argv[n-1] = duplicate(a)))
 							out_of_memory();
-						*q = c;
+						*q = (char)c;
 					}
 					if (!argv)
 						break;
@@ -1120,13 +1120,13 @@ static void substitute(Buf_t *buf, char *s)
 					q = use(scr);
 					if ((argv ? (argv[2] = q, execute_v(NULL, argv)) : execute(NULL, q)) != 0)
 						error_out("expansion script error", t);
-					*s = n;
+					*s = (char)n;
 					drop(scr);
 					/* read output back, converting each newline but the last to a space */
 					if (!(f = fopen(out, "r")))
 						error_out(strerror(errno), "could not open pipe command output for reading");
 					while ((c = getc(f)) != EOF)
-						add(buf, (final_newline = (c == '\n')) ? ' ' : c);
+						add(buf, (final_newline = (c == '\n')) ? ' ' : (char)c);
 					if (final_newline)
 						unadd(buf);
 					if (ferror(f) || fclose(f) == EOF)
@@ -1150,7 +1150,7 @@ static void substitute(Buf_t *buf, char *s)
 					c = *s;
 					*s = 0;
 					substitute(buf, t);
-					*s = c;
+					*s = (char)c;
 					break;
 				}
 				if (c != '-')
@@ -1211,7 +1211,7 @@ static void substitute(Buf_t *buf, char *s)
 					c = *s;
 					*s = 0;
 					append(buf, b);
-					*s = c;
+					*s = (char)c;
 					continue;
 				}
 				break;
@@ -1220,7 +1220,7 @@ static void substitute(Buf_t *buf, char *s)
 				s++;
 		}
 		else
-			add(buf, c);
+			add(buf, (char)c);
 	}
 }
 
@@ -1314,7 +1314,7 @@ static char *find(Buf_t *buf, char *file, struct stat *st)
 					c = vp->dir[vp->node];
 					vp->dir[vp->node] = 0;
 					append(buf, vp->dir);
-					vp->dir[vp->node] = c;
+					vp->dir[vp->node] = (char)c;
 				}
 				else
 				{
@@ -1322,7 +1322,7 @@ static char *find(Buf_t *buf, char *file, struct stat *st)
 					append(buf, "/");
 				}
 				append(buf, file);
-				o = getsize(buf);
+				o = (size_t)getsize(buf);
 				s = use(buf);
 				if (s = status(buf, o, s, st))
 				{
@@ -1754,7 +1754,7 @@ static void run(Rule_t *r, char *s)
 					else
 					{
 						for (i = 3; isspace(*(t + i)); i++);
-						*s = c;
+						*s = (char)c;
 						for (s = t + i; *s && !isspace(*s); s++);
 						c = *s;
 						*s = 0;
@@ -1778,7 +1778,7 @@ static void run(Rule_t *r, char *s)
 					}
 				}
 			}
-		} while (*s = c);
+		} while (*s = (char)c);
 		s = use(buf);
 		if (tofree)
 			free(tofree);
@@ -1857,7 +1857,7 @@ static void probe(Rule_t *r, Makestate_t *stp)
 		pop();
 	}
 	for (h = 0, s = cc; *s; s++)
-		h = h * 0x63c63cd9L + *s + 0x9c39c33dL;
+		h = h * 0x63c63cd9L + (unsigned long)*s + 0x9c39c33dL;
 	/* use the hash as the file name */
 	append(buf, state.installroot);
 	append(buf, "/lib/probe/C/mam/");
@@ -1897,7 +1897,7 @@ static void attributes(Rule_t *r, char *s)
 		int	flag = 0;
 		for (; isspace(*s); s++);
 		for (t = s; *s && !isspace(*s); s++);
-		if (!(n = s - t))
+		if (!(n = (size_t)(s - t)))
 			break;
 		switch (*t)
 		{
@@ -1953,7 +1953,7 @@ static void attributes(Rule_t *r, char *s)
  * append libNAME.a to the given buffer
  */
 
-void append_ar_name(Buf_t *buf, char *name)
+static void append_ar_name(Buf_t *buf, char *name)
 {
 	append(buf, "lib");
 	append(buf, name);
@@ -2019,7 +2019,7 @@ static char *require(char *lib, int dontcare)
 					break;
 				do
 				{
-					add(tmp, c);
+					add(tmp, (char)c);
 				} while ((c = fgetc(f)) != EOF && !isspace(c));
 				s = use(tmp);
 				if (s[0] && (s[0] != '-' || s[1]))
@@ -2883,7 +2883,7 @@ int main(int argc, char **argv)
 		case 'j':
 			append(state.opt, " -j");
 			append(state.opt, opt_info.arg);
-			state.maxjobs = opt_info.num;
+			state.maxjobs = (int)opt_info.num;
 			continue;
 		case 'k':
 			append(state.opt, " -k");
@@ -2916,7 +2916,7 @@ int main(int argc, char **argv)
 		case 'D':
 			append(state.opt, " -D");
 			append(state.opt, opt_info.arg);
-			state.debug = -opt_info.num;
+			state.debug = -((int)opt_info.num);
 			if (state.debug > 0)
 				state.debug = 0;
 			continue;
@@ -2956,7 +2956,7 @@ int main(int argc, char **argv)
 				break;
 			}
 			for (t = s += 2; *t && *t != '='; t++);
-			if (!strncmp(s, "debug-symbols", t - s) && append(state.opt, " -G") || !strncmp(s, "strip-symbols", t - s) && append(state.opt, " -S"))
+			if (!strncmp(s, "debug-symbols", (size_t)(t - s)) && append(state.opt, " -G") || !strncmp(s, "strip-symbols", (size_t)(t - s)) && append(state.opt, " -S"))
 			{
 				if (*t)
 				{
@@ -2973,7 +2973,7 @@ int main(int argc, char **argv)
 				}
 				setval(state.vars, s - 1, v);
 				if (c)
-					*t = c;
+					*t = (char)c;
 				continue;
 			}
 			usage();
@@ -3137,7 +3137,7 @@ int main(int argc, char **argv)
 				append(tmp, ".FORCE");
 				setval(state.vars, use(tmp), v);
 				drop(tmp);
-				*t = c;
+				*t = (char)c;
 				break;
 			}
 		}

--- a/src/cmd/builtin/features/pty
+++ b/src/cmd/builtin/features/pty
@@ -11,6 +11,8 @@ lib	openpty,_getpty,ptsname -lutil
 lib	grantpt,unlockpt,posix_openpt stdlib.h
 lib	cfmakeraw termios.h
 
+typ	useconds_t = uint32_t
+
 tst output{
 	#include	<fcntl.h>
 	#if _lib_ptsname
@@ -22,7 +24,7 @@ tst output{
 	#include	<sfio.h>
 	int main(void)
 	{
-		int		i;
+		size_t		i;
 		struct stat	statb;
 		static char*	pty[] = { "/dev/ptyp0000", "/dev/ptym/ptyp0", "/dev/ptyp0" };
 	#if _lib_ptsname

--- a/src/cmd/builtin/pty.c
+++ b/src/cmd/builtin/pty.c
@@ -254,13 +254,13 @@ mkpty(int* master, int* minion)
 #endif
 	tty.c_oflag |= (ONLCR | OPOST);
 #ifdef OCRNL
-	tty.c_oflag &= ~OCRNL;
+	tty.c_oflag &= (tcflag_t)~OCRNL;
 #endif
 #ifdef ONLRET
-	tty.c_oflag &= ~ONLRET;
+	tty.c_oflag &= (tcflag_t)~ONLRET;
 #endif
 	tty.c_iflag |= BRKINT;
-	tty.c_iflag &= ~IGNBRK;
+	tty.c_iflag &= (tcflag_t)~IGNBRK;
 	tty.c_cc[VTIME] = 0;
 	tty.c_cc[VMIN] = CMIN;
 #ifdef B115200
@@ -371,7 +371,7 @@ runcmd(char** argv, int minion, int session)
  */
 
 static int
-process(Sfio_t* mp, Sfio_t* lp, int delay, int timeout)
+process(Sfio_t* mp, Sfio_t* lp, useconds_t delay, int timeout)
 {
 	int		i;
 	int		n;
@@ -419,7 +419,7 @@ process(Sfio_t* mp, Sfio_t* lp, int delay, int timeout)
 					sfclose(mp);
 					mp = 0;
 				}
-				else if ((r = sfvalue(mp)) > 0 && (sfwrite(sfstdout, s, r) != r || sfsync(sfstdout)))
+				else if ((r = sfvalue(mp)) > 0 && (sfwrite(sfstdout, s, (size_t)r) != r || sfsync(sfstdout)))
 				{
 					error(ERROR_SYSTEM|2, "output write failed");
 					goto done;
@@ -509,9 +509,9 @@ typedef struct Master_s
 	char*		bufunderflow;	/* FIXME: kludge to cope with underflow	*/
 	char*		buf;		/* current buffer			*/
 	char*		prompt;		/* peek prompt				*/
-	int		cursor;		/* cursor in buf, 0 if fresh line	*/
+	ptrdiff_t	cursor;		/* cursor in buf, 0 if fresh line	*/
 	int		line;		/* prompt line number			*/
-	int		restore;	/* previous line save char		*/
+	char		restore;	/* previous line save char		*/
 } Master_t;
 #define BUFUNDERFLOW	128		/* bytes of buffer underflow to allow	*/
 
@@ -530,11 +530,10 @@ masterline(Sfio_t* mp, Sfio_t* lp, char* prompt, int must, int timeout, Master_t
 	char*		t;
 	ssize_t		n;
 	size_t		promptlen = 0;
-	ptrdiff_t	d;
 	char		promptbuf[64];
 
 	if (prompt)
-		promptlen = sfsprintf(promptbuf, sizeof(promptbuf), prompt, ++bp->line);
+		promptlen = (size_t)sfsprintf(promptbuf, sizeof(promptbuf), prompt, ++bp->line);
  again:
 	if (prompt)
 	{
@@ -558,7 +557,7 @@ masterline(Sfio_t* mp, Sfio_t* lp, char* prompt, int must, int timeout, Master_t
 				error(-1, "p \"%s\"", fmtnesq(promptbuf, "\"", promptlen));
 				return r;
 			}
-			while (r = memchr(r, '\n', bp->end - r))
+			while (r = memchr(r, '\n', (size_t)(bp->end - r)))
 			{
 				if (strneq(r, promptbuf, promptlen))
 				{
@@ -585,12 +584,12 @@ masterline(Sfio_t* mp, Sfio_t* lp, char* prompt, int must, int timeout, Master_t
 		else
 		{
 			bp->cur = bp->nxt;
-			if (bp->nxt = memchr(bp->nxt + 1, '\n', bp->end - bp->nxt - 1))
+			if (bp->nxt = memchr(bp->nxt + 1, '\n', (size_t)(bp->end - bp->nxt - 1)))
 				bp->nxt++;
 		}
 		goto done;
 	}
-	if ((n = sfpoll(&mp, 1, timeout)) <= 0 || !((int)sfvalue(mp) & SFIO_READ))
+	if ((n = sfpoll(&mp, 1, timeout)) <= 0 || !(sfvalue(mp) & SFIO_READ))
 	{
 		if (n < 0)
 		{
@@ -652,27 +651,27 @@ masterline(Sfio_t* mp, Sfio_t* lp, char* prompt, int must, int timeout, Master_t
 		return NULL;
 	}
 	n = sfvalue(mp);
-	error(-2, "b \"%s\"", fmtnesq(s, "\"", n));
+	error(-2, "b \"%s\"", fmtnesq(s, "\"", (size_t)n));
 	if ((bp->max - bp->end) < n)
 	{
 		size_t	new_buf_size;
 		r = bp->buf;
-		new_buf_size = roundof(bp->max - bp->buf + 1 + n, SFIO_BUFSIZE);
+		new_buf_size = (size_t)roundof(bp->max - bp->buf + 1 + n, SFIO_BUFSIZE);
 		bp->bufunderflow = vmresize(bp->vm, bp->bufunderflow, new_buf_size + BUFUNDERFLOW);
 		bp->buf = bp->bufunderflow + BUFUNDERFLOW;
 		bp->max = bp->buf + new_buf_size - 1;
 		if (bp->buf != r)
 		{
-			d = bp->buf - r;
+			ptrdiff_t d = bp->buf - r;
 			bp->cur += d;
 			bp->end += d;
 		}
 	}
-	memcpy(bp->end, s, n);
+	memcpy(bp->end, s, (size_t)n);
 	bp->end += n;
 	if ((r = bp->cur) > bp->buf && bp->restore >= 0)
 		*r = bp->restore;
-	if (bp->cur = memchr(bp->cur, '\n', bp->end - bp->cur))
+	if (bp->cur = memchr(bp->cur, '\n', (size_t)(bp->end - bp->cur)))
 	{
 		bp->restore = *++bp->cur;
 		*bp->cur = 0;
@@ -681,7 +680,7 @@ masterline(Sfio_t* mp, Sfio_t* lp, char* prompt, int must, int timeout, Master_t
 			bp->cur = bp->end = bp->buf;
 			bp->nxt = 0;
 		}
-		else if (bp->nxt = memchr(bp->cur + 1, '\n', bp->end - bp->cur - 1))
+		else if (bp->nxt = memchr(bp->cur + 1, '\n', (size_t)(bp->end - bp->cur - 1)))
 			bp->nxt++;
 		if (prompt)
 			goto again;
@@ -701,7 +700,7 @@ masterline(Sfio_t* mp, Sfio_t* lp, char* prompt, int must, int timeout, Master_t
 	{
 		r -= bp->cursor; /* FIXME: r may now be before bp->buf */
 		if (r < bp->bufunderflow)
-			error(ERROR_PANIC, "pty.c:%d: internal error: r is %d bytes before bp->bufunderflow", __LINE__, bp->bufunderflow - r);
+			error(ERROR_PANIC, "pty.c:%d: internal error: r is %td bytes before bp->bufunderflow", __LINE__, bp->bufunderflow - r);
 		bp->cursor = 0;
 	}
 	for (t = 0, n = 0; *s; s++)
@@ -778,7 +777,7 @@ struct Cond_s
 };
 
 static int
-dialogue(Sfio_t* mp, Sfio_t* lp, int delay, int timeout)
+dialogue(Sfio_t* mp, Sfio_t* lp, useconds_t delay, int timeout)
 {
 	int		op;
 	int		line;
@@ -829,7 +828,7 @@ dialogue(Sfio_t* mp, Sfio_t* lp, int delay, int timeout)
 			if (master->prompt && !masterline(mp, lp, master->prompt, 0, timeout, master))
 				goto done;
 			if (delay)
-				usleep((unsigned long)delay * 1000);
+				usleep(delay * 1000);
 			if (op == 'w')
 				error(-1, "w \"%s\\r\"", s);
 			else
@@ -842,10 +841,10 @@ dialogue(Sfio_t* mp, Sfio_t* lp, int delay, int timeout)
 				goto done;
 			}
 			if (delay)
-				usleep((unsigned long)delay * 1000);
+				usleep(delay * 1000);
 			break;
 		case 'd':
-			delay = (int)strtol(s, &e, 0);
+			delay = (useconds_t)strtol(s, &e, 0);
 			if (*e)
 				error(2, "%s: invalid delay -- milliseconds expected", s);
 			break;
@@ -923,7 +922,7 @@ dialogue(Sfio_t* mp, Sfio_t* lp, int delay, int timeout)
 			if (*e)
 				error(2, "%s: invalid delay -- milliseconds expected", s);
 			if (n)
-				usleep((unsigned long)n * 1000);
+				usleep((useconds_t)n * 1000);
 			break;
 		case 't':
 			timeout = (int)strtol(s, &e, 0);
@@ -1018,13 +1017,13 @@ b_pty(int argc, char** argv, Shbltin_t* context)
 	Sfio_t*		lp;
 	char		buf[64];
 
-	int		delay = 0;
+	useconds_t	delay = 0;
 	char*		log = 0;
 	char*		messages = 0;
 	char*		stty = 0;
 	int		session = 1;
 	int		timeout = 1000;
-	int		(*fun)(Sfio_t*,Sfio_t*,int,int) = process;
+	int		(*fun)(Sfio_t*,Sfio_t*,useconds_t,int) = process;
 
 	cmdinit(argc, argv, context, ERROR_CATALOG, 0);
 	for (;;)
@@ -1054,7 +1053,7 @@ b_pty(int argc, char** argv, Shbltin_t* context)
 			stty = opt_info.arg;
 			continue;
 		case 'w':
-			delay = (int)opt_info.num;
+			delay = (useconds_t)opt_info.num;
 			continue;
 		case ':':
 			break;
@@ -1076,7 +1075,7 @@ b_pty(int argc, char** argv, Shbltin_t* context)
 		error(ERROR_system(1), "unable to create pty");
 		UNREACHABLE();
 	}
-	if (!(mp = sfnew(NULL, 0, SFIO_UNBOUND, master, SFIO_READ|SFIO_WRITE)))
+	if (!(mp = sfnew(NULL, 0, (size_t)SFIO_UNBOUND, master, SFIO_READ|SFIO_WRITE)))
 	{
 		error(ERROR_system(1), "cannot open master stream");
 		UNREACHABLE();
@@ -1088,7 +1087,7 @@ b_pty(int argc, char** argv, Shbltin_t* context)
 		for (s = stty; *s; s++)
 			if (isspace(*s))
 				n++;
-		ap = newof(0, Argv_t, 1, (n + 2) * sizeof(char*) + (s - stty + 1));
+		ap = newof(0, Argv_t, 1, (size_t)(n + 2) * sizeof(char*) + (size_t)(s - stty + 1));
 		ap->argc = n + 1;
 		ap->argv = (char**)(ap + 1);
 		ap->args = (char*)(ap->argv + n + 2);

--- a/src/lib/libdll/dll_lib.c
+++ b/src/lib/libdll/dll_lib.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1997-2012 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2025 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -12,6 +12,7 @@
 *                                                                      *
 *                 Glenn Fowler <gsf@research.att.com>                  *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 /*
@@ -59,7 +60,7 @@ dllnames(const char* id, const char* name, Dllnames_t* names)
 	 * determine the base name
 	 */
 
-	if ((s = strrchr(name, '/')) || (s = strrchr(name, '\\')))
+	if ((s = (char*)strrchr(name, '/')) || (s = (char*)strrchr(name, '\\')))
 		s++;
 	else
 		s = (char*)name;
@@ -108,7 +109,7 @@ dll_lib(Dllnames_t* names, unsigned long version, Dllerror_f dllerrorf, void* di
 	void*			dll;
 	Dll_lib_t*		lib;
 	Dll_lib_f		libf;
-	ssize_t			n;
+	size_t			len;
 	char			sym[64];
 
 	static Dll_lib_t*	loaded;
@@ -131,7 +132,8 @@ dll_lib(Dllnames_t* names, unsigned long version, Dllerror_f dllerrorf, void* di
 	 * load
 	 */
 
-	if (!(dll = dllplugin(names->id, names->name, NULL, version, NULL, RTLD_LAZY, names->path, names->data + sizeof(names->data) - names->path)) && (streq(names->name, names->base) || !(dll = dllplugin(names->id, names->base, NULL, version, NULL, RTLD_LAZY, names->path, names->data + sizeof(names->data) - names->path))))
+	if (!(dll = dllplugin(names->id, names->name, NULL, version, NULL, RTLD_LAZY, names->path, (size_t)(names->data + sizeof(names->data) - names->path))) && (streq(names->name, names->base)
+				|| !(dll = dllplugin(names->id, names->base, NULL, version, NULL, RTLD_LAZY, names->path, (size_t)(names->data + sizeof(names->data) - names->path)))))
 	{
 		if (dllerrorf)
 			(*dllerrorf)(NULL, disc, 2, "%s: library not found", names->name);
@@ -158,11 +160,11 @@ dll_lib(Dllnames_t* names, unsigned long version, Dllerror_f dllerrorf, void* di
 	 * add to the loaded list
 	 */
 
-	if (lib = newof(0, Dll_lib_t, 1, (n = strlen(names->base)) + strlen(names->path) + 1))
+	if (lib = newof(0, Dll_lib_t, 1, (len = strlen(names->base)) + strlen(names->path) + 1))
 	{
 		lib->libf = libf;
 		strcpy(lib->base, names->base);
-		strcpy(lib->path = lib->base + n + 1, names->path);
+		strcpy(lib->path = lib->base + len + 1, names->path);
 		lib->next = loaded;
 		loaded = lib;
 		errorf("dll", NULL, -1, "dll_lib: %s version %lu loaded from %s", names->name, version, lib->path);

--- a/src/lib/libdll/dllscan.c
+++ b/src/lib/libdll/dllscan.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1997-2012 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2025 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -40,9 +40,9 @@
 	char*		pb; \
 	char*		pp; \
 	char*		pe; \
-	int		off; \
-	int		prelen; \
-	int		suflen; \
+	ssize_t		off; \
+	size_t		prelen; \
+	size_t		suflen; \
 	char**		lib; \
 	char		nam[64]; \
 	char		pat[64]; \
@@ -87,9 +87,9 @@ dllinfo(void)
 	char*			d;
 	char*			v;
 	char*			p;
-	int			dn;
-	int			vn;
-	int			pn;
+	ptrdiff_t		vn;
+	size_t			dn;
+	size_t			pn;
 	char			pat[256];
 
 	static Dllinfo_t	info;
@@ -108,7 +108,7 @@ dllinfo(void)
 				for (;;)
 				{
 					for (d = s; *s && *s != ':' && *s != ','; s++);
-					if (!(dn = s - d))
+					if (!(dn = (size_t)(s - d)))
 						d = 0;
 					if (*s == ':')
 					{
@@ -118,7 +118,7 @@ dllinfo(void)
 						if (*s == ':')
 						{
 							for (p = ++s; *s && *s != ':' && *s != ','; s++);
-							if (!(pn = s - p))
+							if (!(pn = (size_t)(s - p)))
 								p = 0;
 						}
 						else
@@ -144,11 +144,11 @@ dllinfo(void)
 					memcpy(info.sibbuf, d, dn);
 					info.sibling[0] = info.sibbuf;
 				}
-				if (v && vn < sizeof(info.envbuf))
+				if (v && vn < (ssize_t)sizeof(info.envbuf))
 				{
 					if(vn <= 0)
 						abort();
-					memcpy(info.envbuf, v, vn);
+					memcpy(info.envbuf, v, (size_t)vn);
 					info.env = info.envbuf;
 				}
 			}
@@ -187,9 +187,9 @@ vercmp(FTSENT* const* ap, FTSENT* const* bp)
 	{
 		if (isdigit(*a) && isdigit(*b))
 		{
-			m = strtol((char*)a, &e, 10);
+			m = (int)strtol((char*)a, &e, 10);
 			a = (unsigned char*)e;
-			n = strtol((char*)b, &e, 10);
+			n = (int)strtol((char*)b, &e, 10);
 			b = (unsigned char*)e;
 			if (n -= m)
 				return n;
@@ -216,9 +216,9 @@ dllsopen(const char* lib, const char* name, const char* version)
 	Dllscan_t*	scan;
 	Dllinfo_t*	info;
 	Vmalloc_t*	vm;
-	int		i;
-	int		j;
-	int		k;
+	size_t		i;
+	size_t		j;
+	size_t		k;
 	char		buf[32];
 
 	if (!(vm = vmopen()))
@@ -229,7 +229,7 @@ dllsopen(const char* lib, const char* name, const char* version)
 		 * grab the local part of the library ID
 		 */
 
-		if (s = strrchr(lib, ':'))
+		if (s = (char*)strrchr(lib, ':'))
 			lib = (const char*)(s + 1);
 		i = 2 * sizeof(char**) + strlen(lib) + 5;
 	}
@@ -261,11 +261,11 @@ dllsopen(const char* lib, const char* name, const char* version)
 		name = (const char*)"?*";
 		scan->flags |= DLL_MATCH_NAME;
 	}
-	else if (t = strrchr(name, '/'))
+	else if (t = (char*)strrchr(name, '/'))
 	{
-		if (!(scan->pb = vmnewof(vm, 0, char, t - (char*)name, 2)))
+		if (!(scan->pb = vmnewof(vm, 0, char, (size_t)(t - (char*)name), 2)))
 			goto bad;
-		memcpy(scan->pb, name, t - (char*)name);
+		memcpy(scan->pb, name, (size_t)(t - (char*)name));
 		name = (const char*)(t + 1);
 	}
 	if (name)
@@ -292,9 +292,9 @@ dllsopen(const char* lib, const char* name, const char* version)
 					if (*t != '-')
 						scan->flags |= DLL_MATCH_VERSION;
 					version = t + 1;
-					if (!(s = vmnewof(vm, 0, char, t - (char*)name, 1)))
+					if (!(s = vmnewof(vm, 0, char, (size_t)(t - (char*)name), 1)))
 						goto bad;
-					memcpy(s, name, t - (char*)name);
+					memcpy(s, name, (size_t)(t - (char*)name));
 					name = (const char*)s;
 					break;
 				}

--- a/src/lib/libsum/sum-ast4.c
+++ b/src/lib/libsum/sum-ast4.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1996-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2025 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -80,7 +80,7 @@ ast4_block(Sum_t* p, const void* s, size_t n)
 	Ast4_sum_t*	a = &((Ast4_t*)p)->cur;
 	unsigned char*	b = (unsigned char*)s;
 	unsigned char*	e = b + n;
-	int		c;
+	unsigned int	c;
 
 	while (b < e)
 	{

--- a/src/lib/libsum/sum-crc.c
+++ b/src/lib/libsum/sum-crc.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1996-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -119,8 +119,9 @@ crc_open(const Method_t* method, const char* name)
 	const char*	s;
 	const char*	t;
 	const char*	v;
-	int		i;
+	size_t		i;
 	int		j;
+	ptrdiff_t	k;
 	Crcnum_t	polynomial;
 	Crcnum_t	x;
 
@@ -150,20 +151,20 @@ crc_open(const Method_t* method, const char* name)
 		for (t = s, v = 0; *s && *s != '-'; s++)
 			if (*s == '=' && !v)
 				v = s;
-		i = (v ? v : s) - t;
-		if (isdigit(*t) || v && i >= 4 && strneq(t, "poly", 4) && (t = v + 1))
-			polynomial = strtoul(t, NULL, 0);
-		else if (strneq(t, "done", i))
-			sum->done = v ? strtoul(v + 1, NULL, 0) : ~sum->done;
-		else if (strneq(t, "init", i))
-			sum->init = v ? strtoul(v + 1, NULL, 0) : ~sum->init;
-		else if (strneq(t, "rotate", i))
+		k = (v ? v : s) - t;
+		if (isdigit(*t) || v && k >= 4 && strneq(t, "poly", 4) && (t = v + 1))
+			polynomial = (Crcnum_t)strtoul(t, NULL, 0);
+		else if (strneq(t, "done", (size_t)k))
+			sum->done = v ? (Crcnum_t)strtoul(v + 1, NULL, 0) : ~sum->done;
+		else if (strneq(t, "init", (size_t)k))
+			sum->init = v ? (Crcnum_t)strtoul(v + 1, NULL, 0) : ~sum->init;
+		else if (strneq(t, "rotate", (size_t)k))
 			sum->rotate = 1;
-		else if (strneq(t, "size", i))
+		else if (strneq(t, "size", (size_t)k))
 		{
 			sum->addsize = 1;
 			if (v)
-				sum->xorsize = strtoul(v + 1, NULL, 0);
+				sum->xorsize = (Crcnum_t)strtoul(v + 1, NULL, 0);
 		}
 		if (*s == '-')
 			s++;
@@ -179,7 +180,7 @@ crc_open(const Method_t* method, const char* name)
 		for (i = 0; i < elementsof(sum->tabdata); i++)
 		{
 			t = 0;
-			x = i;
+			x = (Crcnum_t)i;
 			for (j = 0; j < 8; j++)
 			{
 				if (x & 1)
@@ -193,7 +194,7 @@ crc_open(const Method_t* method, const char* name)
 	{
 		for (i = 0; i < elementsof(sum->tabdata); i++)
 		{
-			x = i;
+			x = (Crcnum_t)i;
 			for (j = 0; j < 8; j++)
 				x = (x>>1) ^ ((x & 1) ? polynomial : 0);
 			sum->tabdata[i] = x;

--- a/src/lib/libsum/sum-lmd.c
+++ b/src/lib/libsum/sum-lmd.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1996-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2023 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -65,7 +65,7 @@ static int
 lmd_done(Sum_t* p)
 {
 	Lmd_t*	lmd = (Lmd_t*)p;
-	int	i;
+	unsigned int	i;
 
 	(*lmd->finalf)(lmd->data, &lmd->context);
 	for (i = 0; i < lmd->datasize; i++)
@@ -78,7 +78,7 @@ lmd_print(Sum_t* p, Sfio_t* sp, int flags, size_t scale)
 {
 	Lmd_t*		lmd = (Lmd_t*)p;
 	unsigned char*	d;
-	int		i;
+	unsigned int	i;
 
 	d = (flags & SUM_TOTAL) ? lmd->total : lmd->data;
 	for (i = 0; i < lmd->datasize; i++)

--- a/src/lib/libsum/sum-md5.c
+++ b/src/lib/libsum/sum-md5.c
@@ -334,7 +334,7 @@ md5_print(Sum_t* p, Sfio_t* sp, int flags, size_t scale)
 {
 	Md5_t*		x = (Md5_t*)p;
 	unsigned char*	d;
-	int		n;
+	size_t		n;
 
 	NOT_USED(scale);
 	d = (flags & SUM_TOTAL) ? x->digest_sum : x->digest;

--- a/src/lib/libsum/sum-prng.c
+++ b/src/lib/libsum/sum-prng.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1996-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2023 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -12,6 +12,7 @@
 *                                                                      *
 *                 Glenn Fowler <gsf@research.att.com>                  *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 
@@ -53,7 +54,7 @@ prng_open(const Method_t* method, const char* name)
 	const char*	s;
 	const char*	t;
 	const char*	v;
-	int		i;
+	ptrdiff_t	i;
 
 	if (sum = newof(0, Prng_t, 1, 0))
 	{
@@ -67,12 +68,12 @@ prng_open(const Method_t* method, const char* name)
 			if (*s == '=' && !v)
 				v = s;
 		i = (v ? v : s) - t;
-		if (isdigit(*t) || v && strneq(t, "mpy", i) && (t = v + 1))
-			sum->mpy = strtoul(t, NULL, 0);
-		else if (strneq(t, "add", i))
-			sum->add = v ? strtoul(v + 1, NULL, 0) : ~sum->add;
-		else if (strneq(t, "init", i))
-			sum->init = v ? strtoul(v + 1, NULL, 0) : ~sum->init;
+		if (isdigit(*t) || v && strneq(t, "mpy", (size_t)i) && (t = v + 1))
+			sum->mpy = (Prngnum_t)strtoul(t, NULL, 0);
+		else if (strneq(t, "add", (size_t)i))
+			sum->add = v ? (Prngnum_t)strtoul(v + 1, NULL, 0) : ~sum->add;
+		else if (strneq(t, "init", (size_t)i))
+			sum->init = v ? (Prngnum_t)strtoul(v + 1, NULL, 0) : ~sum->init;
 		if (*s == '-')
 			s++;
 	}

--- a/src/lib/libsum/sum-sha1.c
+++ b/src/lib/libsum/sum-sha1.c
@@ -208,7 +208,7 @@ sha1_block(Sum_t* p, const void* s, size_t len)
 {
 	Sha1_t*		sha = (Sha1_t*)p;
 	uint8_t*	data = (uint8_t*)s;
-	unsigned int	i, j;
+	size_t		i, j;
 
 	if (len) {
 		j = sha->count[0];
@@ -302,7 +302,7 @@ sha1_print(Sum_t* p, Sfio_t* sp, int flags, size_t scale)
 {
 	Sha1_t*	sha = (Sha1_t*)p;
 	unsigned char*	d;
-	int		n;
+	size_t		n;
 
 	NOT_USED(scale);
 	d = (flags & SUM_TOTAL) ? sha->digest_sum : sha->digest;

--- a/src/lib/libsum/sum-sha2.c
+++ b/src/lib/libsum/sum-sha2.c
@@ -96,7 +96,7 @@ typedef uint64_t sha2_word64;	/* Exactly 8 bytes */
 #define REVERSE32(w,x)	{ \
 	sha2_word32 tmp = (w); \
 	tmp = (tmp >> 16) | (tmp << 16); \
-	(x) = ((tmp & 0xff00ff00UL) >> 8) | ((tmp & 0x00ff00ffUL) << 8); \
+	(x) = ((sha2_word32)(((tmp & 0xff00ff00UL) >> 8) | ((tmp & 0x00ff00ffUL) << 8))); \
 }
 #if _ast_LL
 #define REVERSE64(w,x)	{ \

--- a/src/lib/libsum/sumlib.c
+++ b/src/lib/libsum/sumlib.c
@@ -357,7 +357,7 @@ int
 sumusage(Sfio_t* sp)
 {
 	size_t	i;
-	int	n = 0;
+	ssize_t	n = 0;
 
 	for (i = 0; i < elementsof(methods); i++)
 	{
@@ -367,5 +367,5 @@ sumusage(Sfio_t* sp)
 	}
 	for (i = 0; i < elementsof(maps); i++)
 		n += sfprintf(sp, "[+%s?%s Shorthand for \b%s\b.]", maps[i].match, maps[i].description, maps[i].map);
-	return n;
+	return (int)n;
 }

--- a/src/lib/libsum/sumlib.c
+++ b/src/lib/libsum/sumlib.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1996-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2024 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -122,7 +122,7 @@ long_print(Sum_t* p, Sfio_t* sp, int flags, size_t scale)
 	if (flags & SUM_SIZE)
 	{
 		z = (flags & SUM_TOTAL) ? x->total_size : x->size;
-		if ((flags & SUM_SCALE) && ((n = scale) || (n = x->method->scale)))
+		if ((flags & SUM_SCALE) && ((n = scale) || (n = (size_t)x->method->scale)))
 			z = SCALE(z, n);
 		sfprintf(sp, " %*I*u", (flags & SUM_LEGACY) ? 6 : 0, sizeof(z), z);
 	}
@@ -258,7 +258,7 @@ match(const char* s, const char* p)
 		}
 		s = b;
 	}
-	return 0;
+	UNREACHABLE();
 }
 
 /*
@@ -268,7 +268,7 @@ match(const char* s, const char* p)
 Sum_t*
 sumopen(const char* name)
 {
-	int	n;
+	size_t	n;
 
 	if (!name || !name[0] || name[0] == '-' && !name[1])
 		name = "default";
@@ -356,10 +356,10 @@ sumclose(Sum_t* p)
 int
 sumusage(Sfio_t* sp)
 {
-	int	i;
-	int	n;
+	size_t	i;
+	int	n = 0;
 
-	for (i = n = 0; i < elementsof(methods); i++)
+	for (i = 0; i < elementsof(methods); i++)
 	{
 		n += sfprintf(sp, "[+%s?%s]", methods[i].match, methods[i].description);
 		if (methods[i].options)


### PR DESCRIPTION
This is the eight of the thickfold patch series, which enables ksh93 to operate within a 64-bit address space.

The parts of ksh93 affected by this commit are:
- The entirety of the libdll library.
- The entirety of the libsum library.
  - `match()`: Added an `UNREACHABLE()` to fix a `-Wunreachable-code-return` warning.
- The pty test utility.
- The mamake build program.

Change in the number of warnings on Linux when compiling with clang using `-Wsign-compare -Wshorten-64-to-32 -Wsign-conversion -Wimplicit-int-conversion`: 1,188 => 1,032 => 37 (progression from part 7 => part 8 => part 13)

Progresses https://github.com/ksh93/ksh/issues/592