### PR TITLE
libast/tm: DST offset and contemporaneous time zone fixes.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,12 @@ This documents significant changes in the dev branch of ksh 93u+m.
 For full details, see the git log at: https://github.com/ksh93/ksh
 Uppercase BUG_* IDs are shell bug IDs as used by the Modernish shell library.
 
+2026-07-25:
+
+- For 'printf %T' and the date(1) builtin, multiple problems have been fixed
+  with the conversion of Daylight Savings Time offsets and contemporaneous
+  time zones on Linux systems with musl libc.
+
 2026-07-24:
 
 - Fix for 'read -t': the timeout was not deactivated if the read operation

--- a/NEWS
+++ b/NEWS
@@ -4,9 +4,9 @@ Uppercase BUG_* IDs are shell bug IDs as used by the Modernish shell library.
 
 2026-07-25:
 
-- For 'printf %T' and the date(1) builtin, multiple problems have been fixed
-  with the conversion of Daylight Savings Time offsets and contemporaneous
-  time zones on Linux systems with musl libc.
+- For 'printf %T' and the date(1) builtin, multiple problems have been
+  fixed with the conversion of Daylight Savings Time offsets, as well as
+  contemporaneous time zones.
 
 2026-07-24:
 

--- a/src/cmd/ksh93/data/builtins.c
+++ b/src/cmd/ksh93/data/builtins.c
@@ -1230,7 +1230,7 @@ const char sh_optprint[] =
 ;
 
 const char sh_optprintf[] =
-"[-1c?\n@(#)$Id: printf (ksh 93u+m) 2024-07-31 $\n]"
+"[-1c?\n@(#)$Id: printf (ksh 93u+m) 2026-07-25 $\n]"
 "[--catalog?" SH_DICT "]"
 "[+NAME?printf - write formatted output]"
 "[+DESCRIPTION?\bprintf\b writes each \astring\a operand to "

--- a/src/cmd/ksh93/include/version.h
+++ b/src/cmd/ksh93/include/version.h
@@ -21,7 +21,7 @@
 #include <ast_release.h>
 #include "git.h"
 
