### PR TITLE
64-bit transition part 9: ksh93 command line editors

### DIFF
--- a/src/cmd/ksh93/edit/completion.c
+++ b/src/cmd/ksh93/edit/completion.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1982-2012 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2025 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -39,7 +39,7 @@ static char *fmtx(const char *string)
 	int	 	n = 0, c;
 	int		pos = 0;
 	unsigned char 	*state = (unsigned char*)sh_lexstates[ST_NORM];
-	int		offset = stktell(sh.stk);
+	ptrdiff_t	offset = stktell(sh.stk);
 	char		hc[3];
 #if SHOPT_HISTEXPAND
 	const char	hexp = sh_isoption(SH_HISTEXPAND)!=0;
@@ -55,17 +55,18 @@ static char *fmtx(const char *string)
 		;
 	if(n==S_EOF && *string!='#')
 		return (char*)string;
-	sfwrite(sh.stk,string,--cp-string);
+	sfwrite(sh.stk,string,(size_t)(--cp-string));
 	for(string=cp;c=mbchar(cp);string=cp)
 	{
-		if((n=cp-string)==1)
+		ptrdiff_t diff = cp-string;
+		if(diff==1)
 		{
 			if(((n=state[c]) && n!=S_EPAT) || (hexp && ((c==hc[0]) || (c==hc[2] && !pos))))
 				sfputc(sh.stk,'\\');
 			sfputc(sh.stk,c);
 		}
 		else
-			sfwrite(sh.stk,string,n);
+			sfwrite(sh.stk,string,(size_t)diff);
 		pos++;
 	}
 	sfputc(sh.stk,0);
@@ -81,16 +82,10 @@ static int charcmp(int a, int b, int nocase)
 	{
 #if _lib_towlower
 		if(mbwide())
-		{
-			a = (int)towlower((wint_t)a);
-			b = (int)towlower((wint_t)b);
-		}
+			return towlower((wint_t)a)==towlower((wint_t)b);
 		else
 #endif
-		{
-			a = tolower(a);
-			b = tolower(b);
-		}
+			return tolower(a)==tolower(b);
 	}
 	return a==b;
 }
@@ -138,7 +133,7 @@ static char *find_begin(char outbuff[], char *last, int endchar, int *type)
 		    case '\'': case '"':
 			if(!inquote)
 			{
-				inquote = c;
+				inquote = (char)c;
 				bp = xp;
 				break;
 			}
@@ -328,7 +323,7 @@ int ed_expand(Edit_t *ep, char outbuff[],int *cur,int *eol,int mode, int count)
 		{
 			/* expand ${!varname@} to complete variable name(s) */
 			sfputr(sh.stk,"${!",-1);
-			sfwrite(sh.stk,out,last-out);
+			sfwrite(sh.stk,out,(size_t)(last-out));
 			sfputr(sh.stk,"@}",-1);
 			out = last;
 		}
@@ -370,10 +365,11 @@ int ed_expand(Edit_t *ep, char outbuff[],int *cur,int *eol,int mode, int count)
 	if(mode!='*')
 		sh_onoption(SH_MARKDIRS);
 	{
-		char	**com;
-		char	*cp=begin, *left=0, *saveout=(char*)e_dot;
-		int	nocase=0, narg, cmd_completion=0;
-		int	size='x';
+		char		**com;
+		char		*cp=begin, *left=0, *saveout=(char*)e_dot;
+		int		nocase=0, narg, cmd_completion=0;
+		int		size='x';
+		ptrdiff_t	sz;
 		while(cp>outbuff && ((size=cp[-1])==' ' || size=='\t'))
 			cp--;
 		if(!var && !strchr(ap->argval,'/') && (((cp==outbuff&&sh.nextprompt==1) || (strchr(";&|(",size)) && (cp==outbuff+1||size=='('||cp[-2]!='>') && *begin!='~' )))
@@ -434,7 +430,7 @@ int ed_expand(Edit_t *ep, char outbuff[],int *cur,int *eol,int mode, int count)
 			goto done;
 		}
 		/* see if there is enough room */
-		size = *eol - (out-begin);
+		sz = *eol - (out-begin);
 		if(mode=='\\')
 		{
 			int c;
@@ -449,22 +445,22 @@ int ed_expand(Edit_t *ep, char outbuff[],int *cur,int *eol,int mode, int count)
 				nocase = (pathicase(saveout) > 0);
 #endif
 			if(dir)
-				*dir = c;
+				*dir = (char)c;
 			/* just expand until name is unique */
-			size += strlen(*com);
+			sz += (ptrdiff_t)strlen(*com);
 		}
 		else
 		{
-			size += narg;
+			sz += narg;
 			{
 				char **savcom = com;
 				while (*com)
-					size += strlen(cp=fmtx(*com++));
+					sz += (ptrdiff_t)strlen(cp=fmtx(*com++));
 				com = savcom;
 			}
 		}
 		/* see if room for expansion */
-		if(outbuff+size >= &outbuff[MAXLINE])
+		if(outbuff+sz >= &outbuff[MAXLINE])
 		{
 			com[0] = ap->argval;
 			com[1] = 0;
@@ -481,7 +477,7 @@ int ed_expand(Edit_t *ep, char outbuff[],int *cur,int *eol,int mode, int count)
 				if(*cp==var)
 					cp++;
 				else
-					*begin++ = var;
+					*begin++ = (char)var;
 				out = strcopy(begin,cp);
 				var = 0;
 			}
@@ -555,11 +551,11 @@ int ed_expand(Edit_t *ep, char outbuff[],int *cur,int *eol,int mode, int count)
 				out--;
 			*out = 0;
 		}
-		*cur = (out-outbuff);
+		*cur = (int)(out-outbuff);
 		/* restore rest of buffer */
 		if(left)
 			out = strcopy(out,left);
-		*eol = (out-outbuff);
+		*eol = (int)(out-outbuff);
 	}
  done:
 	sh_offstate(SH_FCOMPLETE);
@@ -570,7 +566,8 @@ int ed_expand(Edit_t *ep, char outbuff[],int *cur,int *eol,int mode, int count)
 		sh_offoption(SH_MARKDIRS);
 #if SHOPT_MULTIBYTE
 	{
-		int c,n=0;
+		char c;
+		int n=0;
 		/* first re-adjust cur */
 		c = outbuff[*cur];
 		outbuff[*cur] = 0;
@@ -596,17 +593,17 @@ int ed_macro(Edit_t *ep, int i)
 	Namval_t *np;
 	genchar buff[LOOKAHEAD+1];
 	if(i != '@')
-		ep->e_macro[1] = i;
+		ep->e_macro[1] = (char)i;
 	/* macros of the form <ESC>[c evoke alias __c */
 	if(i=='_')
-		ep->e_macro[2] = i = ed_getchar(ep,1);
+		ep->e_macro[2] = (char)(i = ed_getchar(ep,1));
 	else
 		ep->e_macro[2] = 0;
 	if (isalnum(i)&&(np=nv_search(ep->e_macro,sh.alias_tree,0))&&(out=nv_getval(np)))
 	{
-#if SHOPT_MULTIBYTE
 		/* copy to buff in internal representation */
-		int c = 0;
+#if SHOPT_MULTIBYTE
+		char c = 0;
 		if( strlen(out) > LOOKAHEAD )
 		{
 			c = out[LOOKAHEAD];
@@ -615,13 +612,16 @@ int ed_macro(Edit_t *ep, int i)
 		i = ed_internal(out,buff);
 		if(c)
 			out[LOOKAHEAD] = c;
-#else
-		strncpy((char*)buff,out,LOOKAHEAD);
-		buff[LOOKAHEAD] = 0;
-		i = strlen((char*)buff);
-#endif /* SHOPT_MULTIBYTE */
 		while(i-- > 0)
 			ed_ungetchar(ep,buff[i]);
+#else
+		size_t len;
+		strncpy((char*)buff,out,LOOKAHEAD);
+		buff[LOOKAHEAD] = 0;
+		len = strlen((char*)buff);
+		while(len-- > 0)
+			ed_ungetchar(ep,buff[len]);
+#endif /* SHOPT_MULTIBYTE */
 		return 1;
 	}
 	return 0;
@@ -645,16 +645,16 @@ int ed_fulledit(Edit_t *ep)
 		ep->e_inbuf[ep->e_eol+1] = 0;
 		ed_external(ep->e_inbuf, (char *)ep->e_inbuf);
 #endif /* SHOPT_MULTIBYTE */
-		sfwrite(sh.hist_ptr->histfp,(char*)ep->e_inbuf,ep->e_eol+1);
+		sfwrite(sh.hist_ptr->histfp,(char*)ep->e_inbuf,(size_t)ep->e_eol+1);
 		sh_onstate(SH_HISTORY);
 		hist_flush(sh.hist_ptr);
 	}
 	cp = strcopy((char*)ep->e_inbuf,e_runvi);
 	cp = strcopy(cp, fmtint(ep->e_hline,1));
 #if SHOPT_VSH
-	ep->e_eol = ((unsigned char*)cp - (unsigned char*)ep->e_inbuf)-(sh_isoption(SH_VI)!=0);
+	ep->e_eol = (int)(((unsigned char*)cp - (unsigned char*)ep->e_inbuf)-(sh_isoption(SH_VI)!=0));
 #else
-	ep->e_eol = ((unsigned char*)cp - (unsigned char*)ep->e_inbuf);
+	ep->e_eol = (int)((unsigned char*)cp - (unsigned char*)ep->e_inbuf);
 #endif
 	return 0;
 }

