### PR TITLE
Expand stored nvflags from 16-bit to 64-bit

### DIFF
--- a/src/cmd/ksh93/bltins/alarm.c
+++ b/src/cmd/ksh93/bltins/alarm.c
@@ -226,7 +226,7 @@ static char *setdisc(Namval_t *np, const char *event, Namval_t* action, Namfun_t
 /*
  * catch assignments and set alarm traps
  */
-static void putval(Namval_t* np, const char* val, int flag, Namfun_t* fp)
+static void putval(Namval_t* np, const char* val, nvflag_t flag, Namfun_t* fp)
 {
 	struct tevent	*tp = (struct tevent*)fp;
 	double		d, x;

--- a/src/cmd/ksh93/bltins/enum.c
+++ b/src/cmd/ksh93/bltins/enum.c
@@ -149,7 +149,7 @@ static int enuminfo(Opt_t* op, Sfio_t *out, const char *str, Optdisc_t *fp)
 	return 0;
 }
 
-static Namfun_t *clone_enum(Namval_t* np, Namval_t *mp, int flags, Namfun_t *fp)
+static Namfun_t *clone_enum(Namval_t* np, Namval_t *mp, nvflag_t flags, Namfun_t *fp)
 {
 	struct Enum	*ep, *pp=(struct Enum*)fp;
 	NOT_USED(np);
@@ -160,7 +160,7 @@ static Namfun_t *clone_enum(Namval_t* np, Namval_t *mp, int flags, Namfun_t *fp)
 	return &ep->hdr;
 }
 
-static void put_enum(Namval_t* np,const char *val,int flags,Namfun_t *fp)
+static void put_enum(Namval_t* np,const char *val,nvflag_t flags,Namfun_t *fp)
 {
 	struct Enum 		*ep = (struct Enum*)fp;
 	const char		*v;

--- a/src/cmd/ksh93/bltins/mkservice.c
+++ b/src/cmd/ksh93/bltins/mkservice.c
@@ -369,7 +369,7 @@ static char* setdisc(Namval_t* np, const char* event, Namval_t* action, Namfun_t
 	return nv_setdisc(np, event, action, fp);
 }
 
-static void putval(Namval_t* np, const char* val, int flag, Namfun_t* fp)
+static void putval(Namval_t* np, const char* val, nvflag_t flag, Namfun_t* fp)
 {
 	Service_t* sp = (Service_t*)fp;
 	if (!val)

--- a/src/cmd/ksh93/bltins/read.c
+++ b/src/cmd/ksh93/bltins/read.c
@@ -239,7 +239,7 @@ int sh_readline(char **names, volatile int fd, int flags, ssize_t size, Sflong_t
 	int			delim = '\n';
 	int			jmpval=0;
 	int			binary;
-	int			oflags=NV_VARNAME;
+	nvflag_t		oflags=NV_VARNAME;
 	char			inquote = 0;
 	struct checkpt		buff;
 	Edit_t			*ep = (struct edit*)sh.ed_context;

--- a/src/cmd/ksh93/bltins/typeset.c
+++ b/src/cmd/ksh93/bltins/typeset.c
@@ -66,7 +66,7 @@ struct tdata
 	short     	aflag;
 	short     	pflag;
 	int     	argnum;
-	int     	scanmask;
+	nvflag_t     	scanmask;
 	Dt_t 		*scanroot;
 	char    	**argnam;
 	size_t		indent;
@@ -77,9 +77,9 @@ struct tdata
 static int	print_namval(Sfio_t*, Namval_t*, int, struct tdata*);
 static void	print_attribute(Namval_t*,void*);
 static void	print_all(Sfio_t*, Dt_t*, struct tdata*);
-static void	print_scan(Sfio_t*, int, Dt_t*, int, struct tdata*);
+static void	print_scan(Sfio_t*, nvflag_t, Dt_t*, int, struct tdata*);
 static int	unall(int, char**, Dt_t*);
-static int	setall(char**, int, Dt_t*, struct tdata*);
+static int	setall(char**, nvflag_t, Dt_t*, struct tdata*);
 static void	pushname(Namval_t*,void*);
 static void(*nullscan)(Namval_t*,void*);
 
@@ -92,14 +92,15 @@ static void(*nullscan)(Namval_t*,void*);
 #endif
 int    b_readonly(int argc,char *argv[],Shbltin_t *context)
 {
-	int flag;
+	int n;
+	nvflag_t flag;
 	char *command = argv[0];
 	struct tdata tdata;
 	NOT_USED(argc);
 	NOT_USED(context);
 	memset(&tdata,0,sizeof(tdata));
 	tdata.aflag = '-';
-	while((flag = optget(argv,*command=='e'?sh_optexport:sh_optreadonly))) switch(flag)
+	while((n = optget(argv,*command=='e'?sh_optexport:sh_optreadonly))) switch(n)
 	{
 		case 'p':
 			tdata.prefix = command;
@@ -136,7 +137,7 @@ int    b_readonly(int argc,char *argv[],Shbltin_t *context)
 #endif
 int    b_alias(int argc,char *argv[],Shbltin_t *context)
 {
-	unsigned flag = NV_NOARRAY|NV_NOSCOPE|NV_ASSIGN;
+	nvflag_t flag = NV_NOARRAY|NV_NOSCOPE|NV_ASSIGN;
 	Dt_t *troot;
 	int rflag=0, xflag=0, n;
 	struct tdata tdata;
@@ -221,7 +222,8 @@ int    b_alias(int argc,char *argv[],Shbltin_t *context)
 #endif
 int    b_typeset(int argc,char *argv[],Shbltin_t *context)
 {
-	int		n, flag = NV_VARNAME|NV_ASSIGN;
+	int		n;
+	nvflag_t	flag = NV_VARNAME|NV_ASSIGN;
 	struct tdata	tdata;
 	const char	*optstring = sh_opttypeset;
 	Namdecl_t 	*ntp = (Namdecl_t*)context->ptr;
@@ -650,12 +652,14 @@ static void print_value(Sfio_t *iop, Namval_t *np, struct tdata *tp)
 	}
 }
 
-static int     setall(char **argv,int flag,Dt_t *troot,struct tdata *tp)
+static int     setall(char **argv,nvflag_t flag,Dt_t *troot,struct tdata *tp)
 {
 	char *name;
 	char *last = 0;
-	int nvflags=(flag&(NV_ARRAY|NV_NOARRAY|NV_VARNAME|NV_IDENT|NV_ASSIGN|NV_STATIC|NV_MOVE));
-	int r=0, ref=0, comvar=(flag&NV_COMVAR),iarray=(flag&NV_IARRAY);
+	nvflag_t nvflags=(flag&(NV_ARRAY|NV_NOARRAY|NV_VARNAME|NV_IDENT|NV_ASSIGN|NV_STATIC|NV_MOVE));
+	int r=0, ref=0;
+	nvflag_t comvar=(flag&NV_COMVAR);
+	nvflag_t iarray=(flag&NV_IARRAY);
 	Dt_t *save_vartree = NULL;
 #if SHOPT_NAMESPACE
 	Namval_t *save_namespace = NULL;
@@ -692,11 +696,11 @@ static int     setall(char **argv,int flag,Dt_t *troot,struct tdata *tp)
 			nvflags |= (NV_NOREF|NV_NOADD|NV_NOFAIL);
 		while(name = *++argv)
 		{
-			unsigned newflag;
-			Namval_t *np;
+			nvflag_t	newflag;
+			Namval_t	*np;
 			Namarr_t	*ap=0;
 			Namval_t	*mp;
-			unsigned curflag;
+			nvflag_t	curflag;
 			if(troot == sh.fun_tree)
 			{
 				/*
@@ -1128,8 +1132,9 @@ Shbltin_f sh_getlib(char* sym, Pathcomp_t* pp)
 int	b_builtin(int argc,char *argv[],Shbltin_t *context)
 {
 	char *arg=0, *name;
-	int n, r=0, flag=0;
+	int n, r=0;
 	ptrdiff_t offset;
+	nvflag_t flag=0;
 	Namval_t *np;
 	int dlete=0;
 	struct tdata tdata;
@@ -1332,7 +1337,8 @@ static int unall(int argc, char **argv, Dt_t *troot)
 	const char *name;
 	volatile int r;
 	Dt_t	*dp;
-	int nflag=0,all=0,isfun,jmpval;
+	int all=0,isfun,jmpval;
+	nvflag_t nflag=0;
 	struct checkpt buff;
 	NOT_USED(argc);
 	if(troot==sh.alias_tree)
@@ -1647,7 +1653,7 @@ static void	print_attribute(Namval_t *np,void *data)
  * print the nodes in tree <root> which have attributes <flag> set
  * if <option> is non-zero, no subscript or value is printed
  */
-static void print_scan(Sfio_t *file, int flag, Dt_t *root, int option,struct tdata *tp)
+static void print_scan(Sfio_t *file, nvflag_t flag, Dt_t *root, int option,struct tdata *tp)
 {
 	char **argv;
 	Namval_t *np;

--- a/src/cmd/ksh93/include/argnod.h
+++ b/src/cmd/ksh93/include/argnod.h
@@ -97,7 +97,11 @@ struct argnod
 		struct argnod	*ap;
 		char		*cp;
 	}		argchn;
-	unsigned char	argflag;
+	/*
+	 * argflag must be 8 bits because the code expects that assigning
+	 * to it will mask off any high bits; e.g., ARG_ARITH and friends.
+	 */
+	uint8_t		argflag;
 	char		argval[4];
 };
 

--- a/src/cmd/ksh93/include/defs.h
+++ b/src/cmd/ksh93/include/defs.h
@@ -105,7 +105,7 @@ extern void		sh_assignok(Namval_t*,int);
 extern struct dolnod	*sh_arguse(void);
 extern char		*sh_checkid(char*,char*);
 extern void		sh_chktrap(void);
-extern void		sh_deparse(Sfio_t*,const Shnode_t*,uint32_t,int);
+extern void		sh_deparse(Sfio_t*,const Shnode_t*,uint64_t,int);
 extern int		sh_debug(const char*,const char*,const char*,char *const[],int);
 extern char 		**sh_envgen(void);
 extern Sfdouble_t	sh_arith(const char*);

--- a/src/cmd/ksh93/include/defs.h
+++ b/src/cmd/ksh93/include/defs.h
@@ -105,7 +105,7 @@ extern void		sh_assignok(Namval_t*,int);
 extern struct dolnod	*sh_arguse(void);
 extern char		*sh_checkid(char*,char*);
 extern void		sh_chktrap(void);
-extern void		sh_deparse(Sfio_t*,const Shnode_t*,uint64_t,int);
+extern void		sh_deparse(Sfio_t*,const Shnode_t*,nvflag_t,int);
 extern int		sh_debug(const char*,const char*,const char*,char *const[],int);
 extern char 		**sh_envgen(void);
 extern Sfdouble_t	sh_arith(const char*);

--- a/src/cmd/ksh93/include/defs.h
+++ b/src/cmd/ksh93/include/defs.h
@@ -105,7 +105,7 @@ extern void		sh_assignok(Namval_t*,int);
 extern struct dolnod	*sh_arguse(void);
 extern char		*sh_checkid(char*,char*);
 extern void		sh_chktrap(void);
-extern void		sh_deparse(Sfio_t*,const Shnode_t*,int,int);
+extern void		sh_deparse(Sfio_t*,const Shnode_t*,uint32_t,int);
 extern int		sh_debug(const char*,const char*,const char*,char *const[],int);
 extern char 		**sh_envgen(void);
 extern Sfdouble_t	sh_arith(const char*);
@@ -149,7 +149,7 @@ extern void		sh_clear_subshell_pwdfd(void);
     extern int		sh_validate_subpwdfd(void);
 #endif /* _lib_openat */
 #if SHOPT_NAMESPACE
-    extern Namval_t	*sh_fsearch(const char *,int);
+    extern Namval_t	*sh_fsearch(const char *,nvflag_t);
 #endif /* SHOPT_NAMESPACE */
 
 /* malloc related wrappers */

--- a/src/cmd/ksh93/include/name.h
+++ b/src/cmd/ksh93/include/name.h
@@ -42,7 +42,6 @@
 #if SHOPT_FIXEDARRAY
 #   define ARRAY_FIXED	ARRAY_NOCLONE		/* For index values */
 #endif /* SHOPT_FIXEDARRAY */
-#define NV_FARRAY	0x10000000		/* fixed-size arrays */
 #define NV_ASETSUB	8			/* set subscript */
 
 /* These flags are used as options to array_get() */
@@ -86,13 +85,11 @@ struct Ufunction
 
 /* The following attributes are for internal use */
 #define NV_NOCHANGE	(NV_EXPORT|NV_MINIMAL|NV_RDONLY|NV_TAGGED|NV_NOFREE|NV_ARRAY)
-#define NV_ATTRIBUTES	(~(NV_NOSCOPE|NV_ARRAY|NV_NOARRAY|NV_IDENT|NV_ASSIGN|NV_REF|NV_VARNAME|NV_STATIC))
+#define NV_ATTRIBUTES	(NV_ARRAY|NV_IDENT|NV_ASSIGN|NV_REF)
+#define NV_OPENMASK	(NV_APPEND|NV_MOVE|NV_NOARRAY|NV_IARRAY|NV_VARNAME|NV_NOADD|NV_NOSCOPE|NV_NOFAIL|NV_UNATTR|NV_GLOBAL|NV_TYPE|NV_STATIC|NV_COMVAR|NV_ADD|NV_FARRAY)
 #define NV_PARAM	NV_NODISC	/* expansion use positional params */
 
 /* This following are for use with nodes which are not name-values */
-#define NV_TYPE		0x1000000
-#define NV_STATIC	0x2000000
-#define NV_COMVAR	0x4000000
 #define NV_FUNCTION	(NV_RJUST|NV_FUNCT)	/* value is shell function */
 #define NV_FPOSIX	NV_LJUST		/* POSIX function semantics */
 #define NV_STATICF	NV_INTEGER		/* static class function */
@@ -142,13 +139,13 @@ struct Ufunction
 #define array_assoc(ap)	((ap)->fun)
 
 extern ssize_t		array_maxindex(Namval_t*);
-extern char 		*nv_endsubscript(Namval_t*, char*, int);
+extern char 		*nv_endsubscript(Namval_t*, char*, nvflag_t);
 extern Namfun_t 	*nv_enforcedisc(Namval_t*);
 extern int		nv_arrayisset(Namval_t*, Namarr_t*);
-extern int		nv_arraysettype(Namval_t*, Namval_t*,const char*,int);
+extern int		nv_arraysettype(Namval_t*, Namval_t*, const char*, nvflag_t);
 extern ssize_t		nv_aimax(Namval_t*);
 extern int		nv_atypeindex(Namval_t*, const char*);
-extern void		nv_setlist(struct argnod*, int, Namval_t*);
+extern void		nv_setlist(struct argnod*, nvflag_t, Namval_t*);
 #if SHOPT_OPTIMIZE
     extern void		nv_optimize(Namval_t*);
     extern void		nv_optimize_clear(Namval_t*);
@@ -163,8 +160,8 @@ extern void		nv_setlist(struct argnod*, int, Namval_t*);
 extern void		nv_outname(Sfio_t*,char*, ptrdiff_t);
 extern void 		nv_unref(Namval_t*);
 extern int		nv_hasget(Namval_t*);
-extern void		clone_all_disc(Namval_t*, Namval_t*, int);
-extern Namfun_t		*nv_clone_disc(Namfun_t*, int);
+extern void		clone_all_disc(Namval_t*, Namval_t*, nvflag_t);
+extern Namfun_t		*nv_clone_disc(Namfun_t*, nvflag_t);
 extern void		*nv_diropen(Namval_t*, const char*, int);
 extern char		*nv_dirnext(void*);
 extern void		nv_dirclose(void*);
@@ -178,7 +175,7 @@ extern Namval_t		*nv_mount(Namval_t*, const char *name, Dt_t*);
 extern Namval_t		*nv_arraychild(Namval_t*, Namval_t*, int);
 extern int		nv_compare(Dt_t*, void*, void*, Dtdisc_t*);
 extern void		nv_outnode(Namval_t*,Sfio_t*, int, int);
-extern int		nv_subsaved(Namval_t*, int);
+extern int		nv_subsaved(Namval_t*, nvflag_t);
 extern void		nv_typename(Namval_t*, Sfio_t*);
 extern Namval_t		*nv_typeparent(Namval_t*);
 extern int		nv_istable(Namval_t*);

--- a/src/cmd/ksh93/include/nval.h
+++ b/src/cmd/ksh93/include/nval.h
@@ -43,6 +43,12 @@ typedef struct Namarray Namarr_t;
 typedef struct Namdecl Namdecl_t;
 
 /*
+ * Any place that assigns or compares the NV_* symbols below to a var should use 'nvflag_t' for the
+ * type of the var rather than 'unsigned short', 'int', etc.
+ */
+typedef uint64_t nvflag_t;
+
+/*
  * Poor man's alignof() -- the real one is not available in C99 and cannot
  * be portably reimplemented. This nv_alignof() version can only be used
  * with types defined in the dummy struct below. The _c* char entries are
@@ -78,17 +84,17 @@ typedef struct
 struct Namdisc
 {
 	size_t	dsize;
-	void	(*putval)(Namval_t*, const char*, int, Namfun_t*);
+	void	(*putval)(Namval_t*, const char*, nvflag_t, Namfun_t*);
 	char	*(*getval)(Namval_t*, Namfun_t*);
 	Sfdouble_t	(*getnum)(Namval_t*, Namfun_t*);
 	char	*(*setdisc)(Namval_t*, const char*, Namval_t*, Namfun_t*);
-	Namval_t *(*createf)(Namval_t*, const char*, int, Namfun_t*);
-	Namfun_t *(*clonef)(Namval_t*, Namval_t*, int, Namfun_t*);
+	Namval_t *(*createf)(Namval_t*, const char*, nvflag_t, Namfun_t*);
+	Namfun_t *(*clonef)(Namval_t*, Namval_t*, nvflag_t, Namfun_t*);
 	char	*(*namef)(Namval_t*, Namfun_t*);
 	Namval_t *(*nextf)(Namval_t*, Dt_t*, Namfun_t*);
 	Namval_t *(*typef)(Namval_t*, Namfun_t*);
 	int	(*readf)(Namval_t*, Sfio_t*, int, Namfun_t*);
-	int	(*writef)(Namval_t*, Sfio_t*, int, Namfun_t*);
+	int	(*writef)(Namval_t*, Sfio_t*, nvflag_t, Namfun_t*);
 };
 
 struct Namfun
@@ -115,7 +121,7 @@ struct Namarray
 {
 	Namfun_t	hdr;
 	long		nelem;				/* number of elements */
-	void	*(*fun)(Namval_t*,const char*,int);	/* associative arrays */
+	void	*(*fun)(Namval_t*,const char*,nvflag_t);/* associative arrays */
 	void		*fixed;			/* for fixed-size arrays */
 	Dt_t		*table;			/* for subscripts */
 	void		*scope;			/* non-zero when scoped */
@@ -131,7 +137,7 @@ struct Namdecl
 
 /* attributes of name-value node attribute flags */
 
-#define NV_DEFAULT 0
+#define NV_DEFAULT ((nvflag_t)0)
 
 /*
  * This defines the attributes for an attributed name-value pair node.
@@ -143,7 +149,7 @@ struct Namval
 {
 	Dtlink_t	nvlink;		/* space for cdt links */
 	char		*nvname;	/* pointer to name of the node */
-	uint16_t	nvflag; 	/* attributes */
+	nvflag_t	nvflag; 	/* attributes */
 	size_t  	nvsize;		/* size or base */
 	Namfun_t	*nvfun;		/* pointer to trap functions */
 	void		*nvalue;	/* pointer to any kind of value */
@@ -158,65 +164,69 @@ struct Namval
 #define nv_namptr(p,n)	((Namval_t*)((char*)(p) + (n) * NV_MINSZ - offsetof(struct Namval, nvname)))
 
 /* The following attributes are for internal use */
-#define NV_NOFREE	0x200	/* don't free the space when releasing value */
-#define NV_ARRAY	0x400	/* node is an array */
-#define NV_REF		0x4000	/* reference bit */
-#define NV_TABLE	0x800	/* node is a dictionary table */
-#define NV_MINIMAL	0x1000	/* node does not contain all fields */
+#define NV_NOFREE	((nvflag_t)1 << 9)	/* don't free the space when releasing value */
+#define NV_ARRAY	((nvflag_t)1 << 10)	/* node is an array */
+#define NV_REF		((nvflag_t)1 << 14)	/* reference bit */
+#define NV_TABLE	((nvflag_t)1 << 11)	/* node is a dictionary table */
+#define NV_MINIMAL	((nvflag_t)1 << 12)	/* node does not contain all fields */
 #if _BLD_ksh
 #if SHOPT_OPTIMIZE
-#define NV_NOOPTIMIZE	NV_TABLE	/* disable loop invariants optimizer */
+#define NV_NOOPTIMIZE	NV_TABLE		/* disable loop invariants optimizer */
 #else
 #define NV_NOOPTIMIZE	0
 #endif /* SHOPT_OPTIMIZE */
 #endif /* _BLD_ksh */
 
-#define NV_INTEGER	0x2	/* integer attribute */
+#define NV_INTEGER	((nvflag_t)1 << 1)	/* integer attribute */
 /* The following attributes are valid only when NV_INTEGER is off */
-#define NV_LTOU		0x4	/* convert to uppercase */
-#define NV_UTOL		0x8	/* convert to lowercase */
-#define NV_ZFILL	0x10	/* right justify and fill with leading zeros */
-#define NV_RJUST	0x20	/* right justify and blank fill */
-#define NV_LJUST	0x40	/* left justify and blank fill */
-#define NV_BINARY	0x100	/* fixed size data buffer */
-#define NV_RAW		NV_LJUST	/* used only with NV_BINARY */
+#define NV_LTOU		((nvflag_t)1 << 2)	/* convert to uppercase */
+#define NV_UTOL		((nvflag_t)1 << 3)	/* convert to lowercase */
+#define NV_ZFILL	((nvflag_t)1 << 4)	/* right justify and fill with leading zeros */
+#define NV_RJUST	((nvflag_t)1 << 5)	/* right justify and blank fill */
+#define NV_LJUST	((nvflag_t)1 << 6)	/* left justify and blank fill */
+#define NV_BINARY	((nvflag_t)1 << 8)	/* fixed size data buffer */
+#define NV_RAW		NV_LJUST		/* used only with NV_BINARY */
 #define NV_HOST		(NV_RJUST|NV_LJUST)	/* map to host filename */
 
 /* The following attributes do not affect the value */
-#define NV_RDONLY	0x1	/* readonly bit */
-#define NV_EXPORT	0x2000	/* export bit */
-#define NV_TAGGED	0x8000	/* user define tag bit */
+#define NV_RDONLY	((nvflag_t)1 << 0)	/* readonly bit */
+#define NV_EXPORT	((nvflag_t)1 << 13)	/* export bit */
+#define NV_TAGGED	((nvflag_t)1 << 15)	/* user define tag bit */
 
 /* The following are used with NV_INTEGER */
-#define NV_SHORT	(NV_RJUST)	/* when integers are not long */
-#define NV_LONG		(NV_UTOL)	/* for long long and long double */
-#define NV_UNSIGN	(NV_LTOU)	/* for unsigned quantities */
+#define NV_SHORT	(NV_RJUST)		/* when integers are not long */
+#define NV_LONG		(NV_UTOL)		/* for long long and long double */
+#define NV_UNSIGN	(NV_LTOU)		/* for unsigned quantities */
 #define NV_DOUBLE	(NV_INTEGER|NV_ZFILL)	/* for floating point */
-#define NV_EXPNOTE	(NV_LJUST)	/* for scientific notation */
-#define NV_HEXFLOAT	(NV_LTOU)	/* for C99 base16 float notation */
-#define NV_FLTSIZEZERO	-1		/* a float with size of 0 being <0 */
+#define NV_EXPNOTE	(NV_LJUST)		/* for scientific notation */
+#define NV_HEXFLOAT	(NV_LTOU)		/* for C99 base16 float notation */
+#define NV_FLTSIZEZERO	-1			/* a float with size of 0 being <0 */
 
-/* options for nv_open */
+/* options of nv_open. */
+#define NV_APPEND	((nvflag_t)1 << 32)	/* append value */
+#define NV_MOVE		((nvflag_t)1 << 43)	/* for use with nv_clone */
+#define NV_ADD		((nvflag_t)1 << 45)	/* add node if not found */
+#define NV_ASSIGN	NV_NOFREE		/* assignment is possible */
+#define NV_NOARRAY	((nvflag_t)1 << 37)	/* array name not possible */
+#define NV_IARRAY	((nvflag_t)1 << 38)	/* for indexed array */
+#define NV_NOREF	NV_REF			/* don't follow reference */
+#define NV_IDENT	((nvflag_t)1 << 7)	/* name must be identifier */
+#define NV_VARNAME	((nvflag_t)1 << 33)	/* name must be ?(.)id*(.id) */
+#define NV_NOADD	((nvflag_t)1 << 34)	/* do not add node */
+#define NV_NOSCOPE	((nvflag_t)1 << 35)	/* look only in current scope */
+#define NV_NOFAIL	((nvflag_t)1 << 36)	/* return 0 on failure, no msg */
+#define NV_NODISC	NV_IDENT		/* ignore disciplines */
+#define NV_UNATTR	((nvflag_t)1 << 39)	/* unset attributes before assignment */
+#define NV_GLOBAL	((nvflag_t)1 << 44)	/* create global variable, ignoring local scope */
+/* Moved here from name.h */
+#define NV_TYPE		((nvflag_t)1 << 40)
+#define NV_STATIC	((nvflag_t)1 << 41)
+#define NV_COMVAR	((nvflag_t)1 << 42)
+#define NV_FARRAY	((nvflag_t)1 << 46)	/* fixed-size arrays */
+/* Mask for flags pertaining to nv_open */
 
-#define NV_APPEND	0x10000		/* append value */
-#define NV_MOVE		0x8000000	/* for use with nv_clone */
-#define NV_ADD		8
-					/* add node if not found */
-#define NV_ASSIGN	NV_NOFREE	/* assignment is possible */
-#define NV_NOARRAY	0x200000	/* array name not possible */
-#define NV_IARRAY	0x400000	/* for indexed array */
-#define NV_NOREF	NV_REF		/* don't follow reference */
-#define NV_IDENT	0x80		/* name must be identifier */
-#define NV_VARNAME	0x20000		/* name must be ?(.)id*(.id) */
-#define NV_NOADD	0x40000		/* do not add node */
-#define NV_NOSCOPE	0x80000		/* look only in current scope */
-#define NV_NOFAIL	0x100000	/* return 0 on failure, no msg */
-#define NV_NODISC	NV_IDENT	/* ignore disciplines */
-#define NV_UNATTR	0x800000	/* unset attributes before assignment */
-#define NV_GLOBAL	0x20000000	/* create global variable, ignoring local scope */
-
-#define NV_FUNCT	NV_IDENT	/* option for nv_create */
-#define NV_BLTINOPT	NV_ZFILL	/* mark builtins in libcmd */
+#define NV_FUNCT	NV_IDENT		/* option for nv_create */
+#define NV_BLTINOPT	NV_ZFILL		/* mark builtins in libcmd */
 
 #define NV_PUBLIC	(~(NV_NOSCOPE|NV_ASSIGN|NV_IDENT|NV_VARNAME|NV_NOADD))
 
@@ -269,8 +279,8 @@ struct Namval
 
 /* prototype for array interface */
 extern Namarr_t	*nv_arrayptr(Namval_t*);
-extern Namarr_t	*nv_setarray(Namval_t*,void*(*)(Namval_t*,const char*,int));
-extern void	*nv_associative(Namval_t*,const char*,int);
+extern Namarr_t	*nv_setarray(Namval_t*,void*(*)(Namval_t*,const char*,nvflag_t));
+extern void	*nv_associative(Namval_t*,const char*,nvflag_t);
 extern int	nv_aindex(Namval_t*);
 extern int	nv_nextsub(Namval_t*);
 extern char	*nv_getsub(Namval_t*);
@@ -279,10 +289,10 @@ extern Namval_t	*nv_opensub(Namval_t*);
 
 /* name-value pair function prototypes */
 extern int		nv_adddisc(Namval_t*, const char**, Namval_t**);
-extern int		nv_clone(Namval_t*, Namval_t*, int);
+extern int		nv_clone(Namval_t*, Namval_t*, nvflag_t);
 extern void		*nv_context(Namval_t*);
-extern Namval_t		*nv_create(const char*, Dt_t*, int,Namfun_t*);
-extern void		nv_delete(Namval_t*, Dt_t*, int);
+extern Namval_t		*nv_create(const char*, Dt_t*, nvflag_t,Namfun_t*);
+extern void		nv_delete(Namval_t*, Dt_t*, nvflag_t);
 extern Dt_t		*nv_dict(Namval_t*);
 extern Sfdouble_t	nv_getn(Namval_t*, Namfun_t*);
 extern Sfdouble_t	nv_getnum(Namval_t*);
@@ -293,23 +303,23 @@ extern int		nv_isnull(Namval_t*);
 extern Namfun_t		*nv_isvtree(Namval_t*);
 extern Namval_t		*nv_lastdict(void);
 extern Namval_t		*nv_mkinttype(char*, size_t, int, const char*, Namdisc_t*);
-extern void 		nv_newattr(Namval_t*,unsigned,ssize_t);
+extern void 		nv_newattr(Namval_t*,nvflag_t,ssize_t);
 extern void 		nv_newtype(Namval_t*);
-extern Namval_t		*nv_open(const char*,Dt_t*,int);
-extern void 		nv_putval(Namval_t*,const char*,int);
-extern void 		nv_putv(Namval_t*,const char*,int,Namfun_t*);
-extern int		nv_rename(Namval_t*,int);
+extern Namval_t		*nv_open(const char*,Dt_t*,nvflag_t);
+extern void 		nv_putval(Namval_t*,const char*,nvflag_t);
+extern void 		nv_putv(Namval_t*,const char*,nvflag_t,Namfun_t*);
+extern int		nv_rename(Namval_t*,nvflag_t);
 extern void		nv_rehash(Namval_t*,void*);
-extern int		nv_scan(Dt_t*,void(*)(Namval_t*,void*),void*,int,int);
+extern int		nv_scan(Dt_t*,void(*)(Namval_t*,void*),void*,nvflag_t,nvflag_t);
 extern char 		*nv_setdisc(Namval_t*,const char*,Namval_t*,Namfun_t*);
-extern void		nv_setref(Namval_t*, Dt_t*,int);
-extern int		nv_settype(Namval_t*, Namval_t*, int);
+extern void		nv_setref(Namval_t*,Dt_t*,nvflag_t);
+extern int		nv_settype(Namval_t*,Namval_t*,nvflag_t);
 extern void 		nv_setvec(Namval_t*,int,int,char*[]);
 extern void		nv_setvtree(Namval_t*);
 extern size_t 		nv_setsize(Namval_t*,size_t);
-extern Namfun_t		*nv_disc(Namval_t*,Namfun_t*,int);
-extern void 		nv_unset(Namval_t*,int);
-extern Namval_t		*nv_search(const char *, Dt_t*, int);
+extern Namfun_t		*nv_disc(Namval_t*,Namfun_t*,nvflag_t);
+extern void 		nv_unset(Namval_t*,nvflag_t);
+extern Namval_t		*nv_search(const char *, Dt_t*, nvflag_t);
 extern char		*nv_name(Namval_t*);
 extern Namval_t		*nv_type(Namval_t*);
 extern void		nv_addtype(Namval_t*,const char*, Optdisc_t*, size_t);

--- a/src/cmd/ksh93/include/shell.h
+++ b/src/cmd/ksh93/include/shell.h
@@ -424,7 +424,7 @@ typedef struct Libcomp_s
 	char*		lib;
 	dev_t		dev;
 	ino_t		ino;
-	unsigned int	attr;
+	nvflag_t	attr;
 } Libcomp_t;
 extern Libcomp_t *liblist;
 

--- a/src/cmd/ksh93/include/shtable.h
+++ b/src/cmd/ksh93/include/shtable.h
@@ -29,20 +29,20 @@
 typedef struct shtable1
 {
 	const char	*sh_name;
-	const unsigned	sh_number;
+	const uint32_t	sh_number;
 } Shtable_t;
 
 struct shtable2
 {
 	const char	*sh_name;
-	const unsigned	sh_number;
+	const uint32_t	sh_number;
 	const char	*sh_value;
 };
 
 struct shtable3
 {
 	const char	*sh_name;
-	const unsigned	sh_number;
+	const uint32_t	sh_number;
 	int		(*sh_value)(int, char*[], Shbltin_t*);
 };
 

--- a/src/cmd/ksh93/nval.3
+++ b/src/cmd/ksh93/nval.3
@@ -23,10 +23,10 @@ Namdisc_t;
 .SS "OPENING/CLOSING"
 .nf
 .ft 5
-Namval_t 	*nv_open(const char *\fIname\fP, Dt_t *\fIdict\fP, int \fIflags\fP);
-Namval_t	*nv_create(const char *\fIname\fP,  Dt_t *\fIdict\fP, int \fIflags\fP, Namfun_t *\fIfp\fP);
+Namval_t 	*nv_open(const char *\fIname\fP, Dt_t *\fIdict\fP, nvflag_t \fIflags\fP);
+Namval_t	*nv_create(const char *\fIname\fP,  Dt_t *\fIdict\fP, nvflag_t \fIflags\fP, Namfun_t *\fIfp\fP);
 Namval_t	*nv_namptr(void *\fIptr\fP, size_t \fIindx\fP);
-void		nv_delete(Namval_t *\fInp\fP, Dt_t *\fIdict\fP, int \fInofree\fP);
+void		nv_delete(Namval_t *\fInp\fP, Dt_t *\fIdict\fP, nvflag_t \fInofree\fP);
 .ft R
 .fi
 .SS "GETTING AND SETTING VALUES"
@@ -35,9 +35,9 @@ void		nv_delete(Namval_t *\fInp\fP, Dt_t *\fIdict\fP, int \fInofree\fP);
 char		*nv_getval(Namval_t *\fInp\fP);
 Sfdouble_t	nv_getnum(Namval_t *\fInp\fP);
 char		*nv_name(Namval_t *\fInp\fP);
-void		nv_putval(Namval_t *\fInp\fP, const char *\fIval\fP, int \fIflags\fP);
-void		nv_unset(Namval_t *\fInp\fP, int \fIflags\fP);
-int		nv_clone(Namval_t *\fIsrc\fP, Namval_t *\fIdest\fP, int \fIflags\fP);
+void		nv_putval(Namval_t *\fInp\fP, const char *\fIval\fP, nvflag_t \fIflags\fP);
+void		nv_unset(Namval_t *\fInp\fP, nvflag_t \fIflags\fP);
+int		nv_clone(Namval_t *\fIsrc\fP, Namval_t *\fIdest\fP, nvflag_t \fIflags\fP);
 .ft R
 .fi
 .SS "ATTRIBUTES AND SIZE"
@@ -46,11 +46,11 @@ int		nv_clone(Namval_t *\fIsrc\fP, Namval_t *\fIdest\fP, int \fIflags\fP);
 int		nv_isnull(Namval_t *\fInp\fP);
 size_t		nv_setsize(Namval_t *\fInp\fP, size_t \fIsize\fP);
 size_t		nv_size(Namval_t *\fInp\fP);
-unsigned	nv_isattr(Namval_t *\fInp\fP, unsigned \fIflags\fP);
+unsigned	nv_isattr(Namval_t *\fInp\fP, nvflag_t \fIflags\fP);
 Namfun_t	*nv_isvtree(Namval_t *\fInp\fP);
-unsigned	nv_onattr(Namval_t *\fInp\fP, unsigned \fIflags\fP);
-unsigned	nv_offattr(Namval_t *\fInp\fP, unsigned \fIflags\fP);
-void		nv_newattr(Namval_t *\fInp\fP, unsigned \fIflags\fP, ssize_t \fIsize\fP);
+unsigned	nv_onattr(Namval_t *\fInp\fP, nvflag_t \fIflags\fP);
+unsigned	nv_offattr(Namval_t *\fInp\fP, nvflag_t \fIflags\fP);
+void		nv_newattr(Namval_t *\fInp\fP, nvflag_t \fIflags\fP, ssize_t \fIsize\fP);
 .ft R
 .fi
 
@@ -58,7 +58,7 @@ void		nv_newattr(Namval_t *\fInp\fP, unsigned \fIflags\fP, ssize_t \fIsize\fP);
 .nf
 .ft 5
 unsigned	nv_isarray(Namval_t *\fInp\fP);
-Namarr_t	*nv_setarray(Namval_t *\fInp\fP, void*(*\fIfun\fP)(Namval_t*, const char*, int));
+Namarr_t	*nv_setarray(Namval_t *\fInp\fP, void*(*\fIfun\fP)(Namval_t*, const char*, nvflag_t));
 Namarr_t	*nv_arrayptr(Namval_t *\fInp\fP);
 Namval_t	*nv_putsub(Namval_t *\fInp\fP, char *\fIname\fP, long \fImode\fP);
 Namval_t	*nv_opensub(Namval_t *\fInp\fP);
@@ -71,13 +71,13 @@ int		nv_aindex(Namval_t *\fInp\fP);
 .SS "DISCIPLINES"
 .nf
 .ft 5
-Namfun_t	*nv_disc(Namval_t *\fInp\fP, Namfun_t *\fIfp\fP, int \fIflags\fP);
+Namfun_t	*nv_disc(Namval_t *\fInp\fP, Namfun_t *\fIfp\fP, nvflag_t \fIflags\fP);
 Namfun_t	*nv_hasdisc(Namval_t *\fInp\fP, const Namdisc_t *\fIdp\fP);
 char		*nv_getv(Namval_t *\fInp\fP, Namfun_t *\fIfp\fP);
 Sfdouble_t	nv_getn(Namval_t *\fInp\fP, Namfun_t *\fIfp\fP);
-void		nv_putv(Namval_t *\fInp\fP, const char *\fIval\fP, int \fIflags\fP, Namfun_t *\fIfp\fP);
+void		nv_putv(Namval_t *\fInp\fP, const char *\fIval\fP, nvflag_t \fIflags\fP, Namfun_t *\fIfp\fP);
 char		*nv_setdisc(Namval_t *\fInp\fP, const char *\fIa\fP, Namval_t *\fIf\fP, Namfun_t *\fIfp\fP);
-char		*nv_adddisc(Namval_t *\fInp\fP, const char **\fInames\fP);
+char		*nv_adddisc(Namval_t *\fInp\fP, const char **\fInames\fP, Namval_t **\fPfuns\fP);
 const Namdisc_t	*nv_discfun(int \fIwhich\fP);
 .ft R
 .fi
@@ -85,7 +85,7 @@ const Namdisc_t	*nv_discfun(int \fIwhich\fP);
 .nf
 .ft 5
 Namval_t	*nv_type(Namval_t  *\fInp\fP);
-int		*nv_settype(Namval_t  *\fInp\fP, Namval_t *\fItp\fP, int \fIflags\fP);
+int		*nv_settype(Namval_t  *\fInp\fP, Namval_t *\fItp\fP, nvflag_t \fIflags\fP);
 Namval_t	*nv_mkinttype(char *\fIname\fP, size_t \fIsz\fP, int \fIus\fP, const char *\fIstr\fP, Namdisc_t *\fIdp\fP);
 void		nv_addtype(Namval_t *\fInp\fP, const char *\fIstr\fP, Optdisc_t* *\fIop\fP, size_t \fIsz\fP);
 .ft R
@@ -93,10 +93,10 @@ void		nv_addtype(Namval_t *\fInp\fP, const char *\fIstr\fP, Optdisc_t* *\fIop\fP
 .SS "MISCELLANEOUS FUNCTIONS"
 .nf
 .ft 5
-int		nv_scan(Dt_t *\fIdict\fP, void(*\fIfn\fP)(Namval_t*,void*), void *\fIdata\fP, int \fImask\fP, int \fIflags\fP);
+int		nv_scan(Dt_t *\fIdict\fP, void(*\fIfn\fP)(Namval_t*,void*), void *\fIdata\fP, nvflag_t \fImask\fP, nvflag_t \fIflags\fP);
 Dt_t		*nv_dict(Namval_t *\fInp\fP);
 void		nv_setvtree(Namval_t *\fInp\fP);
-void		nv_setref(Namval_t *\fInp\fP, Dt_t *\fIdp\fP, int \fIflags\fP);
+void		nv_setref(Namval_t *\fInp\fP, Dt_t *\fIdp\fP, nvflag_t \fIflags\fP);
 Namval_t	*nv_lastdict(void);
 .ft R
 .fi
@@ -189,7 +189,7 @@ Name-value pairs can also be allocated without belonging to
 a dictionary.  They will typically be looked up by a \fIcreate\fP
 discipline associated with a parent node.  In this case the
 node size will be \f3NV_MINSZ\fP and \fIn\fP nodes can be allocated
-vial \f3calloc(5NV_MINSZ,\fP\fIn\fP\f3)\fP(3).
+via \f3calloc(5NV_MINSZ,\fP\fIn\fP\f3)\fP(3).
 The \f3nv_namptr\fP function can be used on the pointer returned by
 \f3calloc\fP along with the element number to return the
 corresponding node.
@@ -376,15 +376,17 @@ can therefore be shared by several name-value pairs.
 It contains following public fields in the order listed:
 .nf
       \f3size_t	dsize;\fP
-      \f3void	(*putval)(Namval_t*,const char*,int,Namfun_t*);\fP
+      \f3void	(*putval)(Namval_t*,const char*,nvflag_t,Namfun_t*);\fP
       \f3char	*(*getval)(Namval_t*,Namfun_t*);\fP
       \f3double	(*getnum)(Namval_t*,Namfun_t*);\fP
       \f3char	*(*setdisc)(Namval_t*,const char*,Namval_t*,Namfun_t*);\fP
-      \f3Namval_t	*(*createf)(Namval_t*,const char*,Namfun_t*);\fP
-      \f3Namfun_t	*(*clonef)(Namval_t*,Namval_t*,int,Namfun_t*);\fP
+      \f3Namval_t	*(*createf)(Namval_t*,const char*,nvflag_t,Namfun_t*);\fP
+      \f3Namfun_t	*(*clonef)(Namval_t*,Namval_t*,nvflag_t,Namfun_t*);\fP
       \f3char	*(*namef)(Namval_t*,Namfun_t*);\fP
       \f3Namval_t	*(*nextf)(Namval_t*,Dt_t*,Namfun_t*);\fP
       \f3Namval_t	*(*typef)(Namval_t*,Namfun_t*);\fP
+      \f3Namval_t	*(*readf)(Namval_t*,Sfio_t*,int,Namfun_t*);\fP
+      \f3Namval_t	*(*writef)(Namval_t*,Sfio_t*,nvflag_t,Namfun_t*);\fP
 .fi
 The \f3Namfun_t\fP type contains a member named
 \f3disc\fP which points to a \f3Namdisc_t\fP structure.

--- a/src/cmd/ksh93/sh/arith.c
+++ b/src/cmd/ksh93/sh/arith.c
@@ -58,7 +58,7 @@ static Namval_t FunNode =
 	"?",
 };
 
-static Namval_t *scope(Namval_t *np,struct lval *lvalue,int assign)
+static Namval_t *scope(Namval_t *np,struct lval *lvalue,nvflag_t assign)
 {
 	int	flag = lvalue->flag;
 	char	*sub=0, *cp=(char*)np;
@@ -234,7 +234,7 @@ static Sfdouble_t arith(const char **ptr, struct lval *lvalue, int type, Sfdoubl
 	    case ASSIGN:
 	    {
 		Namval_t *np;
-		unsigned short attr;
+		nvflag_t attr;
 		if (lvalue->sub && lvalue->nosub > 0) /* indexed array ARITH_ASSIGNOP */
 		{
 			np = (Namval_t*)lvalue->sub; /* use saved subscript reference instead of last worked value */
@@ -307,7 +307,7 @@ static Sfdouble_t arith(const char **ptr, struct lval *lvalue, int type, Sfdoubl
 		if(isaletter(c))
 		{
 			Namval_t *np=0;
-			int dot=0;
+			nvflag_t dot=0;
 			while(1)
 			{
 				while(xp=str, c=mbchar(str), isaname(c));

--- a/src/cmd/ksh93/sh/array.c
+++ b/src/cmd/ksh93/sh/array.c
@@ -81,7 +81,7 @@ struct assoc_array
    static void array_fixed_setdata(Namval_t*,Namarr_t*,struct fixed_array*);
 #endif /* SHOPT_FIXEDARRAY */
 
-static Namarr_t *array_scope(Namarr_t *ap, int flags)
+static Namarr_t *array_scope(Namarr_t *ap, nvflag_t flags)
 {
 	Namarr_t *aq;
 #if SHOPT_FIXEDARRAY
@@ -273,7 +273,7 @@ int nv_arrayisset(Namval_t *np, Namarr_t *arp)
  * Delete space as necessary if flag is ARRAY_DELETE
  * After the lookup is done the last @ or * subscript is incremented
  */
-static Namval_t *array_find(Namval_t *np,Namarr_t *arp, int flag)
+static Namval_t *array_find(Namval_t *np,Namarr_t *arp, nvflag_t flag)
 {
 	struct index_array	*ap = (struct index_array*)arp;
 	void			**vpp;	/* pointer to value pointer */
@@ -409,7 +409,7 @@ static Namval_t *array_find(Namval_t *np,Namarr_t *arp, int flag)
 /*
  * for 'typeset -T' types
  */
-int nv_arraysettype(Namval_t *np, Namval_t *tp, const char *sub, int flags)
+int nv_arraysettype(Namval_t *np, Namval_t *tp, const char *sub, nvflag_t flags)
 {
 	Namval_t	*nq;
 	Namarr_t	*ap = nv_arrayptr(np);
@@ -437,7 +437,7 @@ int nv_arraysettype(Namval_t *np, Namval_t *tp, const char *sub, int flags)
 }
 
 
-static Namfun_t *array_clone(Namval_t *np, Namval_t *mp, int flags, Namfun_t *fp)
+static Namfun_t *array_clone(Namval_t *np, Namval_t *mp, nvflag_t flags, Namfun_t *fp)
 {
 	Namarr_t		*ap = (Namarr_t*)fp;
 	Namval_t		*nq, *mq;
@@ -590,7 +590,7 @@ static Sfdouble_t array_getnum(Namval_t *np, Namfun_t *disc)
 	return nv_getn(np,&ap->hdr);
 }
 
-static void array_putval(Namval_t *np, const char *string, int flags, Namfun_t *dp)
+static void array_putval(Namval_t *np, const char *string, nvflag_t flags, Namfun_t *dp)
 {
 	Namarr_t	*ap = (Namarr_t*)dp;
 	void		**vpp;	/* pointer to value pointer */
@@ -916,7 +916,7 @@ Namarr_t *nv_arrayptr(Namval_t *np)
  * Verify that argument is an indexed array and convert to associative,
  * freeing relevant storage
  */
-static Namarr_t *nv_changearray(Namval_t *np, void *(*fun)(Namval_t*,const char*,int))
+static Namarr_t *nv_changearray(Namval_t *np, void *(*fun)(Namval_t*,const char*,nvflag_t))
 {
 	Namarr_t *ap;
 	char numbuff[NUMSIZE+1];
@@ -962,7 +962,7 @@ static Namarr_t *nv_changearray(Namval_t *np, void *(*fun)(Namval_t*,const char*
  * set the associative array processing method for node <np> to <fun>
  * The array pointer is returned if successful.
  */
-Namarr_t *nv_setarray(Namval_t *np, void *(*fun)(Namval_t*,const char*,int))
+Namarr_t *nv_setarray(Namval_t *np, void *(*fun)(Namval_t*,const char*,nvflag_t))
 {
 	Namarr_t	*ap;
 	char		*value=0;
@@ -1480,7 +1480,7 @@ skip:
  * process an array subscript for node <np> given the subscript <cp>
  * returns pointer to character after the subscript
  */
-char *nv_endsubscript(Namval_t *np, char *cp, int mode)
+char *nv_endsubscript(Namval_t *np, char *cp, nvflag_t mode)
 {
 	int quoted=0;
 	char c;
@@ -1650,10 +1650,10 @@ ssize_t nv_aimax(Namval_t* np)
 /*
  *  This is the default implementation for associative arrays
  */
-void *nv_associative(Namval_t *np,const char *sp,int mode)
+void *nv_associative(Namval_t *np,const char *sp,nvflag_t mode)
 {
 	struct assoc_array *ap = (struct assoc_array*)nv_arrayptr(np);
-	int type;
+	nvflag_t type;
 	switch(mode)
 	{
 	    case NV_AINIT:

--- a/src/cmd/ksh93/sh/deparse.c
+++ b/src/cmd/ksh93/sh/deparse.c
@@ -39,10 +39,10 @@
 #define POST	2
 
 /* flags that can be specified with p_tree() */
-#define NO_NEWLINE	(1 << 0)
-#define NEED_BRACE	(1 << 1)
-#define NO_BRACKET	(1 << 2)
-#define PROC_SUBST	(1 << 3)
+#define NO_NEWLINE	(1U << 0)
+#define NEED_BRACE	(1U << 1)
+#define NO_BRACKET	(1U << 2)
+#define PROC_SUBST	(1U << 3)
 
 static void p_comlist(const struct dolnod*,int);
 static void p_arg(const struct argnod*, int endchar, int opts);
@@ -51,7 +51,7 @@ static void p_keyword(const char*,int);
 static void p_redirect(const struct ionod*);
 static void p_switch(const struct regnod*);
 static void here_body(const struct ionod*);
-static void p_tree(const Shnode_t*,int);
+static void p_tree(const Shnode_t*,uint32_t);
 
 static int level;
 static int begin_line;
@@ -62,7 +62,7 @@ static const struct ionod *here_doc;
 static Sfio_t *outfile;
 static const char *forinit = "";
 
-void sh_deparse(Sfio_t *out, const Shnode_t *t,int tflags, int initlevel)
+void sh_deparse(Sfio_t *out, const Shnode_t *t,uint32_t tflags, int initlevel)
 {
 	int firstnodetype = t->tre.tretyp & COMMSK;
 	char needouterbrace = (tflags & NEED_BRACE) && firstnodetype != TLST && (!(tflags & NV_FPOSIX) || firstnodetype != TPAR);
@@ -78,12 +78,12 @@ void sh_deparse(Sfio_t *out, const Shnode_t *t,int tflags, int initlevel)
 /*
  * print script corresponding to shell tree <t>
  */
-static void p_tree(const Shnode_t *t,int tflags)
+static void p_tree(const Shnode_t *t,uint32_t tflags)
 {
 	char *cp=0;
-	int save = end_line;
-	int needbrace = (tflags&NEED_BRACE);
-	int procsub = (tflags&PROC_SUBST);
+	int save = end_line, e;
+	uint32_t needbrace = (tflags&NEED_BRACE);
+	uint32_t procsub = (tflags&PROC_SUBST);
 	tflags &= ~NEED_BRACE;
 	if(tflags&NO_NEWLINE)
 		end_line = ' ';
@@ -281,10 +281,10 @@ static void p_tree(const Shnode_t *t,int tflags)
 			if(t->for_.forlst)
 			{
 				sfputr(outfile,"in",' ');
-				tflags = end_line;
+				e = end_line;
 				end_line = '\n';
 				p_comarg(t->for_.forlst);
-				end_line = tflags;
+				end_line = e;
 			}
 			else
 				sfputc(outfile,'\n');
@@ -303,10 +303,10 @@ static void p_tree(const Shnode_t *t,int tflags)
 			{
 				begin_line = 1;
 				sfputr(outfile,"in",'\n');
-				tflags = end_line;
+				e = end_line;
 				end_line = '\n';
 				p_switch(t->sw.swlst);
-				end_line = tflags;
+				end_line = e;
 			}
 			p_keyword("esac",END);
 			break;
@@ -323,7 +323,7 @@ static void p_tree(const Shnode_t *t,int tflags)
 				if(t->funct.functargs)
 				{
 					/* function reference list (for .sh.math.* functions) */
-					int e = end_line;
+					e = end_line;
 					sfputc(outfile,' ');
 					end_line = '\n';
 					p_comarg(t->funct.functargs);

--- a/src/cmd/ksh93/sh/deparse.c
+++ b/src/cmd/ksh93/sh/deparse.c
@@ -51,7 +51,7 @@ static void p_keyword(const char*,int);
 static void p_redirect(const struct ionod*);
 static void p_switch(const struct regnod*);
 static void here_body(const struct ionod*);
-static void p_tree(const Shnode_t*,uint32_t);
+static void p_tree(const Shnode_t*,uint64_t);
 
 static int level;
 static int begin_line;
@@ -62,7 +62,7 @@ static const struct ionod *here_doc;
 static Sfio_t *outfile;
 static const char *forinit = "";
 
-void sh_deparse(Sfio_t *out, const Shnode_t *t,uint32_t tflags, int initlevel)
+void sh_deparse(Sfio_t *out, const Shnode_t *t,uint64_t tflags, int initlevel)
 {
 	int firstnodetype = t->tre.tretyp & COMMSK;
 	char needouterbrace = (tflags & NEED_BRACE) && firstnodetype != TLST && (!(tflags & NV_FPOSIX) || firstnodetype != TPAR);
@@ -78,12 +78,12 @@ void sh_deparse(Sfio_t *out, const Shnode_t *t,uint32_t tflags, int initlevel)
 /*
  * print script corresponding to shell tree <t>
  */
-static void p_tree(const Shnode_t *t,uint32_t tflags)
+static void p_tree(const Shnode_t *t,uint64_t tflags)
 {
 	char *cp=0;
 	int save = end_line, e;
-	uint32_t needbrace = (tflags&NEED_BRACE);
-	uint32_t procsub = (tflags&PROC_SUBST);
+	uint64_t needbrace = (tflags&NEED_BRACE);
+	uint64_t procsub = (tflags&PROC_SUBST);
 	tflags &= ~NEED_BRACE;
 	if(tflags&NO_NEWLINE)
 		end_line = ' ';

--- a/src/cmd/ksh93/sh/deparse.c
+++ b/src/cmd/ksh93/sh/deparse.c
@@ -51,7 +51,7 @@ static void p_keyword(const char*,int);
 static void p_redirect(const struct ionod*);
 static void p_switch(const struct regnod*);
 static void here_body(const struct ionod*);
-static void p_tree(const Shnode_t*,uint64_t);
+static void p_tree(const Shnode_t*,nvflag_t);
 
 static int level;
 static int begin_line;
@@ -62,7 +62,7 @@ static const struct ionod *here_doc;
 static Sfio_t *outfile;
 static const char *forinit = "";
 
-void sh_deparse(Sfio_t *out, const Shnode_t *t,uint64_t tflags, int initlevel)
+void sh_deparse(Sfio_t *out, const Shnode_t *t,nvflag_t tflags, int initlevel)
 {
 	int firstnodetype = t->tre.tretyp & COMMSK;
 	char needouterbrace = (tflags & NEED_BRACE) && firstnodetype != TLST && (!(tflags & NV_FPOSIX) || firstnodetype != TPAR);
@@ -78,12 +78,12 @@ void sh_deparse(Sfio_t *out, const Shnode_t *t,uint64_t tflags, int initlevel)
 /*
  * print script corresponding to shell tree <t>
  */
-static void p_tree(const Shnode_t *t,uint64_t tflags)
+static void p_tree(const Shnode_t *t,nvflag_t tflags)
 {
 	char *cp=0;
 	int save = end_line, e;
-	uint64_t needbrace = (tflags&NEED_BRACE);
-	uint64_t procsub = (tflags&PROC_SUBST);
+	uint32_t needbrace = (tflags&NEED_BRACE);
+	uint32_t procsub = (tflags&PROC_SUBST);
 	tflags &= ~NEED_BRACE;
 	if(tflags&NO_NEWLINE)
 		end_line = ' ';

--- a/src/cmd/ksh93/sh/init.c
+++ b/src/cmd/ksh93/sh/init.c
@@ -290,7 +290,7 @@ char *sh_getcwd(void)
 
 #if SHOPT_VSH || SHOPT_ESH
 /* Trap for VISUAL and EDITOR variables */
-static void put_ed(Namval_t *np,const char *val,int flags,Namfun_t *fp)
+static void put_ed(Namval_t* np,const char *val,nvflag_t flags,Namfun_t *fp)
 {
 	const char *cp, *name=nv_name(np);
 	uint64_t newopt=0;
@@ -330,7 +330,7 @@ done:
 #endif /* SHOPT_VSH || SHOPT_ESH */
 
 /* Trap for HISTFILE and HISTSIZE variables */
-static void put_history(Namval_t *np,const char *val,int flags,Namfun_t *fp)
+static void put_history(Namval_t* np,const char *val,nvflag_t flags,Namfun_t *fp)
 {
 	void 	*histopen = sh.hist_ptr;
 	char	*cp;
@@ -353,7 +353,7 @@ static void put_history(Namval_t *np,const char *val,int flags,Namfun_t *fp)
 }
 
 /* Trap for OPTINDEX */
-static void put_optindex(Namval_t *np,const char *val,int flags,Namfun_t *fp)
+static void put_optindex(Namval_t* np,const char *val,nvflag_t flags,Namfun_t *fp)
 {
 	sh.st.opterror = sh.st.optchar = 0;
 	nv_putv(np, val, flags, fp);
@@ -368,7 +368,7 @@ static Sfdouble_t nget_optindex(Namval_t *np, Namfun_t *fp)
 	return (Sfdouble_t)*lp;
 }
 
-static Namfun_t *clone_optindex(Namval_t *np, Namval_t *mp, int flags, Namfun_t *fp)
+static Namfun_t *clone_optindex(Namval_t* np, Namval_t *mp, nvflag_t flags, Namfun_t *fp)
 {
 	Namfun_t *dp = (Namfun_t*)sh_malloc(sizeof(Namfun_t));
 	NOT_USED(flags);
@@ -380,7 +380,7 @@ static Namfun_t *clone_optindex(Namval_t *np, Namval_t *mp, int flags, Namfun_t 
 
 
 /* Trap for restricted variables FPATH, PATH, SHELL, ENV */
-static void put_restricted(Namval_t *np,const char *val,int flags,Namfun_t *fp)
+static void put_restricted(Namval_t* np,const char *val,nvflag_t flags,Namfun_t *fp)
 {
 	int	path_scoped = 0, fpath_scoped=0;
 	char	*name = nv_name(np);
@@ -420,7 +420,7 @@ static void put_restricted(Namval_t *np,const char *val,int flags,Namfun_t *fp)
 	}
 }
 
-static void put_cdpath(Namval_t *np,const char *val,int flags,Namfun_t *fp)
+static void put_cdpath(Namval_t* np,const char *val,nvflag_t flags,Namfun_t *fp)
 {
 	nv_putv(np, val, flags, fp);
 	if(!sh.cdpathlist)
@@ -430,7 +430,7 @@ static void put_cdpath(Namval_t *np,const char *val,int flags,Namfun_t *fp)
 }
 
 /* Trap for the LC_* and LANG variables */
-static void put_lang(Namval_t *np,const char *val,int flags,Namfun_t *fp)
+static void put_lang(Namval_t* np,const char *val,nvflag_t flags,Namfun_t *fp)
 {
 	int type;
 	char *name = nv_name(np);
@@ -482,7 +482,7 @@ static void put_lang(Namval_t *np,const char *val,int flags,Namfun_t *fp)
 }
 
 /* Trap for IFS assignment and invalidates state table */
-static void put_ifs(Namval_t *np,const char *val,int flags,Namfun_t *fp)
+static void put_ifs(Namval_t* np,const char *val,nvflag_t flags,Namfun_t *fp)
 {
 	struct ifs *ip = (struct ifs*)fp;
 	ip->ifsnp = 0;
@@ -556,7 +556,7 @@ static char* get_ifs(Namval_t *np, Namfun_t *fp)
 #define dtime(tp) ((double)((tp)->tv_sec)+1e-6*((double)((tp)->tv_usec)))
 #define tms	timeval
 
-static void put_seconds(Namval_t *np,const char *val,int flags,Namfun_t *fp)
+static void put_seconds(Namval_t* np,const char *val,nvflag_t flags,Namfun_t *fp)
 {
 	double d;
 	double *dp = np->nvalue;
@@ -618,7 +618,7 @@ static void seed_rand_uint(struct rand *rp, unsigned int seed)
 /*
  * These four functions are used to get and set the RANDOM variable
  */
-static void put_rand(Namval_t *np,const char *val,int flags,Namfun_t *fp)
+static void put_rand(Namval_t* np,const char *val,nvflag_t flags,Namfun_t *fp)
 {
 	struct rand *rp = (struct rand*)fp;
 	Sfdouble_t n;
@@ -676,7 +676,7 @@ void sh_reseed_rand(struct rand *rp)
  * The following three functions are for SRANDOM
  */
 
-static void put_srand(Namval_t *np,const char *val,int flags,Namfun_t *fp)
+static void put_srand(Namval_t* np,const char *val,nvflag_t flags,Namfun_t *fp)
 {
 	if(!val)  /* unset */
 	{
@@ -724,7 +724,7 @@ static Sfdouble_t nget_lineno(Namval_t *np, Namfun_t *fp)
 	return (Sfdouble_t)d;
 }
 
-static void put_lineno(Namval_t *np,const char *val,int flags,Namfun_t *fp)
+static void put_lineno(Namval_t* np,const char *val,nvflag_t flags,Namfun_t *fp)
 {
 	Sfdouble_t n;
 	if(!val)
@@ -758,7 +758,7 @@ static char* get_lastarg(Namval_t *np, Namfun_t *fp)
 	return sh.lastarg;
 }
 
-static void put_lastarg(Namval_t *np,const char *val,int flags,Namfun_t *fp)
+static void put_lastarg(Namval_t* np,const char *val,nvflag_t flags,Namfun_t *fp)
 {
 	NOT_USED(fp);
 	if(flags&NV_INTEGER)
@@ -1057,7 +1057,7 @@ static void math_init(void)
 	}
 }
 
-static Namval_t *create_math(Namval_t *np,const char *name,int flag,Namfun_t *fp)
+static Namval_t *create_math(Namval_t *np,const char *name,nvflag_t flag,Namfun_t *fp)
 {
 	NOT_USED(np);
 	NOT_USED(flag);
@@ -1483,7 +1483,7 @@ void sh_reinit(void)
 	/* Unset all variables (don't delete yet) */
 	for(np = dtfirst(sh.var_tree); np; np = npnext)
 	{
-		int	nofree;
+		nvflag_t nofree;
 		npnext = (Namval_t*)dtnext(sh.var_tree,np);
 		if(np==DOTSHNOD || np==L_ARGNOD)	/* TODO: unset these without crashing */
 			continue;
@@ -1598,7 +1598,7 @@ static Namval_t *next_stat(Namval_t *np, Dt_t *root,Namfun_t *fp)
 	return nv_namptr(sp->nodes,sp->current);
 }
 
-static Namval_t *create_stat(Namval_t *np,const char *name,int flag,Namfun_t *fp)
+static Namval_t *create_stat(Namval_t *np,const char *name,nvflag_t flag,Namfun_t *fp)
 {
 	struct Stats		*sp = (struct Stats*)fp;
 	const char		*cp=name;
@@ -1964,7 +1964,7 @@ struct Mapchar
 	int		lctype;
 };
 
-static void put_trans(Namval_t *np,const char *val,int flags,Namfun_t *fp)
+static void put_trans(Namval_t* np,const char *val,nvflag_t flags,Namfun_t *fp)
 {
 	struct Mapchar *mp = (struct Mapchar*)fp;
 	int c;

--- a/src/cmd/ksh93/sh/macro.c
+++ b/src/cmd/ksh93/sh/macro.c
@@ -1185,7 +1185,8 @@ static int varsub(Mac_t *mp)
 	ptrdiff_t	vsize = -1;
 	char		idbuff[3], *id = idbuff, *pattern=0, *repstr=0, *arrmax=0;
 	char		*idx = 0;
-	int		var=1,addsub=0,idnum=0,nvflag=0;
+	int		var=1,addsub=0,idnum=0;
+	nvflag_t	nvflag=0;
 	char		oldpat=mp->pattern;
 	Stk_t		*stkp = sh.stk;
 	size_t		replen=0;

--- a/src/cmd/ksh93/sh/name.c
+++ b/src/cmd/ksh93/sh/name.c
@@ -79,7 +79,7 @@ struct sh_type
 		Namval_t	*np;
 		Namval_t	*last_table;
 		Namval_t	*namespace;
-		int		flags;
+		nvflag_t	flags;
 		size_t		size;
 		size_t		len;
 	} entries[NVCACHE];
@@ -215,7 +215,7 @@ Namval_t *nv_addnode(Namval_t* np, int remove)
  * Perform parameter assignment for a linked list of parameters
  * <flags> contains attributes for the parameters
  */
-void nv_setlist(struct argnod *arg,int flags, Namval_t *typ)
+void nv_setlist(struct argnod *arg,nvflag_t flags, Namval_t *typ)
 {
 	char		*cp;
 	Namval_t	*np, *mp;
@@ -223,11 +223,11 @@ void nv_setlist(struct argnod *arg,int flags, Namval_t *typ)
 	char		*trap=sh.st.trap[SH_DEBUGTRAP];
 	char		*prefix = sh.prefix;
 	int		traceon = (sh_isoption(SH_XTRACE)!=0);
-	int		array = (flags&(NV_ARRAY|NV_IARRAY));
+	nvflag_t	array = (flags&(NV_ARRAY|NV_IARRAY));
 	Namarr_t	*ap;
 	Namval_t	node;
 	struct Namref	nr;
-	int		maketype = flags&NV_TYPE;  /* make a 'typeset -T' type definition command */
+	nvflag_t	maketype = flags&NV_TYPE;  /* make a 'typeset -T' type definition command */
 	struct sh_type	shtp;
 	Dt_t		*vartree, *save_vartree = NULL;
 #if SHOPT_NAMESPACE
@@ -278,7 +278,7 @@ void nv_setlist(struct argnod *arg,int flags, Namval_t *typ)
 			stkseek(sh.stk,0);
 			if(*arg->argval==0 && arg->argchn.ap && !(arg->argflag&~(ARG_APPEND|ARG_QUOTED|ARG_MESSAGE|ARG_ARRAY)))
 			{
-				int flag = (NV_VARNAME|NV_ARRAY|NV_ASSIGN);
+				nvflag_t flag = (NV_VARNAME|NV_ARRAY|NV_ASSIGN);
 				ssize_t sub=0;
 				struct fornod *fp=(struct fornod*)arg->argchn.ap;
 				Shnode_t *tp=fp->fortre;
@@ -445,7 +445,7 @@ void nv_setlist(struct argnod *arg,int flags, Namval_t *typ)
 							nv_putsub(np, NULL, ARRAY_SCAN);
 							if(!ap->fun && !(ap->nelem&ARRAY_TREE) && !np->nvfun->next && !nv_type(np))
 							{
-								unsigned short nvflag = np->nvflag;
+								nvflag_t nvflag = np->nvflag;
 								size_t nvsize = np->nvsize;
 								nv_unset(np,NV_EXPORT);
 								np->nvflag = nvflag;
@@ -747,15 +747,14 @@ static char *stack_extend(const char *cname, char *cp, ptrdiff_t n)
 	return (char*)name;
 }
 
-Namval_t *nv_create(const char *name,  Dt_t *root, int flags, Namfun_t *dp)
+Namval_t *nv_create(const char *name,  Dt_t *root, nvflag_t flags, Namfun_t *dp)
 {
 	char			*sub=0, *cp=(char*)name, *sp, *xp;
 	int			c;
 	Namval_t		*np=0, *nq=0;
 	Namfun_t		*fp=0;
-	long			mode, add=0;
-	int			isref,top=0,noscope=(flags&NV_NOSCOPE);
-	int			nofree=0, level=0;
+	nvflag_t		mode, add=0, nofree=0, noscope=(flags&NV_NOSCOPE);
+	int			isref,top=0,level=0;
 	ptrdiff_t		copy=0;
 	Namarr_t		*ap;
 	if(root==sh.var_tree)
@@ -1069,7 +1068,7 @@ Namval_t *nv_create(const char *name,  Dt_t *root, int flags, Namfun_t *dp)
 #endif /* SHOPT_FIXEDARRAY */
 				if(c=='[' || (c=='.' && nv_isarray(np)))
 				{
-					uint64_t nvflags = 0;
+					nvflag_t nvflags = 0;
 					int idx = -2;  /* later on we need to know if nv_aindex returned 0, so this must be negative */
 					sh.nv_putsub_already_called_sh_arith = 0;
 					sub = 0;
@@ -1236,7 +1235,7 @@ Namval_t *nv_create(const char *name,  Dt_t *root, int flags, Namfun_t *dp)
 					nv_putsub(np,NULL,ARRAY_UNDEF);
 				}
 				nv_onattr(np,nofree);
-				nofree  = 0;
+				nofree = 0;
 				if(c=='.' && (fp=np->nvfun))
 				{
 					for(; fp; fp=fp->next)
@@ -1287,7 +1286,7 @@ Namval_t *nv_create(const char *name,  Dt_t *root, int flags, Namfun_t *dp)
  * if flags contains NV_REF, does not set NullNode to avoid defeating nameref loop detection
  * if np==0 && !root && flags==0, delete the Refdict dictionary
  */
-void nv_delete(Namval_t* np, Dt_t *root, int flags)
+void nv_delete(Namval_t* np, Dt_t *root, nvflag_t flags)
 {
 #if NVCACHE
 	int			c;
@@ -1358,13 +1357,13 @@ void nv_delete(Namval_t* np, Dt_t *root, int flags)
  * If <flags> & NV_UNATTR then unset attributes before assignment
  * SH_INIT is only set while initializing the environment
  */
-Namval_t *nv_open(const char *name, Dt_t *root, int flags)
+Namval_t *nv_open(const char *name, Dt_t *root, nvflag_t flags)
 {
 	char			*cp=(char*)name;
 	ssize_t			c;
 	Namval_t		*np=0;
 	Namfun_t		fun;
-	int			append=0;
+	nvflag_t		append=0;
 	const char		*msg = e_varname;
 	char			*fname = 0;
 	ptrdiff_t		offset = stktell(sh.stk);
@@ -1389,14 +1388,14 @@ Namval_t *nv_open(const char *name, Dt_t *root, int flags)
 			fname = strrchr(cp,'.');
 			*fname = 0;
 			fun.nofree |= 1;
-			flags &=  ~NV_IDENT;
+			flags &= ~NV_IDENT;
 			funroot = root;
 			root = sh.var_tree;
 		}
 	}
 	else if(!(flags&(NV_IDENT|NV_VARNAME|NV_ASSIGN)))
 	{
-		long mode = ((flags&NV_NOADD)?0:NV_ADD);
+		nvflag_t mode = ((flags&NV_NOADD)?0:NV_ADD);
 		if(flags&NV_NOSCOPE)
 			mode |= NV_NOSCOPE;
 		np = nv_search(name,root,mode);
@@ -1492,7 +1491,7 @@ nocache:
 #endif
 	if(fname)
 	{
-		int32_t f = (flags&NV_NOSCOPE)|((flags&NV_NOADD)?0:NV_ADD);
+		nvflag_t f = (flags&NV_NOSCOPE)|((flags&NV_NOADD)?0:NV_ADD);
 		*fname = '.';
 		np = nv_search(name, funroot, f);
 		*fname = 0;
@@ -1524,7 +1523,8 @@ skip:
 			char *sub=0, *prefix= sh.prefix;
 			Namval_t *mp;
 			Namarr_t *ap;
-			int isref, f;
+			int isref;
+			nvflag_t f;
 			sh.prefix = 0;
 			if((flags&NV_STATIC) && !sh.mktype)
 			{
@@ -1576,7 +1576,7 @@ skip:
 			savesub = sub;
 			sh.prefix = prefix;
 		}
-		nv_onattr(np, flags&NV_ATTRIBUTES);
+		nv_onattr(np, flags&~(NV_ATTRIBUTES|NV_OPENMASK));
 	}
 	else if(c)
 	{
@@ -1608,7 +1608,7 @@ static char savechars[8+1];
  * If <flags> contains NV_NOFREE, previous value is freed, and <sp>
  * becomes value of node and <flags> becomes attributes.
  */
-void nv_putval(Namval_t *np, const char *sp, int flags)
+void nv_putval(Namval_t *np, const char *sp, nvflag_t flags)
 {
 	void		**vpp;	/* pointer to value pointer */
 	size_t		size = 0;
@@ -2183,15 +2183,15 @@ char **sh_envgen(void)
 struct scan
 {
 	void    (*scanfn)(Namval_t*, void*);
-	int     scanmask;
-	int     scanflags;
+	nvflag_t scanmask;
+	nvflag_t scanflags;
 	int     scancount;
 	void    *scandata;
 };
 
 static int scanfilter(Namval_t *np, struct scan *sp)
 {
-	int k=np->nvflag;
+	nvflag_t k=np->nvflag;
 	struct adata *tp = (struct adata*)sp->scandata;
 	char	*cp;
 	if(!is_abuiltin(np) && tp && tp->tp && nv_type(np)!=tp->tp)
@@ -2246,7 +2246,7 @@ void nv_rehash(Namval_t *np,void *data)
  *	more of <flags> is visited
  * If <mask> and <flags> are zero, then all nodes are visited
  */
-int nv_scan(Dt_t *root, void (*fn)(Namval_t*,void*), void *data,int mask, int flags)
+int nv_scan(Dt_t *root, void (*fn)(Namval_t*,void*), void *data,nvflag_t mask, nvflag_t flags)
 {
 	Namval_t *np;
 	Dt_t *base=0;
@@ -2295,7 +2295,7 @@ void sh_scope(struct argnod *envlist, int fun)
 	sh.var_tree = newscope;
 }
 
-static void table_unset(Dt_t *root, int flags, Dt_t *oroot)
+static void table_unset(Dt_t *root, nvflag_t flags, Dt_t *oroot)
 {
 	Namval_t *np,*nq, *npnext;
 	for(np=(Namval_t*)dtfirst(root);np;np=npnext)
@@ -2350,7 +2350,7 @@ static void table_unset(Dt_t *root, int flags, Dt_t *oroot)
  *	being cleared.
  *   <flags> can contain NV_EXPORT to preserve nvmeta.
  */
-void	nv_unset(Namval_t *np,int flags)
+void nv_unset(Namval_t *np, nvflag_t flags)
 {
 	void		**vpp;	/* pointer to value pointer */
 #if SHOPT_FIXEDARRAY
@@ -2529,13 +2529,13 @@ void nv_optimize_clear(Namval_t *np)
 	}
 }
 
-static void put_optimize(Namval_t* np,const char *val,int flags,Namfun_t *fp)
+static void put_optimize(Namval_t* np,const char *val,nvflag_t flags,Namfun_t *fp)
 {
 	nv_putv(np,val,flags,fp);
 	optimize_clear(np,fp);
 }
 
-static Namfun_t *clone_optimize(Namval_t* np, Namval_t *mp, int flags, Namfun_t *fp)
+static Namfun_t *clone_optimize(Namval_t* np, Namval_t *mp, nvflag_t flags, Namfun_t *fp)
 {
 	NOT_USED(np);
 	NOT_USED(mp);
@@ -2807,15 +2807,14 @@ Sfdouble_t nv_getnum(Namval_t *np)
  *   value to conform to <newatts>.  The <size> of left and right
  *   justified fields may be given.
  */
-void nv_newattr(Namval_t *np, unsigned newatts, ssize_t size)
+void nv_newattr(Namval_t *np, nvflag_t newatts, ssize_t size)
 {
 	char *sp;
 	char *cp = 0;
-	unsigned int n;
-	size_t len;
+	nvflag_t n, oldatts;
 	Namval_t *mp = 0;
 	Namarr_t *ap = 0;
-	int oldatts,trans;
+	int trans;
 	size_t oldsize;
 	Namfun_t *fp= (newatts&NV_NODISC)?np->nvfun:0;
 	char *prefix = sh.prefix;
@@ -2857,7 +2856,7 @@ void nv_newattr(Namval_t *np, unsigned newatts, ssize_t size)
 		else if(size==NV_FLTSIZEZERO)
 			np->nvsize = 0;
 		nv_offattr(np, ~NV_NOFREE);
-		nv_onattr(np, newatts);
+		nv_onattr(np, newatts&~(NV_OPENMASK));
 		return;
 	}
 	if(size==NV_FLTSIZEZERO)
@@ -2877,7 +2876,7 @@ void nv_newattr(Namval_t *np, unsigned newatts, ssize_t size)
 		{
 			nv_setsize(np,(size_t)size);
 			np->nvflag &= NV_ARRAY;
-			np->nvflag |= newatts;
+			np->nvflag |= newatts&~(NV_OPENMASK);
 			goto skip;
 		}
 #endif /* SHOPT_FIXEDARRAY */
@@ -2888,6 +2887,7 @@ void nv_newattr(Namval_t *np, unsigned newatts, ssize_t size)
 		np->nvflag = oldatts;
 		if (sp = nv_getval(np))
  		{
+			size_t len;
 			if(nv_isattr(np,NV_ZFILL) && *sp=='0')
 			{
 				while(*sp=='0') sp++;	/* skip initial zeros */
@@ -2928,8 +2928,8 @@ void nv_newattr(Namval_t *np, unsigned newatts, ssize_t size)
 			nv_unset(np,NV_EXPORT);
 		nv_setsize(np,(size_t)size);
 		np->nvflag &= (NV_ARRAY|NV_NOFREE);
-		np->nvflag |= newatts;
-		if (cp)
+		np->nvflag |= newatts&~(NV_OPENMASK);
+		if(cp)
 		{
 			if(!mp)
 				nv_putval (np, cp, NV_RDONLY);
@@ -3088,7 +3088,7 @@ static char *lastdot(char *cp, int eq)
 	return eq?0:ep;
 }
 
-int nv_rename(Namval_t *np, int flags)
+int nv_rename(Namval_t *np, nvflag_t flags)
 {
 	Namval_t		*mp=0,*nr=0;
 	char			*cp;
@@ -3250,7 +3250,7 @@ int nv_rename(Namval_t *np, int flags)
 /*
  * Create a reference node from <np> to $np in dictionary <hp>
  */
-void nv_setref(Namval_t *np, Dt_t *hp, int flags)
+void nv_setref(Namval_t *np, Dt_t *hp, nvflag_t flags)
 {
 	Namval_t	*nq=0, *nr=0;
 	char		*ep,*cp;

--- a/src/cmd/ksh93/sh/nvdisc.c
+++ b/src/cmd/ksh93/sh/nvdisc.c
@@ -29,7 +29,7 @@
 #include	"io.h"
 #include	"shlex.h"
 
-static void assign(Namval_t*,const char*,int,Namfun_t*);
+static void assign(Namval_t*,const char*,nvflag_t,Namfun_t*);
 
 int nv_compare(Dt_t* dict, void *sp, void *dp, Dtdisc_t *disc)
 {
@@ -114,7 +114,7 @@ Sfdouble_t nv_getn(Namval_t *np, Namfun_t *nfp)
 /*
  * call the next assign function in the chain
  */
-void nv_putv(Namval_t *np, const char *value, int flags, Namfun_t *nfp)
+void nv_putv(Namval_t *np, const char *value, nvflag_t flags, Namfun_t *nfp)
 {
 	Namfun_t	*fp, *fpnext;
 	Namarr_t	*ap;
@@ -170,7 +170,7 @@ struct blocked
 {
 	struct blocked	*next;
 	Namval_t	*np;
-	int		flags;
+	long		flags;
 	void		*sub;
 	int		isub;
 };
@@ -238,7 +238,7 @@ static void chktfree(Namval_t *np, struct vardisc *vp)
 /*
  * This function performs an assignment disc on the given node <np>
  */
-static void	assign(Namval_t *np,const char* val,int flags,Namfun_t *handle)
+static void	assign(Namval_t *np,const char* val,nvflag_t flags,Namfun_t *handle)
 {
 	int		type = (flags&NV_APPEND)?APPEND:ASSIGN;
 	struct vardisc *vp = (struct vardisc*)handle;
@@ -645,7 +645,7 @@ static char *setdisc(Namval_t* np,const char *event,Namval_t *action,Namfun_t *f
 	return (char*)action;
 }
 
-static void putdisc(Namval_t* np, const char* val, int flag, Namfun_t* fp)
+static void putdisc(Namval_t* np, const char* val, nvflag_t flag, Namfun_t* fp)
 {
 	nv_putv(np,val,flag,fp);
 	if(!val && !(flag&NV_NOFREE))
@@ -674,7 +674,7 @@ static void putdisc(Namval_t* np, const char* val, int flag, Namfun_t* fp)
 
 static const Namdisc_t Nv_bdisc	= {   0, putdisc, 0, 0, setdisc };
 
-Namfun_t *nv_clone_disc(Namfun_t *fp, int flags)
+Namfun_t *nv_clone_disc(Namfun_t *fp, nvflag_t flags)
 {
 	Namfun_t	*nfp;
 	size_t		size;
@@ -721,7 +721,7 @@ int nv_adddisc(Namval_t *np, const char **names, Namval_t **funs)
  *    NV_POP:	 Delete <fp> from top of the stack
  *    NV_CLONE:  Replace fp with a copy created my malloc() and return it
  */
-Namfun_t *nv_disc(Namval_t *np, Namfun_t* fp, int mode)
+Namfun_t *nv_disc(Namval_t *np, Namfun_t* fp, nvflag_t mode)
 {
 	Namfun_t *lp, **lpp;
 	if(nv_isref(np))
@@ -860,7 +860,7 @@ static void *num_clone(Namval_t *np, void *val)
 	return nval;
 }
 
-void clone_all_disc( Namval_t *np, Namval_t *mp, int flags)
+void clone_all_disc( Namval_t *np, Namval_t *mp, nvflag_t flags)
 {
 	Namfun_t *fp, **mfp = &mp->nvfun, *nfp, *fpnext;
 	for(fp=np->nvfun; fp;fp=fpnext)
@@ -892,11 +892,11 @@ void clone_all_disc( Namval_t *np, Namval_t *mp, int flags)
  * NV_NODISC - disciplines with funs non-zero will not be copied
  * NV_COMVAR - cloning a compound variable
  */
-int nv_clone(Namval_t *np, Namval_t *mp, int flags)
+int nv_clone(Namval_t *np, Namval_t *mp, nvflag_t flags)
 {
 	Namfun_t	*fp, *fpnext;
 	const char	*val = mp->nvalue;
-	unsigned short	flag = mp->nvflag;
+	nvflag_t	flag = mp->nvflag;
 	size_t		size = mp->nvsize;
 	for(fp=mp->nvfun; fp; fp=fpnext)
 	{
@@ -987,7 +987,7 @@ int nv_clone(Namval_t *np, Namval_t *mp, int flags)
  *   node's name is used.
  * Note: The mode bitmask is NOT compatible with nv_open's flags bitmask.
  */
-Namval_t *nv_search(const char *name, Dt_t *root, int mode)
+Namval_t *nv_search(const char *name, Dt_t *root, nvflag_t mode)
 {
 	Namval_t *np;
 	Dt_t *dp = 0;
@@ -1230,14 +1230,14 @@ static Namval_t *next_table(Namval_t* np, Dt_t *root,Namfun_t *fp)
 		return (Namval_t*)dtfirst(tp->dict);
 }
 
-static Namval_t *create_table(Namval_t *np,const char *name,int flags,Namfun_t *fp)
+static Namval_t *create_table(Namval_t *np,const char *name,nvflag_t flags,Namfun_t *fp)
 {
 	struct table *tp = (struct table *)fp;
 	sh.last_table = np;
 	return nv_create(name, tp->dict, flags, fp);
 }
 
-static Namfun_t *clone_table(Namval_t* np, Namval_t *mp, int flags, Namfun_t *fp)
+static Namfun_t *clone_table(Namval_t* np, Namval_t *mp, nvflag_t flags, Namfun_t *fp)
 {
 	struct table	*tp = (struct table*)fp;
 	struct table	*ntp = (struct table*)nv_clone_disc(fp,0);
@@ -1272,7 +1272,7 @@ static void delete_fun(Namval_t *np, void *data)
 	nv_delete(np,sh.fun_tree,NV_NOFREE);
 }
 
-static void put_table(Namval_t* np, const char* val, int flags, Namfun_t* fp)
+static void put_table(Namval_t* np, const char* val, nvflag_t flags, Namfun_t* fp)
 {
 	Dt_t		*root = ((struct table*)fp)->dict;
 	Namval_t	*nq, *mp;
@@ -1431,7 +1431,7 @@ int nv_hasget(Namval_t *np)
 }
 
 #if SHOPT_NAMESPACE
-Namval_t *sh_fsearch(const char *fname, int add)
+Namval_t *sh_fsearch(const char *fname, nvflag_t add)
 {
 	if(*fname!='.')
 	{
@@ -1440,6 +1440,6 @@ Namval_t *sh_fsearch(const char *fname, int add)
 		sfputr(sh.stk,fname,0);
 		fname = stkptr(sh.stk,offset);
 	}
-	return nv_search(fname,sh_subfuntree(add&NV_ADD),add);
+	return nv_search(fname,sh_subfuntree((add&NV_ADD)==NV_ADD),add);
 }
 #endif /* SHOPT_NAMESPACE */

--- a/src/cmd/ksh93/sh/nvtree.c
+++ b/src/cmd/ksh93/sh/nvtree.c
@@ -45,8 +45,8 @@ struct nvdir
 
 static int	Indent;
 char *nv_getvtree(Namval_t*, Namfun_t *);
-static void put_tree(Namval_t*, const char*, int,Namfun_t*);
-static char *walk_tree(Namval_t*, Namval_t*, int);
+static void put_tree(Namval_t*, const char*, nvflag_t,Namfun_t*);
+static char *walk_tree(Namval_t*, Namval_t*, nvflag_t);
 
 static int read_tree(Namval_t* np, Sfio_t *iop, int n, Namfun_t *dp)
 {
@@ -64,7 +64,7 @@ static int read_tree(Namval_t* np, Sfio_t *iop, int n, Namfun_t *dp)
 	return c;
 }
 
-static Namval_t *create_tree(Namval_t *np,const char *name,int flag,Namfun_t *dp)
+static Namval_t *create_tree(Namval_t *np,const char *name,nvflag_t flag,Namfun_t *dp)
 {
 	Namfun_t *fp=dp;
 	fp->dsize = 0;
@@ -80,7 +80,7 @@ static Namval_t *create_tree(Namval_t *np,const char *name,int flag,Namfun_t *dp
 	return (flag&NV_NOADD) ? 0 : np;
 }
 
-static Namfun_t *clone_tree(Namval_t *np, Namval_t *mp, int flags, Namfun_t *fp){
+static Namfun_t *clone_tree(Namval_t *np, Namval_t *mp, nvflag_t flags, Namfun_t *fp){
 	Namfun_t	*dp;
 	if ((flags&NV_MOVE) && nv_type(np))
 		return fp;
@@ -380,7 +380,7 @@ void nv_attribute(Namval_t *np,Sfio_t *out,char *prefix,int noname)
 {
 	const Shtable_t *tp;
 	char *cp;
-	unsigned val,mask,attr;
+	nvflag_t val,mask,attr;
 	char *ip=0;
 	Namfun_t *fp=0;
 	Namval_t *typep=0;
@@ -535,13 +535,13 @@ void nv_attribute(Namval_t *np,Sfio_t *out,char *prefix,int noname)
 
 struct Walk
 {
-	Sfio_t	*out;
-	Dt_t	*root;
-	int	noscope;
-	int	indent;
-	int	nofollow;
-	int	array;
-	int	flags;
+	Sfio_t		*out;
+	Dt_t		*root;
+	nvflag_t	noscope;
+	int		indent;
+	int		nofollow;
+	int		array;
+	nvflag_t	flags;
 };
 
 void nv_outnode(Namval_t *np, Sfio_t* out, int indent, int special)
@@ -672,7 +672,8 @@ static void outval(char *name, const char *vname, struct Walk *wp)
 {
 	Namval_t *np, *nq=0, *last_table=sh.last_table;
 	Namfun_t *fp;
-	int isarray=0, special=0,mode=0;
+	int isarray=0, special=0;
+	nvflag_t mode=0;
 	Dt_t *root = wp->root?wp->root:sh.var_base;
 	if(*name!='.' || vname[strlen(vname)-1]==']')
 		mode = NV_ARRAY;
@@ -943,7 +944,7 @@ static char **genvalue(char **argv, const char *prefix, ptrdiff_t n, struct Walk
 /*
  * walk the virtual tree and print or delete name-value pairs
  */
-static char *walk_tree(Namval_t *np, Namval_t *xp, int flags)
+static char *walk_tree(Namval_t *np, Namval_t *xp, nvflag_t flags)
 {
 	static Sfio_t *out;
 	struct Walk walk;
@@ -957,7 +958,8 @@ static char *walk_tree(Namval_t *np, Namval_t *xp, int flags)
 	char *name,*cp, **argv;
 	char *subscript=0;
 	void *dir;
-	int n=0, noscope=(flags&NV_NOSCOPE);
+	int n=0;
+	nvflag_t noscope=(flags&NV_NOSCOPE);
 	Namarr_t *arp = nv_arrayptr(np);
 	Dt_t	*save_tree = sh.var_tree;
 	Namval_t	*mp=0;
@@ -1068,7 +1070,7 @@ Namfun_t *nv_isvtree(Namval_t *np)
  */
 char *nv_getvtree(Namval_t *np, Namfun_t *fp)
 {
-	int flags=0;
+	nvflag_t flags=0;
 	size_t dsize=fp?fp->dsize:0;
 	for(; fp && fp->next; fp=fp->next)
 	{
@@ -1091,7 +1093,7 @@ char *nv_getvtree(Namval_t *np, Namfun_t *fp)
 /*
  * put discipline for compound initializations
  */
-static void put_tree(Namval_t *np, const char *val, int flags,Namfun_t *fp)
+static void put_tree(Namval_t *np, const char *val, nvflag_t flags,Namfun_t *fp)
 {
 	struct Namarray *ap;
 	int nleft = 0;

--- a/src/cmd/ksh93/sh/nvtype.c
+++ b/src/cmd/ksh93/sh/nvtype.c
@@ -97,9 +97,9 @@ struct Namtype
 	size_t		current;
 };
 
-static void put_type(Namval_t*, const char*, int, Namfun_t*);
-static Namval_t* create_type(Namval_t*, const char*, int, Namfun_t*);
-static Namfun_t* clone_type(Namval_t*, Namval_t*, int, Namfun_t*);
+static void put_type(Namval_t*, const char*, nvflag_t, Namfun_t*);
+static Namval_t* create_type(Namval_t*, const char*, nvflag_t, Namfun_t*);
+static Namfun_t* clone_type(Namval_t*, Namval_t*, nvflag_t, Namfun_t*);
 static Namval_t* next_type(Namval_t*, Dt_t*, Namfun_t*);
 
 static const Namdisc_t type_disc =
@@ -192,7 +192,7 @@ static char *name_chtype(Namval_t *np, Namfun_t *fp)
 	return sfstruse(sh.strbuf);
 }
 
-static void put_chtype(Namval_t* np, const char* val, int flag, Namfun_t* fp)
+static void put_chtype(Namval_t* np, const char* val, nvflag_t flag, Namfun_t* fp)
 {
 	if(!val && nv_isattr(np,NV_REF))
 		return;
@@ -227,7 +227,7 @@ static void put_chtype(Namval_t* np, const char* val, int flag, Namfun_t* fp)
 	}
 }
 
-static Namfun_t *clone_chtype(Namval_t* np, Namval_t *mp, int flags, Namfun_t *fp)
+static Namfun_t *clone_chtype(Namval_t* np, Namval_t *mp, nvflag_t flags, Namfun_t *fp)
 {
 	NOT_USED(np);
 	NOT_USED(mp);
@@ -268,7 +268,7 @@ static Namval_t *findref(void *nodes, size_t n)
 	return NULL;
 }
 
-static int fixnode(Namtype_t *dp, Namtype_t *pp, size_t i, struct Namref *nrp,int flag)
+static int fixnode(Namtype_t *dp, Namtype_t *pp, size_t i, struct Namref *nrp,nvflag_t flag)
 {
 	Namval_t	*nq = nv_namptr(dp->nodes,i);
 	Namfun_t	*fp;
@@ -285,7 +285,7 @@ static int fixnode(Namtype_t *dp, Namtype_t *pp, size_t i, struct Namref *nrp,in
 			nrp2->np = nv_namptr(pp->childfun.ttype->nodes,i);
 		nrp2->root = sh.last_root;
 		nrp2->table = pp->np;
-		nq ->nvflag = NV_REF|NV_NOFREE|NV_MINIMAL;
+		nq->nvflag = NV_REF|NV_NOFREE|NV_MINIMAL;
 		return 1;
 	}
 	if(nq->nvalue || nq->nvfun)
@@ -333,7 +333,7 @@ static int fixnode(Namtype_t *dp, Namtype_t *pp, size_t i, struct Namref *nrp,in
 	return 0;
 }
 
-static Namfun_t *clone_type(Namval_t* np, Namval_t *mp, int flags, Namfun_t *fp)
+static Namfun_t *clone_type(Namval_t* np, Namval_t *mp, nvflag_t flags, Namfun_t *fp)
 {
 	Namtype_t		*dp, *pp=(Namtype_t*)fp;
 	ssize_t			i;
@@ -462,7 +462,7 @@ static Namfun_t *clone_type(Namval_t* np, Namval_t *mp, int flags, Namfun_t *fp)
 /*
  * return Namval_t* corresponding to child <name> in <np>
  */
-static Namval_t *create_type(Namval_t *np,const char *name,int flag,Namfun_t *fp)
+static Namval_t *create_type(Namval_t *np,const char *name,nvflag_t flag,Namfun_t *fp)
 {
 	Namtype_t		*dp = (Namtype_t*)fp;
 	const char		*cp=name;
@@ -515,7 +515,7 @@ found:
 	return nq;
 }
 
-static void put_type(Namval_t* np, const char* val, int flag, Namfun_t* fp)
+static void put_type(Namval_t* np, const char* val, nvflag_t flag, Namfun_t* fp)
 {
 	Namval_t	*nq;
 	if(val && (nq=nv_open(val,sh.var_tree,NV_VARNAME|NV_ARRAY|NV_NOADD|NV_NOFAIL)))
@@ -568,7 +568,7 @@ static Namval_t *next_type(Namval_t* np, Dt_t *root,Namfun_t *fp)
 	return nv_namptr(dp->nodes,dp->current);
 }
 
-static Namfun_t *clone_inttype(Namval_t* np, Namval_t *mp, int flags, Namfun_t *fp)
+static Namfun_t *clone_inttype(Namval_t* np, Namval_t *mp, nvflag_t flags, Namfun_t *fp)
 {
 	Namfun_t	*pp = (Namfun_t*)sh_malloc(fp->dsize);
 	NOT_USED(flags);
@@ -1261,12 +1261,12 @@ static void type_init(Namval_t *np)
 }
 
 /*
- * This function turns variable <np>  to the type <tp>
+ * This function turns variable <np> to the type <tp>
  */
-int nv_settype(Namval_t* np, Namval_t *tp, int flags)
+int nv_settype(Namval_t* np, Namval_t *tp, nvflag_t flags)
 {
 	int		isnull = nv_isnull(np);
-	int		rdonly = nv_isattr(np,NV_RDONLY);
+	nvflag_t	rdonly = nv_isattr(np,NV_RDONLY);
 	char		*val=0;
 	Namarr_t	*ap=0;
 	int		nelem = 0;

--- a/src/cmd/ksh93/sh/parse.c
+++ b/src/cmd/ksh93/sh/parse.c
@@ -50,8 +50,8 @@ static Shnode_t	*sh_cmd(Lex_t*,int,int);
 static Shnode_t	*term(Lex_t*,int);
 static Shnode_t	*list(Lex_t*,int);
 static struct regnod	*syncase(Lex_t*,int);
-static Shnode_t	*item(Lex_t*,int);
-static Shnode_t	*simple(Lex_t*,int, struct ionod*);
+static Shnode_t	*item(Lex_t*,nvflag_t);
+static Shnode_t	*simple(Lex_t*,nvflag_t, struct ionod*);
 static int	skipnl(Lex_t*,int);
 static Shnode_t	*test_expr(Lex_t*,int);
 static Shnode_t	*test_and(Lex_t*);
@@ -998,13 +998,14 @@ static int check_array(Lex_t *lexp)
 /*
  * Compound assignment
  */
-static struct argnod *assign(Lex_t *lexp, struct argnod *ap, int type)
+static struct argnod *assign(Lex_t *lexp, struct argnod *ap, nvflag_t type)
 {
 	int n;
 	size_t len;
 	Shnode_t *t, **tp;
 	struct comnod *ac = NULL;
-	int array=0, index=0;
+	uint32_t array=0;
+	int index=0;
 	Namval_t *np;
 	lexp->assignlevel++;
 	len = strlen(ap->argval)-1;
@@ -1194,7 +1195,7 @@ static struct argnod *assign(Lex_t *lexp, struct argnod *ap, int type)
  *	case ... in ... esac
  *	begin ... end
  */
-static Shnode_t	*item(Lex_t *lexp,int flag)
+static Shnode_t	*item(Lex_t *lexp,nvflag_t flag)
 {
 	Shnode_t *t;
 	struct ionod *io;
@@ -1418,7 +1419,7 @@ static struct argnod *process_sub(Lex_t *lexp,int tok)
 /*
  * This is for a simple command, for list, or compound assignment
  */
-static Shnode_t *simple(Lex_t *lexp,int flag, struct ionod *io)
+static Shnode_t *simple(Lex_t *lexp,nvflag_t flag, struct ionod *io)
 {
 	struct comnod	*t;
 	struct argnod	*argp, *ap;
@@ -1426,7 +1427,7 @@ static Shnode_t *simple(Lex_t *lexp,int flag, struct ionod *io)
 	struct argnod	**argtail;
 	struct argnod	**settail;
 	int		cmdarg = 0;
-	int		type = 0;
+	nvflag_t	type = 0;
 	int		was_assign = 0;
 	int		argno = 0;
 	int		assignment = 0;

--- a/src/cmd/ksh93/sh/path.c
+++ b/src/cmd/ksh93/sh/path.c
@@ -877,9 +877,9 @@ Pathcomp_t *path_absolute(const char *name, Pathcomp_t *pp, int flag)
 			stkseek(sh.stk,n);
 			if(np)
 			{
-				n = np->nvflag;
+				nvflag_t save_nvflag = np->nvflag;
 				np = sh_addbuiltin(stkptr(sh.stk,PATH_OFFSET),funptr(np),nv_context(np));
-				np->nvflag = n;
+				np->nvflag = save_nvflag;
 			}
 		}
 		if(f<0 && errno!=ENOENT)
@@ -1813,7 +1813,7 @@ static char *talias_get(Namval_t *np, Namfun_t *nvp)
 	return ptr+PATH_OFFSET;
 }
 
-static void talias_put(Namval_t* np,const char *val,int flags,Namfun_t *fp)
+static void talias_put(Namval_t* np,const char *val,nvflag_t flags,Namfun_t *fp)
 {
 	if(!val && np->nvalue)
 	{

--- a/src/cmd/ksh93/sh/subshell.c
+++ b/src/cmd/ksh93/sh/subshell.c
@@ -189,7 +189,7 @@ void sh_subfork(void)
 	}
 }
 
-int nv_subsaved(Namval_t *np, int flags)
+int nv_subsaved(Namval_t *np, nvflag_t flags)
 {
 	struct subshell	*sp;
 	struct Link		*lp, *lpprev;
@@ -317,7 +317,7 @@ static void nv_restore(struct subshell *sp)
 	struct Link	*lp, *lq;
 	Namval_t	*mp, *np;
 	Namval_t	*mpnext;
-	int		flags;
+	nvflag_t	flags;
 	char		nofree;
 	sh.nv_restore = 1;
 	for(lp=sp->svar; lp; lp=lq)

--- a/src/cmd/ksh93/sh/xec.c
+++ b/src/cmd/ksh93/sh/xec.c
@@ -432,7 +432,7 @@ static void out_string(Sfio_t *iop, const char *cp, int c, int quoted)
  * If a script changes .sh.level inside a DEBUG trap, it will switch the
  * scope as if it were executing the trap at that function call depth.
  */
-static void put_level(Namval_t* np,const char *val,int flags,Namfun_t *fp)
+static void put_level(Namval_t* np,const char *val,nvflag_t flags,Namfun_t *fp)
 {
 	Shscope_t	*sp;
 	int16_t		level, oldlevel = sh.level;
@@ -874,7 +874,8 @@ int sh_exec(const Shnode_t *t, int flags)
 			char		*trap;
 			Namval_t	*np, *nq, *last_table;
 			struct ionod	*io;
-			int		command=0, flgs=NV_ASSIGN, jmpval=0;
+			int		command=0, jmpval=0;
+			nvflag_t	flgs = NV_ASSIGN;
 			sh.bltindata.invariant = type>>(COMBITS+2);
 			type &= (COMMSK|COMSCAN);
 			sh_stats(STAT_SCMDS);
@@ -2300,7 +2301,7 @@ int sh_exec(const Shnode_t *t, int flags)
 				Dt_t *root;
 				Namval_t *oldnspace = sh.namespace;
 				ptrdiff_t offset = stktell(sh.stk);
-				int	flags=NV_NOARRAY|NV_VARNAME;
+				nvflag_t nvflgs =NV_NOARRAY|NV_VARNAME;
 				struct checkpt *chkp = stkalloc(sh.stk,sizeof(struct checkpt));
 				int jmpval;
 				if(cp)
@@ -2315,7 +2316,7 @@ int sh_exec(const Shnode_t *t, int flags)
 				}
 				sfputc(sh.stk,'.');
 				sfputr(sh.stk,fname,0);
-				np = nv_open(stkptr(sh.stk,offset),sh.var_tree,flags);
+				np = nv_open(stkptr(sh.stk,offset),sh.var_tree,nvflgs);
 				offset = stktell(sh.stk);
 				if(nv_istable(np))
 					root = nv_dict(np);

--- a/src/cmd/ksh93/shell.3
+++ b/src/cmd/ksh93/shell.3
@@ -41,7 +41,7 @@ int 		sh_trap(const char *\fIstring\fP, int \fImode\fP);
 int		sh_run(int \fIargc\fP, char *\fIargv\fP[]);
 int 		sh_eval(Sfio_t *\fIsp\fP, int \fImode\fP);
 int 		sh_fun(Namval_t *\fIfunnode\fP, Namval_t *\fIvarnode\fP, char *\fIargv\fP[]);
-int 		sh_funscope(int \fIargc\fP, char *\fIargv\fP[], int(*\fIfn\fP)(void*), void *\fIarg\fP, int \fIflags\fP);
+int 		sh_funscope(int \fIargc\fP, char *\fIargv\fP[], int(*\fIfn\fP)(void*), void *\fIarg\fP, int \fIexecflg\fP);
 Shscope_t	*sh_getscope(int \fIindex\fP, int \fIwhence\fP);
 Shscope_t	*sh_setscope(Shscope_t *\fIscope\fP);
 


### PR DESCRIPTION
List of changes:
- Backported the `nvflag_t` type from ksh2020, but changed it to `uint64_t` for the purpose of future-proofing nvflags expansion.
- Moved the latter half of the nvflags into the 64-bit range. The flags can be moved back into the 32-bit range if that's desirable, but I would recommend against that. The nvflags struct member will have padding on 64-bit machines if it's 32-bit; we should just make the type 64-bit to take advantage of the otherwise unused bytes in the struct.
- Backported a comment from ksh2020 noting that argflags are assumed to be stored as 8-bit (from ksh2020 commit 89437393).
- Fixed a shadowing error in `sh_exec` namespace handling that caused nvflags to shadow the actual `sh_exec()` flags and thus result in the `sh_exec()` call getting passed invalid flags. (I'm unsure if this logic error materialized in any tangible user facing manner though.)

Change in the number of warnings on Linux when compiling with clang using `-Wsign-compare -Wshorten-64-to-32 -Wsign-conversion -Wimplicit-int-conversion`: 37 => 1

Fixes https://github.com/att/ast/issues/1038