-#define SH_RELEASE_DATE	"2026-07-24"	/* must be in this format for $((.sh.version)) */
+#define SH_RELEASE_DATE	"2026-07-25"	/* must be in this format for $((.sh.version)) */
 /*
  * This comment keeps SH_RELEASE_DATE a few lines away from SH_RELEASE_SVER to avoid
  * merge conflicts when cherry-picking dev branch commits onto a release branch.

--- a/src/cmd/ksh93/tests/attributes.sh
+++ b/src/cmd/ksh93/tests/attributes.sh
@@ -15,6 +15,7 @@
 #            Johnothan King <johnothanking@protonmail.com>             #
 #         hyenias <58673227+hyenias@users.noreply.github.com>          #
 #                    Sertonix <sertonix@posteo.net>                    #
+#               K. Eugene Carlson <kvngncrlsn@gmail.com>               #
 #                                                                      #
 ########################################################################
 

--- a/src/cmd/ksh93/tests/attributes.sh
+++ b/src/cmd/ksh93/tests/attributes.sh
@@ -362,9 +362,9 @@ $SHELL -c 'builtin date' >/dev/null 2>&1 &&
 # check env var changes against a builtin that uses the env var
 
 SEC=1234252800
-ETZ=EST5EDT
+ETZ=EST5EDT,M3.2.0/2:00:00,M11.1.0/2:00:00
 EDT=03
-PTZ=PST8PDT
+PTZ=PST8PDT,M3.2.0/2:00:00,M11.1.0/2:00:00
 PDT=00
 
 CMD="date -f%H \\#$SEC"

--- a/src/cmd/ksh93/tests/printf.sh
+++ b/src/cmd/ksh93/tests/printf.sh
@@ -227,15 +227,15 @@ T '#1325239199'				'2011-12-29 23:59:59'
 
 C='Historical change from one DST zone to another (bad time)'
 export TZ=Europe/Chisinau
-T '#642286800'					'1990-05-10 00:00:00'
+T '#642286800'				'1990-05-10 00:00:00'
 
 C='Historical change from DST to standard (bad time)'
 export TZ=America/Indiana/Knox
-T '#688626000'					'1991-10-28 00:00:00'
+T '#688626000'				'1991-10-28 00:00:00'
 
 C='Historical change from standard to DST (bad time)'
 export TZ=America/Kentucky/Louisville
-T '#126766800'					'1974-01-07 00:00:00'
+T '#126766800'				'1974-01-07 00:00:00'
 
 C='Historical change from standard to standard (bad time)'
 export TZ=America/Argentina/San_Juan

--- a/src/cmd/ksh93/tests/printf.sh
+++ b/src/cmd/ksh93/tests/printf.sh
@@ -237,6 +237,10 @@ C='Historical change from standard to DST (bad time)'
 export TZ=America/Kentucky/Louisville
 T '#126766800'					'1974-01-07 00:00:00'
 
+C='Historical change from standard to standard (bad time)'
+export TZ=America/Argentina/San_Juan
+T '#1086148800'				'2004-06-02 00:00:00'
+
 C='POSIX timezone strings without rules (bad time, musl)' #https://github.com/ksh93/ksh/issues/976
 export TZ=EST5EDT
 T '#1274252800'				'2010-05-19 03:06:40'

--- a/src/cmd/ksh93/tests/printf.sh
+++ b/src/cmd/ksh93/tests/printf.sh
@@ -220,14 +220,22 @@ T '#236961303'				'1977-07-05 17:35:03'
 export TZ=Europe/London
 T '#0'					'1970-01-01 01:00:00'
 
-C='Proper offset within one year of a zone change (bad time)'
-export TZ=America/Indiana/Knox
-T '#1150126200'				'2006-06-12 10:30:00'
-
-C='Before and after a zone change (bad time)'
+C='Before and after a historical change (bad time)'
 export TZ=Pacific/Apia
 T '#1325239200'				'2011-12-31 00:00:00'
 T '#1325239199'				'2011-12-29 23:59:59'
+
+C='Historical change from one DST zone to another (bad time)'
+export TZ=Europe/Chisinau
+T '#642286800'					'1990-05-10 00:00:00'
+
+C='Historical change from DST to standard (bad time)'
+export TZ=America/Indiana/Knox
+T '#688626000'					'1991-10-28 00:00:00'
+
+C='Historical change from standard to DST (bad time)'
+export TZ=America/Kentucky/Louisville
+T '#126766800'					'1974-01-07 00:00:00'
 
 C='POSIX timezone strings without rules (bad time, musl)' #https://github.com/ksh93/ksh/issues/976
 export TZ=EST5EDT

--- a/src/cmd/ksh93/tests/printf.sh
+++ b/src/cmd/ksh93/tests/printf.sh
@@ -220,6 +220,19 @@ T '#236961303'				'1977-07-05 17:35:03'
 export TZ=Europe/London
 T '#0'					'1970-01-01 01:00:00'
 
+C='Proper offset within one year of a zone change (bad time)'
+export TZ=America/Indiana/Knox
+T '#1150126200'				'2006-06-12 10:30:00'
+
+C='Before and after a zone change (bad time)'
+export TZ=Pacific/Apia
+T '#1325239200'				'2011-12-31 00:00:00'
+T '#1325239199'				'2011-12-29 23:59:59'
+
+C='POSIX timezone strings without rules (bad time, musl)' #https://github.com/ksh93/ksh/issues/976
+export TZ=EST5EDT
+T '#1274252800'				'2010-05-19 03:06:40'
+
 format='%Y-%m-%d'
 export TZ=UTC
 

--- a/src/cmd/ksh93/tests/printf.sh
+++ b/src/cmd/ksh93/tests/printf.sh
@@ -211,39 +211,62 @@ function do_test # 1:LINENO 2:printf-STRING 3:match-string
 }
 
 # The first tests require a time zone with one or more historical changes.
-format='%Y-%m-%d %H:%M:%S'
-export TZ=Europe/Riga
-
 C='Historical changes (bad time)' # https://github.com/ksh93/ksh/issues/669
+export TZ=Europe/Riga
+format='%Y-%m-%d %H:%M:%S'
 T '#236961303'				'1977-07-05 17:35:03'
+format='%s'
+T '1977-07-05 17:35:03'		'236961303'
 
 export TZ=Europe/London
+format='%Y-%m-%d %H:%M:%S'
 T '#0'					'1970-01-01 01:00:00'
+format='%s'
+T '1970-01-01 01:00:00'		'0'
 
 C='Before and after a historical change (bad time)'
 export TZ=Pacific/Apia
-T '#1325239200'				'2011-12-31 00:00:00'
-T '#1325239199'				'2011-12-29 23:59:59'
+format='%Y-%m-%d %H:%M:%S'
+T '#1325239200'			'2011-12-31 00:00:00'
+T '#1325239199'			'2011-12-29 23:59:59'
+format='%s'
+T '2011-12-31 00:00:00'		'1325239200'
+T '2011-12-29 23:59:59'		'1325239199'
 
 C='Historical change from one DST zone to another (bad time)'
 export TZ=Europe/Chisinau
+format='%Y-%m-%d %H:%M:%S'
 T '#642286800'				'1990-05-10 00:00:00'
+format='%s'
+T '1990-05-10 00:00:00'		'642286800'
 
 C='Historical change from DST to standard (bad time)'
 export TZ=America/Indiana/Knox
+format='%Y-%m-%d %H:%M:%S'
 T '#688626000'				'1991-10-28 00:00:00'
+format='%s'
+T '1991-10-28 00:00:00'		'688626000'
 
 C='Historical change from standard to DST (bad time)'
 export TZ=America/Kentucky/Louisville
+format='%Y-%m-%d %H:%M:%S'
 T '#126766800'				'1974-01-07 00:00:00'
+format='%s'
+T '1974-01-07 00:00:00'		'126766800'
 
 C='Historical change from standard to standard (bad time)'
 export TZ=America/Argentina/San_Juan
-T '#1086148800'				'2004-06-02 00:00:00'
+format='%Y-%m-%d %H:%M:%S'
+T '#1086148800'			'2004-06-02 00:00:00'
+format='%s'
+T '2004-06-02 00:00:00'		'1086148800'
 
 C='POSIX timezone strings without rules (bad time, musl)' #https://github.com/ksh93/ksh/issues/976
 export TZ=EST5EDT
-T '#1274252800'				'2010-05-19 03:06:40'
+format='%Y-%m-%d %H:%M:%S'
+T '#1274252800'			'2010-05-19 03:06:40'
+format='%s'
+T '2010-05-19 03:06:40'		'1274252800'
 
 format='%Y-%m-%d'
 export TZ=UTC

--- a/src/lib/libast/tm/tminit.c
+++ b/src/lib/libast/tm/tminit.c
@@ -197,6 +197,7 @@ tmlocal(time_t now)
 	int			i;
 	int			m;
 	int			o;
+	int			p;
 	int			isdst;
 	char*			t;
 	struct tm*		tp;
@@ -238,6 +239,7 @@ tmlocal(time_t now)
 
 	tm_info.zone = tm_info.local = &local;
 	n = tzwest(&now, &isdst);
+	p = n;
 	o = isdst;
 
 	/*
@@ -251,6 +253,7 @@ tmlocal(time_t now)
 		now -= 31 * 24 * 60 * 60;
 		if ((m = tzwest(&now, &isdst)) != n && ((!isdst && o) || (isdst && !o)))
 		{
+			n = p;
 			if (!isdst)
 			{
 				isdst = n;
@@ -259,6 +262,8 @@ tmlocal(time_t now)
 			}
 			break;
 		}
+		else if (m != n)
+			n = m;
 	}
 	m -= n;
 	isdst = o;

--- a/src/lib/libast/tm/tminit.c
+++ b/src/lib/libast/tm/tminit.c
@@ -253,6 +253,7 @@ tmlocal(time_t now)
 		now -= 31 * 24 * 60 * 60;
 		if ((m = tzwest(&now, &isdst)) != n && ((!isdst && o) || (isdst && !o)))
 		{
+			m -= (n - p);
 			n = p;
 			if (!isdst)
 			{

--- a/src/lib/libast/tm/tminit.c
+++ b/src/lib/libast/tm/tminit.c
@@ -264,6 +264,8 @@ tmlocal(time_t now)
 		}
 		else if (m != n)
 			n = m;
+		if (i == 11)
+			n = p;
 	}
 	m -= n;
 	isdst = o;

--- a/src/lib/libast/tm/tminit.c
+++ b/src/lib/libast/tm/tminit.c
@@ -191,14 +191,14 @@ static void
 tmlocal(time_t now)
 {
 	Tm_zone_t*		zp;
-	int			n;
 	char*			s;
 	char*			e = NULL;
-	int			i;
-	int			m;
-	int			o;
-	int			p;
-	int			isdst;
+	int			utc_offset;	/* offset from Coordinated Universal Time (UTC) */
+	int			utc_offset_old;
+	int			isdst;		/* nonzero if daylight saving time */
+	int			isdst_old;
+	int			dst_offset;
+	int			month;
 	char*			t;
 	struct tm*		tp;
 	char			buf[16];