--- a/src/cmd/ksh93/edit/edit.c
+++ b/src/cmd/ksh93/edit/edit.c
@@ -189,15 +189,15 @@ int tty_raw(int fd, int echomode)
 		echo = 0;
 	}
 #ifdef FLUSHO
-	ttyparm.c_lflag &= ~FLUSHO;
+	ttyparm.c_lflag &= (tcflag_t)~FLUSHO;
 #endif /* FLUSHO */
 	nttyparm = ttyparm;
-	nttyparm.c_iflag &= ~(IGNPAR|PARMRK|INLCR|IGNCR|ICRNL);
+	nttyparm.c_iflag &= (tcflag_t)~(IGNPAR|PARMRK|INLCR|IGNCR|ICRNL);
 	nttyparm.c_iflag |= BRKINT;
 	if(echo)
-		nttyparm.c_lflag &= ~(ICANON);
+		nttyparm.c_lflag &= (tcflag_t)~(ICANON);
 	else
-		nttyparm.c_lflag &= ~(ICANON|ISIG|ECHO|ECHOK);
+		nttyparm.c_lflag &= (tcflag_t)~(ICANON|ISIG|ECHO|ECHOK);
 	nttyparm.c_cc[VTIME] = 0;
 	nttyparm.c_cc[VMIN] = 1;
 #ifdef VREPRINT
@@ -263,11 +263,11 @@ int ed_window(void)
 
 void ed_flush(Edit_t *ep)
 {
-	int n = ep->e_outptr-ep->e_outbase;
+	ptrdiff_t n = ep->e_outptr-ep->e_outbase;
 	int fd = ERRIO;
 	if(n<=0)
 		return;
-	write(fd,ep->e_outbase,(unsigned)n);
+	write(fd,ep->e_outbase,(size_t)n);
 	ep->e_outptr = ep->e_outbase;
 }
 
@@ -413,7 +413,7 @@ void	ed_setup(Edit_t *ep, int fd, int reedit)
 				for(n=1; c = *last++; n++)
 				{
 					if(pp < ppmax)
-						*pp++ = c;
+						*pp++ = (char)c;
 					if(c=='\a' || c==ESC || c=='\r')
 						break;
 					if(skip || (c>='0' && c<='9'))
@@ -476,7 +476,7 @@ void	ed_setup(Edit_t *ep, int fd, int reedit)
 						qlen++;
 					else if(!is_print(c))
 						ep->e_crlf = 0;
-					if((qwid = last - prev) > 1)
+					if((qwid = (int)(last - prev)) > 1)
 						qlen += qwid - mbwidth(c);
 					while(prev < last && pp < ppmax)
 						*pp++ = *prev++;
@@ -485,7 +485,7 @@ void	ed_setup(Edit_t *ep, int fd, int reedit)
 		}
 	}
 	if(pp-ep->e_prompt > qlen)
-		ep->e_plen = pp - ep->e_prompt - qlen;
+		ep->e_plen = (int)(pp - ep->e_prompt - qlen);
 	*pp = 0;
 	if(ep->e_multiline)
 	{
@@ -548,7 +548,7 @@ void	ed_setup(Edit_t *ep, int fd, int reedit)
 		n = strlen(pp);
 		if(n > LOOKAHEAD)
 			n = LOOKAHEAD;
-		ep->e_lookahead = n;
+		ep->e_lookahead = (int)n;
 		while(n-- > 0)
 			ep->e_lbuf[n] = *pp++;
 		ep->e_default = 0;
@@ -618,7 +618,7 @@ int ed_read(void *context, int fd, char *buff, int size, int reedit)
 		 */
 		if(sh.winch && sh_editor_active() && sh_isstate(SH_INTERACTIVE))
 		{
-			int	n;
+			ssize_t n;
 			if(!ep->e_prompt)
 			{
 				/* ed_emacsread or ed_viread was unable to put the tty in raw mode */
@@ -676,7 +676,7 @@ int ed_read(void *context, int fd, char *buff, int size, int reedit)
 		/* an interrupt that should be ignored */
 		errno = 0;
 		if(!waitevent || (rv=(*waitevent)(fd,-1L,0))>=0)
-			rv = sfpkrd(fd,buff,size,delim,-1L,mode);
+			rv = (int)sfpkrd(fd,buff,(size_t)size,delim,-1L,mode);
 	}
 	if(rv < 0)
 	{
@@ -704,7 +704,7 @@ int ed_read(void *context, int fd, char *buff, int size, int reedit)
 #endif /* _hdr_utime */
 		while(1)
 		{
-			rv = read(fd,buff,size);
+			rv = (int)read(fd,buff,(size_t)size);
 			if(rv>=0 || errno!=EINTR)
 				break;
 			if(sh.trapnote&(SH_SIGSET|SH_SIGTRAP))
@@ -714,7 +714,7 @@ int ed_read(void *context, int fd, char *buff, int size, int reedit)
 		}
 	}
 	else if(rv>=0 && mode>0)
-		rv = read(fd,buff,rv>0?rv:1);
+		rv = (int)read(fd,buff,rv>0?(size_t)rv:1);
 done:
 	sh.waitevent = waitevent;
 	sh_offstate(SH_TTYWAIT);
@@ -733,7 +733,8 @@ static int putstack(Edit_t *ep,char string[], int nbyte, int type)
 	int c;
 #if SHOPT_MULTIBYTE
 	char *endp, *p=string;
-	int size, offset = ep->e_lookahead + nbyte;
+	ssize_t size;
+	ssize_t offset = ep->e_lookahead + nbyte;
 	*(endp = &p[nbyte]) = 0;
 	endp = &p[nbyte];
 	do
@@ -764,7 +765,7 @@ static int putstack(Edit_t *ep,char string[], int nbyte, int type)
 				if(type)
 					c = -c;
 			}
-			else if((endp-p) < mbmax())
+			else if((endp-p) < (int)mbmax())
 			{
 				if(errno == EILSEQ)
 					errno = 0;
@@ -854,7 +855,7 @@ int ed_getchar(Edit_t *ep,int mode)
 					{
 						if(!ep->e_lookahead)
 						{
-							if((c=sfpkrd(ep->e_fd,readin+n,1,'\r',(mode?400L:-1L),0))>0)
+							if((c=(int)sfpkrd(ep->e_fd,readin+n,1,'\r',(mode?400L:-1L),0))>0)
 								putstack(ep,readin+n,c,1);
 						}
 						if(!ep->e_lookahead)
@@ -865,7 +866,7 @@ int ed_getchar(Edit_t *ep,int mode)
 							break;
 						}
 						c = -c;
-						readin[n++] = c;
+						readin[n++] = (char)c;
 						if(c>='0' && c<='9' && n>2)
 							continue;
 						if(n>2 || (c!= '['  &&  c!= 'O'))
@@ -919,7 +920,7 @@ void		ed_putchar(Edit_t *ep,int c)
 	char *dp = ep->e_outptr;
 	if(!dp)
 		return;
-	*dp++ = c;
+	*dp++ = (char)c;
 	*dp = '\0';
 	if(dp >= ep->e_outlast)
 		ed_flush(ep);
@@ -993,7 +994,7 @@ Edpos_t ed_curpos(Edit_t *ep,genchar *phys, int off, int cur, Edpos_t curpos)
 		if(col==0)
 			pos.line++;
 	}
-	pos.col = col;
+	pos.col = (unsigned short)col;
 	return pos;
 }
 #endif /* SHOPT_ESH || SHOPT_VSH */
@@ -1048,7 +1049,7 @@ int ed_setcursor(Edit_t *ep,genchar *physical,int old,int new,int first)
 					int m = ep->e_winsz+1-plen;
 					ed_putchar(ep,'\n');
 					n = plen;
