### PR TITLE
Fix build on Debian GNU/Hurd

### DIFF
--- a/src/lib/libast/string/fmtdev.c
+++ b/src/lib/libast/string/fmtdev.c
@@ -27,7 +27,7 @@
 #include <ast.h>
 #include <ctype.h>
 #include <ls.h>
-#ifdef __linux__
+#if defined(__linux__) || defined(__GNU__)
 #include <sys/sysmacros.h>
 #endif
 


### PR DESCRIPTION
Extend the guard in fmtdev.c to include sys/sysmacros.h needed for the build in GNU/Hurd.