@@ -238,9 +238,9 @@ tmlocal(time_t now)
 	 */
 
 	tm_info.zone = tm_info.local = &local;
-	n = tzwest(&now, &isdst);
-	p = n;
-	o = isdst;
+	utc_offset = tzwest(&now, &isdst);
+	utc_offset_old = utc_offset;
+	isdst_old = isdst;
 
 	/*
 	 * compute local DST offset by roaming
@@ -248,31 +248,32 @@ tmlocal(time_t now)
 	 * with a system-recognized DST change
 	 */
 
-	for (i = 0; i < 12; i++)
+	for (month = 1; month <= 12; month++)
 	{
 		now -= 31 * 24 * 60 * 60;
-		if ((m = tzwest(&now, &isdst)) != n && ((!isdst && o) || (isdst && !o)))
+		/* only break offset calculations for a DST shift */
+		if ((dst_offset = tzwest(&now, &isdst)) != utc_offset && ((!isdst && isdst_old) || (isdst && !isdst_old)))
 		{
-			m -= (n - p);
-			n = p;
+			dst_offset -= (utc_offset - utc_offset_old);
+			utc_offset = utc_offset_old;
 			if (!isdst)
 			{
-				n = m;
-				m = p;
+				utc_offset = dst_offset;
+				dst_offset = utc_offset_old;
 			}
 			break;
 		}
-		n = m;
-		if (i == 11)
+		utc_offset = dst_offset;
+		if (month == 12)
 		{
-			n = p;
-			m = n;
+			utc_offset = utc_offset_old;
+			dst_offset = utc_offset;
 		}
 	}