-					if(m < genlen(physical))
+					if(m < (int)genlen(physical))
 					{
 						while(physical[m] && n-->0)
 							ed_putchar(ep,physical[m++]);
@@ -1117,7 +1118,7 @@ int ed_virt_to_phys(Edit_t *ep,genchar *virt,genchar *phys,int cur,int voff,int 
 	for(r=poff;c= *sp;sp++)
 	{
 		if(curp == sp)
-			r = dp - phys;
+			r = (int)(dp - phys);
 #if SHOPT_MULTIBYTE
 		d = mbwidth((wchar_t)c);
 		if(d==1 && is_cntrl(c))
@@ -1141,7 +1142,7 @@ int ed_virt_to_phys(Edit_t *ep,genchar *virt,genchar *phys,int cur,int voff,int 
 		{
 			if(c=='\t')
 			{
-				c = dp-phys;
+				c = (int)(dp - phys);
 				c += ep->e_plen;
 				c = TABSIZE - c%TABSIZE;
 				while(--c>0)
@@ -1154,14 +1155,14 @@ int ed_virt_to_phys(Edit_t *ep,genchar *virt,genchar *phys,int cur,int voff,int 
 				c = printchar(c);
 			}
 			if(curp == sp)
-				r = dp - phys;
+				r = (int)(dp - phys);
 		}
-		*dp++ = c;
+		*dp++ = (genchar)c;
 		if(dp>=dpmax)
 			break;
 	}
 	*dp = 0;
-	ep->e_peol = dp-phys;
+	ep->e_peol = (int)(dp - phys);
 	return r;
 }
 #endif /* SHOPT_ESH || SHOPT_VSH */
@@ -1188,7 +1189,7 @@ int	ed_internal(const char *src, genchar *dest)
 	while(*cp)
 		*dp++ = mbchar(cp);
 	*dp = 0;
-	return dp - (wchar_t*)dest;
+	return (int)(dp - (wchar_t*)dest);
 }
 #endif /* (SHOPT_ESH || SHOPT_VSH) && SHOPT_MULTIBYTE */
 
@@ -1224,12 +1225,12 @@ int	ed_external(const genchar *src, char *dest)
 		{
 			/* copy the character as is */
 			size = 1;
-			*dp = wc;
+			*dp = (char)wc;
 		}
 		dp += size;
 	}
 	*dp = 0;
-	return dp-dest;
+	return (int)(dp-dest);
 }
 #endif /* SHOPT_MULTIBYTE */
 
@@ -1251,11 +1252,11 @@ void	ed_gencpy(genchar *dp,const genchar *sp)
  * copy at most <n> items from <sp> to <dp>
  */
 
-void	ed_genncpy(genchar *dp,const genchar *sp, int n)
+void	ed_genncpy(genchar *dp,const genchar *sp, size_t n)
 {
 	dp = (genchar*)roundof((uintptr_t)dp,sizeof(genchar));
 	sp = (const genchar*)roundof((uintptr_t)sp,sizeof(genchar));
-	while(n-->0 && (*dp++ = *sp++));
+	while(n>0 && (*dp++ = *sp++) && --n);
 }
 #endif /* (SHOPT_ESH || SHOPT_VSH) && SHOPT_MULTIBYTE */
 
@@ -1264,12 +1265,12 @@ void	ed_genncpy(genchar *dp,const genchar *sp, int n)
  * find the string length of <str>
  */
 
-int	ed_genlen(const genchar *str)
+size_t	ed_genlen(const genchar *str)
 {
 	const genchar *sp = str;
 	sp = (const genchar*)roundof((uintptr_t)sp,sizeof(genchar));
 	while(*sp++);
-	return sp-str-1;
+	return (size_t)(sp-str-1);
 }
 #endif /* (SHOPT_ESH || SHOPT_VSH) && SHOPT_MULTIBYTE */
 
@@ -1310,9 +1311,9 @@ static int keytrap(Edit_t *ep,char *inbuff,int insize, int bufsize, int mode)
 		nv_unset(ED_CHRNOD,0);
 	else if(bufsize>0)
 	{
-		strncopy(inbuff,cp,bufsize);
+		strncopy(inbuff,cp,(size_t)bufsize);
 		inbuff[bufsize-1]='\0';
-		insize = strlen(inbuff);
+		insize = (int)strlen(inbuff);
 	}
 	else
 		insize = 0;

--- a/src/cmd/ksh93/edit/emacs.c
+++ b/src/cmd/ksh93/edit/emacs.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1982-2012 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2025 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -256,7 +256,7 @@ int ed_emacsread(void *context, int fd,char *buff,int scend, int reedit)
 			{
 				/* accept a backslashed character */
 				cur--;
-				out[cur++] = c;
+				out[cur++] = (genchar)c;
 				out[eol] = '\0';
 				draw(ep,APPEND);
 				continue;
@@ -339,11 +339,11 @@ int ed_emacsread(void *context, int fd,char *buff,int scend, int reedit)
 				out[i] = out[i - count];
 			backslash = (c == '\\' && !sh_isoption(SH_NOBACKSLCTRL) && count==1);
 			for (i = 0; i < count; i++)
-				out[cur++] = c;
+				out[cur++] = (genchar)c;
 			draw(ep, count > 1 ? UPDATE : APPEND);
 			continue;
 		case cntl('Y') :
-			c = count * genlen(kstack);
+			c = count * (int)genlen(kstack);
 			if (c + eol > scend)
 			{
 				beep();
@@ -356,10 +356,10 @@ int ed_emacsread(void *context, int fd,char *buff,int scend, int reedit)
 			{
 				kptr=kstack;
 				while (i = *kptr++)
-					out[cur++] = i;
+					out[cur++] = (genchar)i;
 			}
 			draw(ep,UPDATE);
-			eol = genlen(out);
+			eol = (int)genlen(out);
 			continue;
 		case '\n':
 		case '\r':
@@ -374,7 +374,7 @@ int ed_emacsread(void *context, int fd,char *buff,int scend, int reedit)
 			kptr = &kstack[count];	/* move old contents here */
 			if (killing)		/* prepend to killbuf */
 			{
-				c = genlen(kstack) + CHARSIZE; /* include '\0' */
+				c = (int)(genlen(kstack) + CHARSIZE); /* include '\0' */
 				while(c--)	/* copy stuff */
 					kptr[c] = kstack[c];
 			}
@@ -383,7 +383,7 @@ int ed_emacsread(void *context, int fd,char *buff,int scend, int reedit)
 			killing = 2;		/* we are killing */
 			i -= count;
 			eol -= count;
-			genncpy(kstack,out+i,cur-i);
+			genncpy(kstack,out+i,(size_t)(cur-i));
 			gencpy(out+i,out+cur);
 			ep->mark = i;
 			goto update;
@@ -439,7 +439,7 @@ int ed_emacsread(void *context, int fd,char *buff,int scend, int reedit)
 #endif /* SHOPT_MULTIBYTE */
 					{
 						c += 'A' - 'a';
-						out[i] = c;
+						out[i] = (genchar)c;
 					}
 				}
 				i++;
@@ -486,7 +486,7 @@ update:
 			{
 				c = out[i - 1];
 				out[i-1] = out[i-2];
-				out[i-2] = c;
+				out[i-2] = (genchar)c;
 			}
 			else
 			{
@@ -588,7 +588,7 @@ update:
 			ed_internal((char*)(out),out);
 #endif /* SHOPT_MULTIBYTE */
 		drawline:
-			eol = genlen(out);
+			eol = (int)genlen(out);
 			cur = eol;
 			draw(ep,UPDATE);
 			/* skip blank lines when going up/down in history */
@@ -727,7 +727,7 @@ static int escape(Emacs_t* ep,genchar *out,int count)
 #endif /* SHOPT_MULTIBYTE */
 					{
 						i += 'a' - 'A';
-						out[cur] = i;
+						out[cur] = (genchar)i;
 					}
 					cur++;
 				}
@@ -817,7 +817,7 @@ static int escape(Emacs_t* ep,genchar *out,int count)
 				beep();
 				break;
 			}
-			if ((eol - cur) >= sizeof(name))
+			if ((eol - cur) >= (ssize_t)sizeof(name))
 			{
 				beep();
 				return -1;
@@ -1141,7 +1141,7 @@ static void xcommands(Emacs_t *ep,int count)
 			if(hline == histlines && sh.hist_ptr)
 			{
 				hist_eof(sh.hist_ptr);
-				histlines = (int)sh.hist_ptr->histind;
+				histlines = sh.hist_ptr->histind;
 				hline = histlines;
 				if(histlines >= sh.hist_ptr->histsize)
 					hist_flush(sh.hist_ptr);
@@ -1324,13 +1324,13 @@ static void search(Emacs_t* ep,genchar *out,int direction)
 					string[--sl] = '\0';
 			}
 		}
