### PR TITLE
Fix tests with GET_LAST= in the environment

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -31,6 +31,7 @@ ksh 93u+m general copyright notice
 #                      Trey Valenta <t@trey.net>                       #
 #  Sterling Jensen <5555776+sterlingjensen@users.noreply.github.com>   #
 #            SHIMIZU Akifumi <shimizu.akifumi@fujitsu.com>             #
+#                    Sertonix <sertonix@posteo.net>                    #
 #           rymrg <54061433+rymrg@users.noreply.github.com>            #
 #                   Marc Wilson <posguy99@gmail.com>                   #
 #                  Manuel Einfalt <m-einfalt@gmx.de>                   #

--- a/src/cmd/ksh93/tests/attributes.sh
+++ b/src/cmd/ksh93/tests/attributes.sh
@@ -2,7 +2,7 @@
 #                                                                      #
 #               This software is part of the ast package               #
 #          Copyright (c) 1982-2012 AT&T Intellectual Property          #
-#          Copyright (c) 2020-2024 Contributors to ksh 93u+m           #
+#          Copyright (c) 2020-2026 Contributors to ksh 93u+m           #
 #                      and is licensed under the                       #
 #                 Eclipse Public License, Version 2.0                  #
 #                                                                      #
@@ -14,6 +14,7 @@
 #                  Martijn Dekker <martijn@inlv.org>                   #
 #            Johnothan King <johnothanking@protonmail.com>             #
 #         hyenias <58673227+hyenias@users.noreply.github.com>          #
+#                    Sertonix <sertonix@posteo.net>                    #
 #                                                                      #
 ########################################################################
 

--- a/src/cmd/ksh93/tests/attributes.sh
+++ b/src/cmd/ksh93/tests/attributes.sh
@@ -167,7 +167,7 @@ foo
 if	(( ${#LAST} != 2 ))
 then	err_exit 'LAST!=2'
 fi
-[[ $(set | grep LAST) == LAST=02 ]] || err_exit "LAST not correct in set list"
+[[ $(set | grep ^LAST=) == LAST=02 ]] || err_exit "LAST not correct in set list"
 set -a
 unset foo
 foo=bar


### PR DESCRIPTION
`grep LAST` would also match variables/values that contain "LAST"