-	m -= n;
-	isdst = o;
-	local.west = (short)n;
-	local.dst = (short)m;
+	dst_offset -= utc_offset;
+	isdst = isdst_old;
+	local.west = (short)utc_offset;
+	local.dst = (short)dst_offset;
 
 	/*
 	 * now get the time zone names
@@ -335,7 +336,7 @@ tmlocal(time_t now)
 		{
 			if (zp->type)
 				t = zp->type;
-			if (zp->west == n && zp->dst == m)
+			if (zp->west == utc_offset && zp->dst == dst_offset)
 			{
 				local.type = t;
 				if (!local.standard)
@@ -347,7 +348,7 @@ tmlocal(time_t now)
 					if (s < e - 1)
 					{
 						*s++ = ' ';
-						tmpoff(s, (size_t)(e - s), tm_info.format[TM_DT], m, TM_DST);
+						tmpoff(s, (size_t)(e - s), tm_info.format[TM_DT], dst_offset, TM_DST);
 					}
 					s = buf;
 				}
@@ -363,13 +364,13 @@ tmlocal(time_t now)
 			 */
 
 			e = (s = buf) + sizeof(buf);
-			s = tmpoff(s, (size_t)(e - s), tm_info.format[TM_UT], n, 0);
+			s = tmpoff(s, (size_t)(e - s), tm_info.format[TM_UT], utc_offset, 0);
 			if (!local.standard)
 				local.standard = strdup(buf);
 			if (s < e - 1)
 			{
 				*s++ = ' ';
-				tmpoff(s, (size_t)(e - s), tm_info.format[TM_UT], m, TM_DST);
+				tmpoff(s, (size_t)(e - s), tm_info.format[TM_UT], dst_offset, TM_DST);
 				if (!local.daylight)
 					local.daylight = strdup(buf);
 			}