-		string[sl++] = i;
+		string[sl++] = (genchar)i;
 		string[sl] = '\0';
 		cur = sl;
 		draw(ep,APPEND);
 	}
 	skip:
-	i = genlen(string);
+	i = (int)genlen(string);
 	if(backwards_search)
 		ep->prevdirection = -2;
 	if(ep->prevdirection == -2 && i!=4 || direction!=1)
@@ -1402,7 +1402,7 @@ static void draw(Emacs_t *ep,Draw_t option)
 	sptr = drawbuff;
 	logcursor = sptr + cur;
 	longline = NORMAL;
-	ep->lastdraw = option;
+	ep->lastdraw = (char)option;
 
 	if (option == FIRST || option == REFRESH)
 	{
@@ -1445,7 +1445,7 @@ static void draw(Emacs_t *ep,Draw_t option)
 	    print(i)&&((ep->cursor-ep->screen)<(w_size-1)))
 	{
 		putchar(ep->ed,i);
-		*ep->cursor++ = i;
+		*ep->cursor++ = (genchar)i;
 		*ep->cursor = '\0';
 		return;
 	}
@@ -1463,7 +1463,7 @@ static void draw(Emacs_t *ep,Draw_t option)
 	 If not, adjust the screen offset so it does.
 	**********************/
 
-	i = ncursor - nscreen;
+	i = (int)(ncursor - nscreen);
 	if ((ep->offset && i<=ep->offset)||(i >= (ep->offset+w_size)))
 	{
 		/* Center the cursor on the screen */
@@ -1499,7 +1499,7 @@ static void draw(Emacs_t *ep,Draw_t option)
 			sptr++;
 			continue;
 		}
-		setcursor(ep,sptr-ep->screen,*nptr);
+		setcursor(ep,(int)(sptr-ep->screen),*nptr);
 		*sptr++ = *nptr++;
 #if SHOPT_MULTIBYTE
 		while(*nptr==MARKER)
@@ -1541,10 +1541,10 @@ static void draw(Emacs_t *ep,Draw_t option)
 		setcursor(ep,w_size,longline);
 		ep->overflow = longline;
 	}
-	i = (ncursor-nscreen) - ep->offset;
+	i = (int)((ncursor-nscreen) - ep->offset);
 	setcursor(ep,i,0);
 	if(option==FINAL && ep->ed->e_multiline)
-		setcursor(ep,nscend+1-nscreen,0);
+		setcursor(ep,(int)(nscend+1-nscreen),0);
 	ep->scvalid = 1;
 	return;
 }
@@ -1569,7 +1569,7 @@ void emacs_redraw(void *vp)
 
 static void setcursor(Emacs_t *ep,int newp,int c)
 {
-	int oldp = ep->cursor - ep->screen;
+	int oldp = (int)(ep->cursor - ep->screen);
 	newp  = ed_setcursor(ep->ed, ep->screen, oldp, newp, 0);
 	if(c)
 	{
@@ -1602,7 +1602,7 @@ static int blankline(Emacs_t *ep, genchar *out, int uptocursor)
 	for(x=0; uptocursor ? (x < cur) : (x <= eol); x++)
 	{
 #if SHOPT_MULTIBYTE
-		if(!iswspace((wchar_t)out[x]))
+		if(!iswspace((wint_t)out[x]))
 #else
 		if(!isspace(out[x]))
 #endif /* SHOPT_MULTIBYTE */

--- a/src/cmd/ksh93/edit/hexpand.c
+++ b/src/cmd/ksh93/edit/hexpand.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1982-2011 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2025 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -61,8 +61,9 @@ struct subst
 
 static char *parse_subst(const char *s, struct subst *sb)
 {
-	char	*cp,del;
-	int	off,n = 0;
+	char		*cp,del;
+	ptrdiff_t	off;
+	int		n = 0;
 
 	/* build the strings on the stack, mainly for '&' substitution in "new" */
 	off = stktell(sh.stk);
@@ -149,8 +150,9 @@ void hist_setchars(char *hc)
 
 int hist_expand(const char *ln, char **xp)
 {
-	int	off,	/* stack offset */
-		q,	/* quotation flags */
+	ptrdiff_t off,	/* stack offset */
+		  off2; /* other stack offset */
+	int	q,	/* quotation flags */
 		p,	/* flag */
 		c,	/* current char */
 		flag=0;	/* HIST_* flags */
@@ -242,10 +244,10 @@ int hist_expand(const char *ln, char **xp)
 		case '#': /* the line up to current position */
 			flag |= HIST_HASH;
 			cp++;
-			n = stktell(sh.stk); /* terminate string and dup */
+			off2 = stktell(sh.stk); /* terminate string and dup */
 			sfputc(sh.stk,'\0');
 			cc = sh_strdup(stkptr(sh.stk,0));
-			stkseek(sh.stk,n); /* remove null byte again */
+			stkseek(sh.stk,off2); /* remove null byte again */
 			ref = sfopen(ref, cc, "s"); /* open as file */
 			n = 0; /* skip history file referencing */
 			break;
@@ -316,7 +318,7 @@ getline:
 			if(n < 0) /* determine index for backref */
 				n = sh.hist_ptr->histind + n;
 			/* search and use history file if found */
-			if(n > 0 && hist_seek(sh.hist_ptr, n) != -1)
+			if(n > 0 && hist_seek(sh.hist_ptr, (int)n) != -1)
 				ref = sh.hist_ptr->histfp;
 
 		}
@@ -326,16 +328,16 @@ getline:
 			c = *cp;
 			*cp = '\0';
 			errormsg(SH_DICT, ERROR_ERROR, "%s: event not found", evp);
-			*cp = c;
+			*cp = (char)c;
 			ERROROUT;
 		}
 
 		if(str) /* string search: restore orig. line */
 		{
 			if(flag&HIST_QUESTION)
-				*cp++ = c; /* skip second question mark */
+				*cp++ = (char)c; /* skip second question mark */
 			else
-				*cp = c;
+				*cp = (char)c;
 		}
 
 		/* colon introduces either word designators or modifiers */
@@ -375,7 +377,7 @@ getline:
 					else
 					{
 						w[0] = -2;
-						w[1] = sftell(ref) + hl.hist_char;
+						w[1] = (Sfoff_t)(sftell(ref) + hl.hist_char);
 					}
 					sfseek(wm, 0, SEEK_SET);
 					goto skip;
@@ -431,7 +433,7 @@ getline:
 			c = *cp;
 			*cp = '\0';
 			errormsg(SH_DICT, ERROR_ERROR, "%s: bad word specifier", evp);
-			*cp = c;
+			*cp = (char)c;
 			ERROROUT;
 		}
 
@@ -492,7 +494,7 @@ getsel:
 			c = *cp;
 			*cp = '\0';
 			errormsg(SH_DICT, ERROR_ERROR, "%s: bad word specifier", evp);
-			*cp = c;
+			*cp = (char)c;
 			ERROROUT;
 		}
 		else if(w[1] == -2)	/* skip last word */
@@ -558,30 +560,30 @@ getsel:
 
 			if(c == 'h' || c == 'r') /* head or base */
 			{
-				n = -1;
+				Sfoff_t sfloc = -1;
 				while((c = sfgetc(tmp)) > 0)
 				{	/* remember position of / or . */
 					if((c == '/' && *cp == 'h') || (c == '.' && *cp == 'r'))
-						n = sftell(tmp2);
+						sfloc = sftell(tmp2);
 					sfputc(tmp2, c);
 				}
-				if(n > 0)
+				if(sfloc > 0)
 				{	 /* rewind to last / or . */
-					sfseek(tmp2, n, SEEK_SET);
+					sfseek(tmp2, sfloc, SEEK_SET);
 					/* end string there */
 					sfputc(tmp2, '\0');
 				}
 			}
 			else if(c == 't' || c == 'e') /* tail or suffix */
 			{
-				n = 0;
+				Sfoff_t sfloc = 0;
 				while((c = sfgetc(tmp)) > 0)
 				{	/* remember position of / or . */
 					if((c == '/' && *cp == 't') || (c == '.' && *cp == 'e'))
-						n = sftell(tmp);
+						sfloc = sftell(tmp);
 				}
 				/* rewind to last / or . */
-				sfseek(tmp, n, SEEK_SET);
+				sfseek(tmp, sfloc, SEEK_SET);
 				/* copy from there on */
 				while((c = sfgetc(tmp)) > 0)
 					sfputc(tmp2, c);
@@ -596,10 +598,10 @@ getsel:
 					if(!sb.str[0] && wm)
 					{
 						char *sbuf = sfsetbuf(wm, (void*)1, 0);
-						int n = sftell(wm);
-						sb.str[0] = sh_malloc(n + 1);
-						sb.str[0][n] = '\0';
-						memcpy(sb.str[0], sbuf, n);
+						size_t sfloc = (size_t)sftell(wm);
+						sb.str[0] = sh_malloc(sfloc + 1);
+						sb.str[0][sfloc] = '\0';
+						memcpy(sb.str[0], sbuf, sfloc);
 					}
 					cp = parse_subst(cp, &sb);
 				}
@@ -612,7 +614,7 @@ getsel:
 						 "%s%s: no previous substitution",
 						(flag & HIST_QUICKSUBST) ? ":s" : "",
 						evp);
-					*cp = c;
+					*cp = (char)c;
 					ERROROUT;
 				}
 
@@ -629,7 +631,7 @@ getsel:
 						*tempcp = '\0';
 						sfputr(tmp2, str, -1);
 						sfputr(tmp2, sb.str[1], -1);
-						*tempcp = c;
+						*tempcp = (char)c;
 						str = tempcp + strlen(sb.str[0]);
 					}
 					else if(!sftell(tmp2))
@@ -640,7 +642,7 @@ getsel:
 							 "%s%s: substitution failed",
 							(flag & HIST_QUICKSUBST) ? ":s" : "",
 							evp);
-						*cp = c;
+						*cp = (char)c;
 						ERROROUT;
 					}
 					/* loop if g modifier specified */

--- a/src/cmd/ksh93/edit/history.c
+++ b/src/cmd/ksh93/edit/history.c
@@ -2,7 +2,7 @@
 *                                                                      *
 *               This software is part of the ast package               *
 *          Copyright (c) 1982-2014 AT&T Intellectual Property          *
-*          Copyright (c) 2020-2025 Contributors to ksh 93u+m           *
+*          Copyright (c) 2020-2026 Contributors to ksh 93u+m           *
 *                      and is licensed under the                       *
 *                 Eclipse Public License, Version 2.0                  *
 *                                                                      *
@@ -44,7 +44,7 @@
 
 #if !SHOPT_SCRIPTONLY
 
-#define HIST_MAX	(sizeof(int)*HIST_BSIZE)
+#define HIST_MAX	((ssize_t)sizeof(int)*HIST_BSIZE)
 #define HIST_BIG	(0100000-1024)	/* 1K less than maximum short */
 #define HIST_LINE	32		/* typical length for history line */
 #define HIST_MARKSZ	6
@@ -65,7 +65,7 @@
 #define _HIST_PRIVATE \
 	off_t	histcnt;	/* offset into history file */\
 	off_t	histmarker;	/* offset of last command marker */ \
-	int	histflush;	/* set if flushed outside of hflush() */\
+	ssize_t	histflush;	/* set if flushed outside of hflush() */\
 	int	histmask;	/* power of two mask for histcnt */ \
 	char	histbuff[HIST_BSIZE+1];	/* history file buffer */ \
 	int	histwfail; \