--- a/src/lib/libast/tm/tminit.c
+++ b/src/lib/libast/tm/tminit.c
@@ -256,9 +256,8 @@ tmlocal(time_t now)
 			n = p;
 			if (!isdst)
 			{
-				isdst = n;
 				n = m;
-				m = isdst;
+				m = p;
 			}
 			break;
 		}

--- a/src/lib/libast/tm/tminit.c
+++ b/src/lib/libast/tm/tminit.c
@@ -245,7 +245,7 @@ tmlocal(time_t now)
 	/*
 	 * compute local DST offset by roaming
 	 * through the last 12 months until tzwest() changes
-	 * with a system-recofgnized DST change
+	 * with a system-recognized DST change
 	 */
 
 	for (i = 0; i < 12; i++)
@@ -265,7 +265,10 @@ tmlocal(time_t now)
 		else if (m != n)
 			n = m;
 		if (i == 11)
+		{
 			n = p;
+			m = n;
+		}
 	}
 	m -= n;
 	isdst = o;

--- a/src/lib/libast/tm/tminit.c
+++ b/src/lib/libast/tm/tminit.c
@@ -196,6 +196,7 @@ tmlocal(time_t now)
 	char*			e = NULL;
 	int			i;
 	int			m;
+	int			o;
 	int			isdst;
 	char*			t;
 	struct tm*		tp;
@@ -237,16 +238,18 @@ tmlocal(time_t now)
 
 	tm_info.zone = tm_info.local = &local;
 	n = tzwest(&now, &isdst);
+	o = isdst;
 
 	/*
 	 * compute local DST offset by roaming
 	 * through the last 12 months until tzwest() changes
+	 * with a system-recofgnized DST change
 	 */
 
 	for (i = 0; i < 12; i++)
 	{
 		now -= 31 * 24 * 60 * 60;
-		if ((m = tzwest(&now, &isdst)) != n)
+		if ((m = tzwest(&now, &isdst)) != n && ((!isdst && o) || (isdst && !o)))
 		{
 			if (!isdst)
 			{
@@ -254,10 +257,11 @@ tmlocal(time_t now)
 				n = m;
 				m = isdst;
 			}
-			m -= n;
 			break;
 		}
 	}
+	m -= n;
+	isdst = o;
 	local.west = (short)n;
 	local.dst = (short)m;
 

--- a/src/lib/libast/tm/tminit.c
+++ b/src/lib/libast/tm/tminit.c
@@ -261,8 +261,7 @@ tmlocal(time_t now)
 			}
 			break;
 		}