@@ -153,7 +153,9 @@ static History_t *hist_ptr;
 static int sh_checkaudit(const char *name, char *logbuf, size_t len)
 {
 	char	*cp, *last;
-	int	id1, id2, r=0, n, fd;
+	uid_t	id1, id2;
+	int	r=0, fd;
+	ssize_t	n;
 	if((fd=open(name, O_RDONLY|O_cloexec)) < 0)
 		return 0;
 	if((n = read(fd, logbuf,len-1)) < 0)
@@ -167,9 +169,9 @@ static int sh_checkaudit(const char *name, char *logbuf, size_t len)
 	do
 	{
 		cp++;
-		id1 = id2 = strtol(cp,&last,10);
+		id1 = id2 = (uid_t)strtol(cp,&last,10);
 		if(*last=='-')
-			id1 = strtol(last+1,&last,10);
+			id1 = (uid_t)strtol(last+1,&last,10);
 		if(sh.euserid >=id1 && sh.euserid <= id2)
 			r |= 1;
 		if(sh.userid >=id1 && sh.userid <= id2)
@@ -211,7 +213,7 @@ int  sh_histinit(void)
 		return 1;
 	if(!(histname = nv_getval(HISTFILE)))
 	{
-		int offset = stktell(sh.stk);
+		ptrdiff_t offset = stktell(sh.stk);
 		if(cp=nv_getval(HOME))
 			sfputr(sh.stk,cp,-1);
 		sfputr(sh.stk,hist_fname,0);
@@ -257,7 +259,7 @@ retry:
 		sh_fcntl(fd,F_SETFD,FD_CLOEXEC);  /* set the file to close-on-exec */
 	if(cp=nv_getval(HISTSIZE))
 	{
-		intmax_t m = strtoll(cp, NULL, 10);
+		long long m = strtoll(cp, NULL, 10);
 		if(m>HIST_MAX)
 			m = HIST_MAX;
 		else if(m<0)
@@ -267,12 +269,12 @@ retry:
 	else
 		maxlines = HIST_DFLT;
 	for(histmask=16;histmask <= maxlines; histmask <<=1 );
-	hp = new_of(History_t,(--histmask)*sizeof(off_t));
+	hp = new_of(History_t,(size_t)(--histmask)*sizeof(off_t));
 	sh.hist_ptr = hist_ptr = hp;
 	hp->histsize = maxlines;
 	hp->histmask = histmask;
 	hp->histfp= sfnew(NULL,hp->histbuff,HIST_BSIZE,fd,SFIO_READ|SFIO_WRITE|SFIO_APPENDWR|SFIO_SHARE);
-	memset((char*)hp->histcmds,0,sizeof(off_t)*(hp->histmask+1));
+	memset((char*)hp->histcmds,0,sizeof(off_t)*(size_t)(hp->histmask+1));
 	hp->histind = 1;
 	hp->histcmds[1] = 2;
 	hp->histcnt = 2;
@@ -289,10 +291,10 @@ retry:
 	{
 		int first,last;
 		off_t mark,size = (HIST_MAX/4)+maxlines*HIST_LINE;
-		hp->histind = first = hist_nearend(hp,hp->histfp,hsize-size);
+		hp->histind = first = (int)hist_nearend(hp,hp->histfp,hsize-size);
 		histinit = 1;
 		hist_eof(hp);	 /* this sets histind to last command */
-		if((hist_start = (last=(int)hp->histind)-maxlines) <=0)
+		if((hist_start = (last=hp->histind)-maxlines) <=0)
 			hist_start = 1;
 		mark = hp->histmarker;
 		while(first > hist_start)
@@ -319,7 +321,7 @@ retry:
 	if(hist_clean(fd) && hist_start>1 && hsize > HIST_MAX)
 	{
 #ifdef DEBUG
-		sfprintf(sfstderr,"%jd: hist_trim hsize=%d\n",(Sflong_t)sh.current_pid,hsize);
+		sfprintf(sfstderr,"%jd: hist_trim hsize=%jd\n",(Sflong_t)sh.current_pid,(intmax_t)hsize);
 		sfsync(sfstderr);
 #endif /* DEBUG */
 		hp = hist_trim(hp,(int)hp->histind-maxlines);
@@ -352,7 +354,7 @@ retry:
 					sh_fcntl(fd,F_SETFD,FD_CLOEXEC);
 				tty = ttyname(2);
 				hp->tty = sh_strdup(tty?tty:"notty");
-				hp->auditfp = sfnew(NULL,NULL,-1,fd,SFIO_WRITE);
+				hp->auditfp = sfnew(NULL,NULL,(size_t)-1,fd,SFIO_WRITE);
 			}
 		}
 	}
@@ -470,9 +472,9 @@ static History_t* hist_trim(History_t *hp, int n)
 			cp++;
 		if(cp > endbuff)
 			cp = endbuff;
-		c = cp-buff;
+		c = (int)(cp-buff);
 		hist_new->histcnt += c;
-		sfwrite(hist_new->histfp,buff,c);
+		sfwrite(hist_new->histfp,buff,(size_t)c);
 	}
 	hist_cancel(hist_new);
 	sfclose(hist_old->histfp);
@@ -486,7 +488,8 @@ static History_t* hist_trim(History_t *hp, int n)
 static int hist_nearend(History_t *hp, Sfio_t *iop, off_t size)
 {
 	unsigned char *cp, *endbuff;
-	int n, incmd=1;
+	int incmd=1;
+	ssize_t n;
 	unsigned char *buff, marker[4];
 	if(size <= 2L || sfseek(iop,size,SEEK_SET)<0)
 		goto begin;
@@ -516,7 +519,7 @@ static int hist_nearend(History_t *hp, Sfio_t *iop, off_t size)
 				break;
 		}
 		size += n;
-		sfread(iop,(char*)buff,n);
+		sfread(iop,(char*)buff,(size_t)n);
 		if(incmd < 0)
 		{
 			if((n=sfread(iop,(char*)marker,4))==4)
@@ -525,7 +528,7 @@ static int hist_nearend(History_t *hp, Sfio_t *iop, off_t size)
 				if(n < size/2)
 				{
 					hp->histmarker = hp->histcnt = size+4;
-					return n;
+					return (int)n;
 				}
 				n=4;
 			}
@@ -554,7 +557,9 @@ void hist_eof(History_t *hp)
 	char *cp,*first,*endbuff;
 	int incmd = 0;
 	off_t count = hp->histcnt;
-	int oldind=0,n,skip=0;
+	int oldind=0;
+	ptrdiff_t skip=0;
+	ssize_t n;
 	off_t last = sfseek(hp->histfp,0,SEEK_END);
 	if(last < count)
 	{
@@ -627,7 +632,7 @@ again:
 		}
 	refill:
 		count += (--cp-first);
-		skip = (cp-endbuff);
+		skip = cp-endbuff;
 		if(!incmd && !skip)
 			hp->histcmds[hist_ind(hp,++hp->histind)] = count;
 	}
@@ -709,12 +714,12 @@ static ssize_t hist_write(Sfio_t *iop,const void *buff,size_t insize,Sfdisc_t* h
 {
 	History_t *hp = (History_t*)handle;
 	char *bufptr = ((char*)buff)+insize;
-	int c,size = insize;
+	ssize_t size = (ssize_t)insize;
 	off_t cur;
-	int saved=0;
+	int c,saved=0;
 	char saveptr[HIST_MARKSZ];
 	if(!hp->histflush)
-		return write(sffileno(iop),(char*)buff,size);
+		return write(sffileno(iop),(char*)buff,(size_t)size);
 	if((cur = lseek(sffileno(iop),0,SEEK_END)) <0)
 	{
 		errormsg(SH_DICT,2,"hist_flush: EOF seek failed errno=%d",errno);
@@ -734,10 +739,10 @@ static ssize_t hist_write(Sfio_t *iop,const void *buff,size_t insize,Sfdisc_t* h
 	}
 	/* don't count empty lines */
 	if(++bufptr <= (char*)buff)
-		return insize;
+		return (ssize_t)insize;
 	*bufptr++ = '\n';
 	*bufptr++ = 0;
-	size = bufptr - (char*)buff;
+	size = (ssize_t)(bufptr - (char*)buff);
 #if	 SHOPT_AUDIT
 	if(hp->auditfp)
 	{
@@ -751,13 +756,13 @@ static ssize_t hist_write(Sfio_t *iop,const void *buff,size_t insize,Sfdisc_t* h
 #if	SHOPT_ACCTFILE
 	if(acctfd)
 	{
-		int timechars, offset;
-		offset = stktell(sh.stk);
+		ssize_t timechars;
+		ptrdiff_t offset = stktell(sh.stk);
 		sfputr(sh.stk,buff,-1);
 		stkseek(sh.stk,stktell(sh.stk) - 1);
-		timechars = sfprintf(sh.stk, "\t%s\t%x\n",logname,time(NULL));
+		timechars = sfprintf(sh.stk, "\t%s\t%lx\n",logname,(unsigned long)time(NULL));
 		lseek(acctfd, 0, SEEK_END);
-		write(acctfd, stkptr(sh.stk,offset), size - 2 + timechars);
+		write(acctfd, stkptr(sh.stk,offset), (size_t)(size - 2 + timechars));
 		stkseek(sh.stk,offset);
 
 	}
@@ -767,7 +772,7 @@ static ssize_t hist_write(Sfio_t *iop,const void *buff,size_t insize,Sfdisc_t* h
 		size++;
 		*bufptr++ = 0;
 	}
-	hp->histcnt +=  size;
+	hp->histcnt += size;
 	c = hist_ind(hp,++hp->histind);
 	hp->histcmds[c] = hp->histcnt;
 	if(hp->histflush>HIST_MARKSZ && hp->histcnt > hp->histmarker+HIST_BSIZE/2)
@@ -780,13 +785,13 @@ static ssize_t hist_write(Sfio_t *iop,const void *buff,size_t insize,Sfdisc_t* h
 		size += HIST_MARKSZ;
 	}
 	errno = 0;
-	size = write(sffileno(iop),(char*)buff,size);
+	size = write(sffileno(iop),(char*)buff,(size_t)size);
 	if(saved)
 		memcpy(bufptr,saveptr,HIST_MARKSZ);
 	if(size>=0)
 	{
 		hp->histwfail = 0;
-		return insize;
+		return (ssize_t)insize;
 	}
 	return -1;
 }
@@ -799,9 +804,9 @@ static void hist_marker(char *buff,long cmdno)
 {
 	*buff++ = HIST_CMDNO;
 	*buff++ = 0;
-	*buff++ = (cmdno>>16);
-	*buff++ = (cmdno>>8);
-	*buff++ = cmdno;
+	*buff++ = (char)(cmdno>>16);
+	*buff++ = (char)(cmdno>>8);
+	*buff++ = (char)cmdno;
 	*buff++ = 0;
 }
 
@@ -862,7 +867,7 @@ Histloc_t hist_find(History_t*hp,char *string,int index1,int flag,int direction)
 {
 	int index2;
 	off_t offset;
-	int *coffset=0;
+	ptrdiff_t *coffset=0;
 	Histloc_t location;
 	location.hist_command = -1;
 	location.hist_char = 0;
@@ -915,21 +920,23 @@ Histloc_t hist_find(History_t*hp,char *string,int index1,int flag,int direction)
  * If coffset==0 then line must begin with string
  * returns the line number of the match if successful, otherwise -1
  */
-int hist_match(History_t *hp,off_t offset,char *string,int *coffset)
+int hist_match(History_t *hp,off_t offset,char *string,ptrdiff_t *coffset)
 {
 	unsigned char *first, *cp;
-	int m,n,c=1,line=0;
+	int c=1,line=0;
+	ssize_t m;
+	size_t n;
 	sfseek(hp->histfp,offset,SEEK_SET);
 	if(!(cp = first = (unsigned char*)sfgetr(hp->histfp,0,0)))
 		return -1;
 	m = sfvalue(hp->histfp);
-	n = (int)strlen(string);
-	while(m > n)
+	n = strlen(string);
+	while(m > (ssize_t)n)
 	{
 		if(strncmp((char*)cp,string,n)==0)
 		{
 			if(coffset)
-				*coffset = (cp-first);
+				*coffset = cp-first;
 			return line;
 		}
 		if(!coffset)
@@ -980,7 +987,7 @@ int hist_copy(char *s1,int size,int command,int line)
 				*--s1 = 0;
 				break;
 			}
-			*s1++ = c;
+			*s1++ = (char)c;
 		}
 	}
 	sfseek(hp->histfp,0,SEEK_END);
@@ -997,7 +1004,7 @@ int hist_copy(char *s1,int size,int command,int line)
  * character following c is considered to start a new word
  */
 
-int hist_iswordbndry(char c)
+int hist_iswordbndry(int c)
 {
 	return isspace(c) || strchr("|&;()`<>",c);
 }
@@ -1016,8 +1023,8 @@ char *hist_word(char *string,int size,int word)
 	History_t *hp = hist_ptr;
 	if(!hp)
 		return NULL;
-	hist_copy(string,size,(int)hp->histind-1,-1);
-	for(quoted=0;c = *cp;cp++)
+	hist_copy(string,size,hp->histind-1,-1);
+	for(quoted=0;c = (int)*cp;cp++)
 	{
 		is_boundary = !quoted && hist_iswordbndry(c);
 		if(is_boundary && flag)
@@ -1087,7 +1094,7 @@ Histloc_t hist_locate(History_t *hp,int command,int line,int lines)
 	}
 	else
 	{
-		int least = (int)hp->histind-hp->histsize;
+		int least = hp->histind-hp->histsize;
 		while(1)
 		{
 			if(line >=0)

--- a/src/cmd/ksh93/edit/vi.c
+++ b/src/cmd/ksh93/edit/vi.c
@@ -371,7 +371,7 @@ static void append(Vi_t *vp,int c, int mode)
 			for(i = ++last_virt;  i > j; --i)
 				virtual[i] = virtual[i-1];
 		}
-		virtual[++cur_virt] = c;
+		virtual[++cur_virt] = (genchar)c;
 	}
 	else
 		ed_ringbell();
@@ -507,7 +507,7 @@ static int cntlmode(Vi_t *vp)
 		default:		/** input mode **/
 			if(!was_inmacro)
 			{
-				vp->last_cmd = c;
+				vp->last_cmd = (char)c;
 				vp->lastrepeat = vp->repeat;
 			}
 			vp->repeat = 1;
@@ -620,7 +620,7 @@ static int cntlmode(Vi_t *vp)
 #if SHOPT_MULTIBYTE
 			ed_internal((char*)virtual,virtual);
 #endif /* SHOPT_MULTIBYTE */
-			if((last_virt=genlen(virtual)-1) >= 0  && cur_virt == INVALID)
+			if((last_virt=(int)genlen(virtual)-1) >= 0  && cur_virt == INVALID)
 				cur_virt = 0;
 			virtual[last_virt+1] = '\0';
 			gencpy(vp->U_space, virtual);
@@ -643,7 +643,7 @@ static int cntlmode(Vi_t *vp)
 			else
 			{
 				gencpy(virtual, vp->U_space);
-				last_virt = genlen(vp->U_space) - 1;
+				last_virt = (int)genlen(vp->U_space) - 1;
 				cur_virt = 0;
 			}
 			break;
@@ -684,7 +684,7 @@ static int cntlmode(Vi_t *vp)
 			if(curhline == histmax && sh.hist_ptr)
 			{
 				hist_eof(sh.hist_ptr);
-				histmax = (int)sh.hist_ptr->histind;
+				histmax = sh.hist_ptr->histind;
 				curhline = histmax;
 				if(histmax >= sh.hist_ptr->histsize)
 					hist_flush(sh.hist_ptr);
@@ -715,7 +715,7 @@ static int cntlmode(Vi_t *vp)
 						}
 						else
 						{
-							cur_virt = p-virtual;
+							cur_virt = (int)(p-virtual);
 							append(vp,'#', APPEND);
 						}
 					}
@@ -815,7 +815,7 @@ static void cdelete(Vi_t *vp,int nchars, int mode)
 			i = cp[nchars];
 			cp[nchars] = 0;
 			gencpy(yankbuf,cp);
-			cp[nchars] = i;
+			cp[nchars] = (genchar)i;
 		}
 
 		/*** now delete these characters ***/
@@ -1106,7 +1106,7 @@ static void get_line(Vi_t* vp,int mode)
 					c = max_virt-cur_virt;
 					if(c > 0 && last_save>=cur_virt)
 					{
-						genncpy((&virtual[cur_virt]),&saveline[cur_virt],c);
+						genncpy((&virtual[cur_virt]),&saveline[cur_virt],(size_t)c);
 						if(last_virt>=last_save)
 							last_virt=last_save-1;
 						refresh(vp,INPUT);
@@ -1132,7 +1132,7 @@ static void get_line(Vi_t* vp,int mode)
 					c = last_save = last_virt+1;
 					if(c >= MAXLINE)
 						c = MAXLINE-1;
-					genncpy(saveline, virtual, c);
+					genncpy(saveline, virtual, (size_t)c);
 				}
 			}
 			break;
@@ -1269,8 +1269,8 @@ static void get_line(Vi_t* vp,int mode)
 				ed_ringbell();
 				break;
 			}
-			/* FALLTHROUGH */
 		}
+		/* FALLTHROUGH */
 		default:
 		fallback:
 			if( mode == REPLACE )
@@ -1562,7 +1562,7 @@ static int mvcursor(Vi_t* vp,int motion)
 
 	case 'T':		/** find up to new char backward **/
 	case 'F':		/** find new char backward **/
-		vp->last_find = motion;
+		vp->last_find = (char)motion;
 		if((vp->findchar=getrchar(vp))==ESC)
 			return 1;
 find_b:
@@ -1592,7 +1592,7 @@ find_b:
 		if(tcur_virt > last_virt )
 			return 0;
 		nextc = virtual[tcur_virt];
-		count = strchr(paren_chars,nextc)-paren_chars;
+		count = (int)(strchr(paren_chars,nextc)-paren_chars);
 		if(count < 3)
 		{
 			incr = 1;
@@ -1721,7 +1721,7 @@ static void refresh(Vi_t* vp, int mode)
 	}
 	virtual[last_virt+1] = 0;
 	ncur_phys = ed_virt_to_phys(vp->ed,virtual,physical,cur_virt,v,p);
-	p = genlen(physical);
+	p = (int)genlen(physical);
 	if( --p < 0 )
 		last_phys = 0;
 	else
@@ -1881,9 +1881,9 @@ static void replace(Vi_t *vp, int c, int increment)
 	}
 	else
 	{
-		virtual[cur_virt] = c;
-		physical[cur_phys] = c;
-		window[cur_window] = c;
+		virtual[cur_virt] = (genchar)c;
+		physical[cur_phys] = (genchar)c;
+		window[cur_window] = (genchar)c;
 		putchar(c);
 		if(increment)
 		{
@@ -1922,7 +1922,7 @@ static void restore_v(Vi_t *vp)
 	save_v(vp);
 	gencpy(virtual, tmpspace);
 	cur_virt = tmpcol;
-	last_virt = genlen(tmpspace) - 1;
+	last_virt = (int)genlen(tmpspace) - 1;
 	vp->ocur_virt = MAXCHAR;	/** invalidate refresh optimization **/
 	return;
 }
@@ -1944,7 +1944,7 @@ static void save_last(Vi_t* vp)
 		/*** save last thing user typed ***/
 		if(i >= MAXLINE)
 			i = MAXLINE-1;
-		genncpy(vp->lastline, (&virtual[first_virt]), i);
+		genncpy(vp->lastline, (&virtual[first_virt]), (size_t)i);
 		vp->lastline[i] = '\0';
 	}
 	return;
@@ -1991,7 +1991,7 @@ static int curline_search(Vi_t *vp, const char *string)
 	for(dp=(char*)vp->u_space,dpmax=dp+strlen(dp)-len; dp<=dpmax; dp++)
 	{
 		if(strncmp(cp,dp,len)==0)
-			return dp - (char*)vp->u_space;
+			return (int)(dp - (char*)vp->u_space);
 	}
 #if SHOPT_MULTIBYTE
 	ed_internal((char*)vp->u_space,vp->u_space);
@@ -2495,7 +2495,7 @@ deleol:
 		else
 			if((c=getrchar(vp))==ESC)
 				return GOOD;
-		*p = c;
+		*p = (genchar)c;
 		save_v(vp);
 		while(trepeat--)
 			replace(vp,c, trepeat!=0);