-		else if (m != n)
-			n = m;
+		n = m;
 		if (i == 11)
 		{
 			n = p;

--- a/src/lib/libast/tm/tmxdate.c
+++ b/src/lib/libast/tm/tmxdate.c
@@ -172,6 +172,11 @@ tmxdate(const char* s, char** e, Time_t now)
 	int		dir;
 	int		dst;
 	int		zone;
+	int		dst_old;
+	int		west_old;
+	int		isdst_old;
+	int		first = 1;
+	int		good_check = 0;
 	int		c;
 	int		f;
 	int		i;
@@ -206,7 +211,13 @@ tmxdate(const char* s, char** e, Time_t now)
 	 */
 
 	tm = tmxtm(&ts, now, NULL, 1);
+	if (!first && dst_old == tm->tm_zone->dst && west_old == tm->tm_zone->west && isdst_old == tm->tm_isdst)
+		good_check = 1;
+	dst_old = tm->tm_zone->dst;
+	west_old = tm->tm_zone->west;
+	isdst_old = tm->tm_isdst;
 	tm_info.date = tm->tm_zone;
+	first = 0;
 	day = -1;
 	dir = 0;
 	dst = TM_DST;
@@ -1779,6 +1790,15 @@ tmxdate(const char* s, char** e, Time_t now)
 			tm->tm_mday += j;
 		}
 	}
+	tm = tmxtm(tm, tmxtime(tm, zone), tm->tm_zone, 1);
+	if (!first)
+	{
+		int offset = tm->tm_zone->west - west_old;
+		if (tm->tm_isdst)
+			offset += tm->tm_zone->dst - dst_old;
+		tm->tm_min += offset;
+		tmfix(tm);
+	}
 	now = tmxtime(tm, zone);
 	if (tm->tm_year <= 70 && tmxsec(now) > 31536000)
 	{
@@ -1787,5 +1807,7 @@ tmxdate(const char* s, char** e, Time_t now)
 	}
 	if (e)
 		*e = last;
+	if (!good_check)
+		goto reset;
 	return now;
 }

--- a/src/lib/libast/tm/tmxdate.c
+++ b/src/lib/libast/tm/tmxdate.c
@@ -1791,14 +1791,11 @@ tmxdate(const char* s, char** e, Time_t now)
 		}
 	}
 	tm = tmxtm(tm, tmxtime(tm, zone), tm->tm_zone, 1);
-	if (!first)
-	{
-		int offset = tm->tm_zone->west - west_old;
-		if (tm->tm_isdst)
-			offset += tm->tm_zone->dst - dst_old;
-		tm->tm_min += offset;
-		tmfix(tm);
-	}
+	int offset = tm->tm_zone->west - west_old;
+	if (tm->tm_isdst)
+		offset += tm->tm_zone->dst - dst_old;
+	tm->tm_min += offset;
+	tmfix(tm);
 	now = tmxtime(tm, zone);
 	if (tm->tm_year <= 70 && tmxsec(now) > 31536000)
 	{

--- a/src/lib/libast/tm/tmxdate.c
+++ b/src/lib/libast/tm/tmxdate.c
@@ -172,11 +172,10 @@ tmxdate(const char* s, char** e, Time_t now)
 	int		dir;
 	int		dst;
 	int		zone;
+	int		offset;
 	int		dst_old;
 	int		west_old;
 	int		isdst_old;
-	int		first = 1;
-	int		good_check = 0;
 	int		c;
 	int		f;
 	int		i;
@@ -211,13 +210,12 @@ tmxdate(const char* s, char** e, Time_t now)
 	 */
 
 	tm = tmxtm(&ts, now, NULL, 1);
-	if (!first && dst_old == tm->tm_zone->dst && west_old == tm->tm_zone->west && isdst_old == tm->tm_isdst)
-		good_check = 1;
+
 	dst_old = tm->tm_zone->dst;
 	west_old = tm->tm_zone->west;
 	isdst_old = tm->tm_isdst;
+
 	tm_info.date = tm->tm_zone;
-	first = 0;
 	day = -1;
 	dir = 0;
 	dst = TM_DST;
@@ -1790,12 +1788,17 @@ tmxdate(const char* s, char** e, Time_t now)
 			tm->tm_mday += j;
 		}
 	}
+
+	/*
+	 * Apply an offset to correct for historical time zone changes.
+	 */
 	tm = tmxtm(tm, tmxtime(tm, zone), tm->tm_zone, 1);
-	int offset = tm->tm_zone->west - west_old;
+	offset = tm->tm_zone->west - west_old;
 	if (tm->tm_isdst)
 		offset += tm->tm_zone->dst - dst_old;
 	tm->tm_min += offset;
 	tmfix(tm);
+
 	now = tmxtime(tm, zone);
 	if (tm->tm_year <= 70 && tmxsec(now) > 31536000)
 	{
@@ -1804,7 +1807,13 @@ tmxdate(const char* s, char** e, Time_t now)
 	}
 	if (e)
 		*e = last;
-	if (!good_check)
+
+	/*
+	 * Ensure that a proper time zone has been chosen. If the time
+	 * zones differ, this means that a historical change has occurred.
+	 */
+	if (!(dst_old == tm->tm_zone->dst && west_old == tm->tm_zone->west && isdst_old == tm->tm_isdst))
 		goto reset;
+
 	return now;
 }

--- a/src/lib/libcmd/date.c
+++ b/src/lib/libcmd/date.c
@@ -30,7 +30,7 @@
 #include <times.h>
 
 static const char usage[] =
-"[-?\n@(#)$Id: date (AT&T Research) 2011-01-27 $\n]"
+"[-?\n@(#)$Id: date (ksh 93u+m) 2026-07-25 $\n]"
 "[--catalog?" ERROR_CATALOG "]"
 "[+NAME?date - set/list/convert dates]"
 "[+DESCRIPTION?\bdate\b sets the current date and time (with appropriate"


### PR DESCRIPTION
RE #976, 98800e9

Pre-u+m code in `tminit.c` sets the standard (ST) and daylight savings time (DST) offsets by checking times over the previous year of the time requested to compare DST status and offsets from UTC. If no offset change is detected, the DST offset is set equal to the ST offset.

Although assigning the DST offset in this way is counter-intuitive, it does not result in incorrect times being reported so long as two implicit assumptions are met:

* If the requested time is DST, a change from ST occurred in the previous year.
* If the offset changed over the previous year, this was the result of a DST transition.

The first assumption fails on `musl` Linux systems (which would not appear until well after the code in question was written). `musl` interprets POSIX timezone specifications with a DST name but without rules as being DST year-round. `tminit.c` therefore calculates both the DST and ST offsets as equal to the overall UTC offset, which is applied twice when reporting times. Because `musl` apparently disregards the top `zoneinfo` directory, even common aliases such as `PST8PDT` return wildly inaccurate results (rather than the one-hour errors that `/bin/date` would suggest on `musl` systems).

The second assumption is broken at all times and places between a historical timezone change and a DST shift or one year later, whichever comes first. Although `Pacific/Apia` between 2011-12-31 and 2012-04-01 yields the most striking results, there are many other examples.

Fixing these problems involves relatively minor changes to `tminit.c` and related tests:

* In `tminit.c`, save and restore the UTC offset and DST status of the requested time; only break offset calculations for a DST shift.
* In `attributes.sh`, use full POSIX timezone specifications in lieu of `EST5EDT` and `PST8PDT`. This is necessary because `musl` applies DST for the entire year and the time of the test is ST.
* In `printf.sh`, add several `TZ` tests to account for different combinations of DST and ST designations across historical timezone changes. Also add an `EST5EDT` test in DST.

In addition, although 98800e9 introduced a fix for looking up times in zones with historical changes, it applied only to searches using seconds from the epoch. Other lookup formats still fail to change to contemporaneous zones. A convenient reproducer is:

    TZ=Europe/London printf "%(%s)T\n" "1970-01-01 01:00:00"

The output should be `0` and not `3600`.

* In `tmxdate.c`, after running through `tmxdate` for the first time, compare the values of `west`, `dst` and `isdst` to ensure that a proper zone has been chosen. If the zones differ, this means that a historical change has occurred. Apply an offset and run again, repeating as necessary.
* In `printf.sh`, add 'reverse' tests looking up epoch seconds by date.