@@ -2607,7 +2607,7 @@ static int blankline(Vi_t *vp, int uptocursor)
 	for(x=0; x <= (uptocursor ? cur_virt : last_virt); x++)
 	{
 #if SHOPT_MULTIBYTE
-		if(!iswspace((wchar_t)virtual[x]))
+		if(!iswspace((wint_t)virtual[x]))
 #else
 		if(!isspace(virtual[x]))
 #endif /* SHOPT_MULTIBYTE */

--- a/src/cmd/ksh93/include/edit.h
+++ b/src/cmd/ksh93/include/edit.h
@@ -113,7 +113,7 @@ typedef struct edit
 	void	*e_vi;		/* vi specific data */
 	void	*e_emacs;	/* emacs specific data */
 	char	*e_stkptr;	/* saved stack pointer */
-	int	e_stkoff;	/* saved stack offset */
+	ptrdiff_t e_stkoff;	/* saved stack offset */
 	char	**e_clist;	/* completion list after <ESC>= */
 	int	e_nlist;	/* number of elements on completion list */
 #if SHOPT_ESH || SHOPT_VSH
@@ -168,8 +168,8 @@ extern void	*ed_open(void);
 	extern int ed_internal(const char*, genchar*);
 	extern int ed_external(const genchar*, char*);
 	extern void ed_gencpy(genchar*,const genchar*);
-	extern void ed_genncpy(genchar*,const genchar*,int);
-	extern int ed_genlen(const genchar*);
+	extern void ed_genncpy(genchar*,const genchar*,size_t);
+	extern size_t ed_genlen(const genchar*);
 #endif /* SHOPT_MULTIBYTE */
 
 extern const char	e_runvi[];

--- a/src/cmd/ksh93/include/history.h
+++ b/src/cmd/ksh93/include/history.h
@@ -12,6 +12,7 @@
 *                                                                      *
 *                  David Korn <dgk@research.att.com>                   *
 *                  Martijn Dekker <martijn@inlv.org>                   *
+*            Johnothan King <johnothanking@protonmail.com>             *
 *                                                                      *
 ***********************************************************************/
 #ifndef _HIST_H
@@ -34,7 +35,7 @@ typedef struct
 	Sfdisc_t	histdisc;	/* discipline for history */
 	Sfio_t		*histfp;	/* history file stream pointer */
 	char		*histname;	/* name of history file */
-	int32_t		histind;	/* current command number index */
+	int		histind;	/* current command number index */
 	int		histsize;	/* number of accessible history lines */
 #ifdef _HIST_PRIVATE
 	_HIST_PRIVATE
@@ -45,7 +46,7 @@ typedef struct
 {
 	int hist_command;
 	int hist_line;
-	int hist_char;
+	ptrdiff_t hist_char;
 } Histloc_t;
 
 #if SHOPT_SCRIPTONLY
@@ -70,8 +71,8 @@ typedef struct
 extern const char	hist_fname[];
 
 extern int _Hist;
-#define hist_min(hp)	((_Hist=((int)((hp)->histind-(hp)->histsize)))>=0?_Hist:0)
-#define hist_max(hp)	((int)((hp)->histind))
+#define hist_min(hp)	((_Hist=((hp)->histind-(hp)->histsize))>=0?_Hist:0)
+#define hist_max(hp)	((hp)->histind)
 /* these are the history interface routines */
 extern int		sh_histinit(void);
 extern void 		hist_cancel(History_t*);
@@ -81,10 +82,10 @@ extern void 		hist_eof(History_t*);
 extern Histloc_t	hist_find(History_t*,char*,int, int, int);
 extern void 		hist_flush(History_t*);
 extern void 		hist_list(History_t*,Sfio_t*, off_t, int, char*);
-extern int		hist_match(History_t*,off_t, char*, int*);
+extern int		hist_match(History_t*,off_t, char*, ptrdiff_t*);
 extern off_t		hist_tell(History_t*,int);
 extern off_t		hist_seek(History_t*,int);
-extern int		hist_iswordbndry(char);
+extern int		hist_iswordbndry(int);
 extern char 		*hist_word(char*, int, int);
 #if !_BLD_ksh || SHOPT_ESH
     extern Histloc_t	hist_locate(History_t*,int, int, int);

--- a/src/cmd/ksh93/sh/jobs.c
+++ b/src/cmd/ksh93/sh/jobs.c
@@ -91,10 +91,7 @@ pid_t	pid_fromstring(char *str)
 	pid_t	pid;
 	char	*last;
 	errno = 0;
-	if(sizeof(pid)==sizeof(Sflong_t))
-		pid = (pid_t)strtoll(str, &last, 10);
-	else
-		pid = (pid_t)strtol(str, &last, 10);
+	pid = (pid_t)strtoll(str, &last, 10);
 	if(errno==ERANGE || *last)
 	{
 		errormsg(SH_DICT,ERROR_exit(1),"%s: invalid process ID",str);
@@ -191,7 +188,8 @@ void job_chldtrap(int unpost)
 {
 	struct process *pw,*pwnext;
 	pid_t bckpid;
-	int oldexit,trapnote;
+	int oldexit;
+	unsigned char trapnote;
 	job_lock();
 	sh.sigflag[SIGCHLD] &= ~SH_SIGTRAP;
 	trapnote = sh.trapnote;
@@ -347,7 +345,7 @@ int job_reap(int sig)
 		else if(WIFSTOPPED(wstat))
 		{
 			pw->p_flag |= (P_NOTIFY|P_SIGNALLED|P_STOPPED|P_BG);
-			pw->p_exit = WSTOPSIG(wstat);
+			pw->p_exit = (unsigned short)WSTOPSIG(wstat);
 			if(pw->p_pgrp && pw->p_pgrp==job.curpgid && sh_isstate(SH_STOPOK))
 				kill(sh.current_pid,pw->p_exit);
 			if(px)
@@ -398,7 +396,7 @@ int job_reap(int sig)
 			{
 				pw->p_exit =  pw->p_exitmin;
 				if(WEXITSTATUS(wstat) > pw->p_exitmin)
-					pw->p_exit = WEXITSTATUS(wstat);
+					pw->p_exit = (unsigned short)WEXITSTATUS(wstat);
 			}
 #if SHOPT_BGX
 			if(pw->p_flag&P_BG)
@@ -566,8 +564,8 @@ void job_init(void)
 #ifdef CNSUSP
 	/* set the switch character */
 	tty_get(JOBTTY,&my_stty);
-	job.suspend = (unsigned)my_stty.c_cc[VSUSP];
-	if(job.suspend == (unsigned char)CNSUSP)
+	job.suspend = my_stty.c_cc[VSUSP];
+	if(job.suspend == CNSUSP)
 	{
 		my_stty.c_cc[VSUSP] = CSWTCH;
 		tty_set(JOBTTY,TCSAFLUSH,&my_stty);
@@ -782,7 +780,8 @@ int job_list(struct process *pw,int flag)
 	struct process *px = pw;
 	int  n;
 	const char *msg;
-	int msize;
+	size_t mlen;
+	char c;
 	if(!pw || pw->p_job<=0)
 		return 1;
 	if(pw->p_env != sh.jobenv)
@@ -799,14 +798,14 @@ int job_list(struct process *pw,int flag)
 	job_lock();
 	n = px->p_job;
 	if(px==job.pwlist)
-		msize = '+';
+		c = '+';
 	else if(px==job.pwlist->p_nxtjob)
-		msize = '-';
+		c = '-';
 	else
-		msize = ' ';
+		c = ' ';
 	if(flag&JOB_NLFLAG)
 		sfputc(outfile,'\n');
-	sfprintf(outfile,"[%d] %c ",n, msize);
+	sfprintf(outfile,"[%d] %c ",n, c);
 	do
 	{
 		n = 0;
@@ -823,19 +822,19 @@ int job_list(struct process *pw,int flag)
 			msg = sh_translate(e_running);
 		px->p_flag &= ~P_NOTIFY;
 		sfputr(outfile,msg,-1);
-		msize = strlen(msg);
+		mlen = strlen(msg);
 		if(n)
 		{
 			sfprintf(outfile,"(%d)",n);
-			msize += (3+(n>10)+(n>100));
+			mlen += (3+(n>10)+(n>100));
 		}
 		if(px->p_flag&P_COREDUMP)
 		{
 			msg = sh_translate(e_coredump);
 			sfputr(outfile, msg, -1);
-			msize += strlen(msg);
+			mlen += strlen(msg);
 		}
-		sfnputc(outfile,' ',MAXMSG>msize?MAXMSG-msize:1);
+		sfnputc(outfile,' ',MAXMSG>mlen?MAXMSG-mlen:1);
 		if(flag&JOB_LFLAG)
 			px = px->p_nxtproc;
 		else
@@ -1016,9 +1015,9 @@ static struct process *job_byname(char *name)
 {
 	struct process *pw = job.pwlist;
 	struct process *pz = 0;
-	int *flag = 0;
+	ptrdiff_t *flag = 0;
+	ptrdiff_t offset;
 	char *cp = name;
-	int offset;
 	if(!sh.hist_ptr)
 		return NULL;
 	if(*cp=='?')
@@ -1150,7 +1149,7 @@ int job_post(pid_t pid, pid_t join)
 	pw->p_pid = pid;
 	if(!sh.outpipe || sh.cpid==pid)
 		pw->p_flag = P_EXITSAVE;
-	pw->p_exitmin = sh.xargexit;
+	pw->p_exitmin = (unsigned short)sh.xargexit;
 	pw->p_exit = 0;
 	if(sh_isstate(SH_MONITOR))
 	{
@@ -1172,7 +1171,7 @@ int job_post(pid_t pid, pid_t join)
 		pw->p_name = -1;
 	if ((val = job_chksave(pid))>=0 && !jobfork)
 	{
-		pw->p_exit = val;
+		pw->p_exit = (unsigned short)val;
 		if(pw->p_exit==SH_STOPSIG)
 		{
 			pw->p_flag |= (P_SIGNALLED|P_STOPPED);


### PR DESCRIPTION
This is the ninth of the thickfold patch series, which enables ksh93 to operate within a 64-bit address space.

The parts of ksh93 affected by this commit are:
- The interactive emacs and vi editor modes. Neither possess an exigent need to operate on exceedingly large buffers (I'd be surprised if they ever needed to operate in gigabytes to begin with), so I opted to keep many variables ints because those are more favorable for struct size. (Decreasing the sizes of the global editor structs would require reordering the variables in those structs, which is best left for a separate patch.)
  - Moved a `/* FALLTHROUGH */` comment to fix an unimportant fallthrough warning.
- Various fixes for jobs.c.
  - Get rid of if/else PID botch; a single casted `strtoll` is fine.

Change in the number of warnings on Linux when compiling with clang using `-Wsign-compare -Wshorten-64-to-32 -Wsign-conversion -Wimplicit-int-conversion`: 1,032 => 911 => 37 (progression from part 8 => part 9 => part 13)

Progresses https://github.com/ksh93/ksh/issues/592